### PR TITLE
[BIKESHED] Type "Options"

### DIFF
--- a/fvm/src/typestate.rs
+++ b/fvm/src/typestate.rs
@@ -1,3 +1,5 @@
+use std::ops::{Deref, DerefMut};
+
 // Ideally we'd use const generics here, but rust isn't quite ready for that.
 
 /// True is a type-level true used in conditionals.
@@ -11,14 +13,101 @@ pub struct False;
 /// ```ignore
 /// let value: <True as Select<i32, bool>>::Type = 1;
 /// ```
-pub trait Select<A, B> {
-    type Type;
+pub trait TypeOption<A>: Sized {
+    type Container: Container<Self, A>;
 }
 
-impl<A, B> Select<A, B> for True {
-    type Type = A;
+#[doc(hidden)]
+pub trait Container<T: TypeOption<A>, A>: Sized {
+    fn as_option(&self) -> Option<&A>;
+    fn as_option_mut(&mut self) -> Option<&mut A>;
+    fn into_option(self) -> Option<A>;
 }
 
-impl<A, B> Select<A, B> for False {
-    type Type = B;
+impl<A> Container<True, A> for A {
+    #[inline(always)]
+    fn as_option(&self) -> Option<&A> {
+        Some(self)
+    }
+    #[inline(always)]
+    fn as_option_mut(&mut self) -> Option<&mut A> {
+        Some(self)
+    }
+    #[inline(always)]
+    fn into_option(self) -> Option<A> {
+        Some(self)
+    }
+}
+
+impl<A> Container<False, A> for () {
+    #[inline(always)]
+    fn as_option(&self) -> Option<&A> {
+        None
+    }
+    #[inline(always)]
+    fn as_option_mut(&mut self) -> Option<&mut A> {
+        None
+    }
+    #[inline(always)]
+    fn into_option(self) -> Option<A> {
+        None
+    }
+}
+
+#[repr(transparent)]
+pub struct ConstOption<T: TypeOption<A>, A>(<T as TypeOption<A>>::Container);
+
+impl<T, A> ConstOption<T, A>
+where
+    T: TypeOption<A>,
+{
+    #[inline(always)]
+    pub fn as_option(&self) -> Option<&A> {
+        self.0.as_option()
+    }
+
+    #[inline(always)]
+    pub fn as_option_mut(&mut self) -> Option<&mut A> {
+        self.0.as_option_mut()
+    }
+
+    #[inline(always)]
+    pub fn into_option(self) -> Option<A> {
+        self.0.into_option()
+    }
+}
+
+impl<A> ConstOption<True, A> {
+    pub fn some(inner: A) -> Self {
+        ConstOption(inner)
+    }
+}
+
+impl<A> ConstOption<False, A> {
+    pub fn none() -> Self {
+        ConstOption(())
+    }
+}
+
+impl<A> Deref for ConstOption<True, A> {
+    type Target = A;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<A> DerefMut for ConstOption<True, A> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<A> TypeOption<A> for True {
+    type Container = A;
+}
+
+impl<A> TypeOption<A> for False {
+    type Container = ();
 }


### PR DESCRIPTION
This lets us make a single method that can handle both the "Some" and "None" at runtime. Ideally, we'd do this at compiletime with specialization, but that's perma-unstable. And this runtime version should optimize away given all the inlining.

This is not for merging as we don't really need it (yet). But it's fun to play with.