### PR TITLE
fix example actor build

### DIFF
--- a/examples/actor/.cargo/config.toml
+++ b/examples/actor/.cargo/config.toml
@@ -1,3 +1,3 @@
 [build]
-rustflags = ["-C", "target-feature=+multivalue", "-C", "link-args=--import-memory"]
+rustflags = ["-C", "target-feature=+multivalue"]
 target = "wasm32-unknown-unknown"

--- a/examples/actor/Makefile
+++ b/examples/actor/Makefile
@@ -1,7 +1,10 @@
 PROFILE ?= actor
+# It lives in the workspace root by default
+CARGO_TARGET_DIR ?= ../../target
 
 build:
 	cargo build --target=wasm32-unknown-unknown --profile=$(PROFILE)
+	cp "$(CARGO_TARGET_DIR)/wasm32-unknown-unknown/$(PROFILE)/fvm_example_actor.wasm" .
 
 decompile: build
-	wasm2wat -o fvm_example_actor.wat fvm_example_actor.wasm
+	wasm2wat -o fvm_example_actor.wat "$(CARGO_TARGET_DIR)/wasm32-unknown-unknown/$(PROFILE)/fvm_example_actor.wasm"

--- a/examples/fvm/Makefile
+++ b/examples/fvm/Makefile
@@ -1,6 +1,11 @@
-build:
-	cp "../../target/wasm32-unknown-unknown/actor/fvm_example_actor.wasm" .
+CARGO_TARGET_DIR ?= ../../target
+
+build-actor:
+	$(MAKE) -C ../actor build
+	cp "$(CARGO_TARGET_DIR)/wasm32-unknown-unknown/actor/fvm_example_actor.wasm" .
+
+build: build-actor
 	cargo build
 
-decompile: build
-	wasm2wat -o fvm_example_actor.wat fvm_example_actor.wasm
+run: build-actor
+	cargo run


### PR DESCRIPTION
- Don't import memory for now, export it. We still need to decide what to do here but this matches the current code.
- Fix decompile.
- Build the actor when building the FVM, just in case.
- Handle the CARGO_TARGET_DIR environment variable.