### PR TITLE
pin rust version

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2021-12-14


### PR DESCRIPTION
The latest nightly is broken, and stable has other issues.