### PR TITLE
[actors consensus fix] pulling over small fix for F16 from forest repo

### DIFF
--- a/actor/src/builtin/miner/mod.rs
+++ b/actor/src/builtin/miner/mod.rs
@@ -2777,7 +2777,6 @@ impl Actor {
             })?;
 
         let amount_withdrawn = std::cmp::min(&available_balance, &params.amount_requested);
-        assert!(!amount_withdrawn.is_negative());
         if amount_withdrawn.is_negative() {
             return Err(actor_error!(
                 ErrIllegalState,


### PR DESCRIPTION
Closes #41 

just takes out a macro assert that kills rust-actors before it gets the chance to correctly return an error