### PR TITLE
correctly handle "out of gas" on return

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -246,7 +246,9 @@ where
     /// XXX: is message the right argument? Most of the fields are unused and unchecked.
     /// Also, won't the params be a block ID?
     fn send(&mut self, message: Message) -> anyhow::Result<RawBytes, ActorError> {
-        self.call_manager.map_mut(|cm| {
+        self.call_manager.state_tree_mut().begin_transaction();
+
+        let res = self.call_manager.map_mut(|cm| {
             let (res, cm) = cm.send(
                 message.to,
                 message.method_num,
@@ -255,7 +257,11 @@ where
             );
             // Do something with the result.
             (cm, res)
-        })
+        });
+        self.call_manager
+            .state_tree_mut()
+            .end_transaction(res.is_err())?;
+        res
     }
 }
 

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -344,14 +344,13 @@ where
         self.snaps.add_layer();
     }
 
-    /// Commit the top transaction.
-    pub fn commit_transaction(&mut self) -> Result<(), Box<dyn Error>> {
-        self.snaps.merge_last_layer()
-    }
-
-    /// Abort and rollback the top transaction.
-    pub fn abort_transaction(&mut self) -> Result<(), Box<dyn Error>> {
-        self.snaps.drop_layer()
+    /// End a transaction, reverting if requested.
+    pub fn end_transaction(&mut self, revert: bool) -> Result<(), Box<dyn Error>> {
+        if revert {
+            self.snaps.drop_layer()
+        } else {
+            self.snaps.merge_last_layer()
+        }
     }
 
     /// Flush state tree and return Cid root.


### PR DESCRIPTION
We need to revert the changes, but then continue to process the rest of the charges.

Unfortunately, this means we do need to handle the "transaction" inside of the machine, not the call manager. So now we create/finish transactions in both the call manager and inside the kernel.