### PR TITLE
use the unsigned varint crate for encoding/decoding

### DIFF
--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -14,7 +14,6 @@ serde_repr = "0.1"
 base64 = { version = "0.13", optional = true }
 chrono = "0.4.9"
 blake2b_simd = "0.5.9"
-leb128 = "0.2.1"
 thiserror = "1.0"
 num-traits = "0.2"
 num-derive = "0.3"
@@ -31,6 +30,7 @@ libsecp256k1 = "0.6"
 bls-signatures = { version = "0.9", default-features = false }
 ## TODO maybe shared shouldn't be depending on filecoin proofs.
 filecoin-proofs-api = { version = "9", features = ["blst"], default_features = false, optional = true }
+unsigned-varint = "0.7.1"
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/shared/src/address/errors.rs
+++ b/shared/src/address/errors.rs
@@ -3,9 +3,9 @@
 
 use super::{BLS_PUB_LEN, PAYLOAD_HASH_LEN, SECP_PUB_LEN};
 use data_encoding::DecodeError;
-use leb128::read::Error as Leb128Error;
 use std::{io, num};
 use thiserror::Error;
+use unsigned_varint::decode::Error as VarintError;
 
 /// Address error
 #[derive(Debug, PartialEq, Error)]
@@ -30,8 +30,6 @@ pub enum Error {
     Base32Decoding(#[from] DecodeError),
     #[error("Cannot get id from non id address")]
     NonIDAddress,
-    #[error("Invalid address ID payload")]
-    InvalidAddressIDPayload(Vec<u8>),
 }
 
 impl From<num::ParseIntError> for Error {
@@ -45,8 +43,8 @@ impl From<io::Error> for Error {
         Error::InvalidPayload
     }
 }
-impl From<Leb128Error> for Error {
-    fn from(_: Leb128Error) -> Error {
+impl From<VarintError> for Error {
+    fn from(_: VarintError) -> Error {
         Error::InvalidPayload
     }
 }

--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -312,26 +312,17 @@ fn encode(addr: &Address) -> String {
 }
 
 pub(crate) fn to_leb_bytes(id: u64) -> Result<Vec<u8>, Error> {
-    let mut buf = Vec::new();
-
     // write id to buffer in leb128 format
-    leb128::write::unsigned(&mut buf, id)?;
-
-    // Create byte vector from buffer
-    Ok(buf)
+    Ok(unsigned_varint::encode::u64(id, &mut unsigned_varint::encode::u64_buffer()).into())
 }
 
 pub(crate) fn from_leb_bytes(bz: &[u8]) -> Result<u64, Error> {
-    let mut readable = bz;
-
     // write id to buffer in leb128 format
-    let id = leb128::read::unsigned(&mut readable)?;
-
-    if to_leb_bytes(id)? == bz {
-        Ok(id)
-    } else {
-        Err(Error::InvalidAddressIDPayload(bz.to_owned()))
+    let (id, remaining) = unsigned_varint::decode::u64(bz)?;
+    if remaining.len() > 0 {
+        return Err(Error::InvalidPayload);
     }
+    Ok(id)
 }
 
 #[cfg(test)]
@@ -362,7 +353,7 @@ mod tests {
                 panic!();
             }
             Err(e) => {
-                assert_eq!(e, Error::InvalidAddressIDPayload(extra_bytes));
+                assert_eq!(e, Error::InvalidPayload);
             }
         }
     }
@@ -380,7 +371,7 @@ mod tests {
                 panic!();
             }
             Err(e) => {
-                assert_eq!(e, Error::InvalidAddressIDPayload(minimal_encoding));
+                assert_eq!(e, Error::InvalidPayload);
             }
         }
     }

--- a/shared/src/encoding/hash.rs
+++ b/shared/src/encoding/hash.rs
@@ -7,7 +7,7 @@ use blake2b_simd::Params;
 ///
 /// # Example
 /// ```
-/// use forest_encoding::blake2b_variable;
+/// use fvm_shared::encoding::blake2b_variable;
 ///
 /// let ingest: Vec<u8> = vec![];
 /// let hash = blake2b_variable(&ingest, 20);
@@ -27,7 +27,7 @@ pub fn blake2b_variable(ingest: &[u8], size: usize) -> Vec<u8> {
 ///
 /// # Example
 /// ```
-/// use forest_encoding::blake2b_256;
+/// use fvm_shared::encoding::blake2b_256;
 ///
 /// let ingest: Vec<u8> = vec![];
 /// let hash = blake2b_256(&ingest);


### PR DESCRIPTION
We need to ensure that varints are minimally encoded. Forest appears to have worked around this internally, but we might as well use a known-good crate (the one multihash/cid depends on).

(probably not worth the patch, but I started it before I noticed it wasn't a real issue)