### PR TITLE
add types to syscall errors

### DIFF
--- a/sdk/src/sys/actor.rs
+++ b/sdk/src/sys/actor.rs
@@ -2,7 +2,7 @@
 #[allow(improper_ctypes)]
 extern "C" {
     /// Resolves the ID address of an actor.
-    pub fn resolve_address(addr_off: *const u8, addr_len: u32) -> (u32, i32, u64);
+    pub fn resolve_address(addr_off: *const u8, addr_len: u32) -> (super::SyscallStatus, i32, u64);
 
     /// Gets the CodeCID of an actor by address.
     pub fn get_actor_code_cid(
@@ -10,14 +10,18 @@ extern "C" {
         addr_len: u32,
         obuf_off: *mut u8,
         obuf_len: u32,
-    ) -> (u32, i32);
+    ) -> (super::SyscallStatus, i32);
 
     /// Generates a new actor address for an actor deployed
     /// by the calling actor.
-    pub fn new_actor_address(obuf_off: *mut u8, obuf_len: u32) -> (u32, u32);
+    pub fn new_actor_address(obuf_off: *mut u8, obuf_len: u32) -> (super::SyscallStatus, u32);
 
     /// Creates a new actor of the specified type in the state tree, under
     /// the provided address.
     /// TODO this syscall will change to calculate the address internally.
-    pub fn create_actor(addr_off: *const u8, addr_len: u32, typ_off: *const u8) -> u32;
+    pub fn create_actor(
+        addr_off: *const u8,
+        addr_len: u32,
+        typ_off: *const u8,
+    ) -> super::SyscallStatus;
 }

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -9,12 +9,16 @@ extern "C" {
         addr_len: u32,
         plaintext_off: *const u8,
         plaintext_len: u32,
-    ) -> (u32, i32);
+    ) -> (super::SyscallStatus, i32);
 
     /// Hashes input data using blake2b with 256 bit output.
     ///
     /// The output buffer must be sized to a minimum of 32 bytes.
-    pub fn hash_blake2b(data_off: *const u8, data_len: u32, obuf_off: *mut u8) -> u32;
+    pub fn hash_blake2b(
+        data_off: *const u8,
+        data_len: u32,
+        obuf_off: *mut u8,
+    ) -> super::SyscallStatus;
 
     /// Computes an unsealed sector CID (CommD) from its constituent piece CIDs
     /// (CommPs) and sizes.
@@ -27,13 +31,13 @@ extern "C" {
         pieces_len: u32,
         cid_off: *mut u8,
         cid_len: u32,
-    ) -> (u32, u32);
+    ) -> (super::SyscallStatus, u32);
 
     /// Verifies a sector seal proof.
-    pub fn verify_seal(info_off: *const u8, info_len: u32) -> (u32, i32);
+    pub fn verify_seal(info_off: *const u8, info_len: u32) -> (super::SyscallStatus, i32);
 
     /// Verifies a window proof of spacetime.
-    pub fn verify_post(info_off: *const u8, info_len: u32) -> (u32, i32);
+    pub fn verify_post(info_off: *const u8, info_len: u32) -> (super::SyscallStatus, i32);
 
     /// Verifies that two block headers provide proof of a consensus fault.
     ///
@@ -47,8 +51,8 @@ extern "C" {
         h2_len: u32,
         extra_off: *const u8,
         extra_len: u32,
-    ) -> (u32, i32, u32);
+    ) -> (super::SyscallStatus, i32, u32);
 
     /// Verifies an aggregated batch of sector seal proofs.
-    pub fn verify_aggregate_seals(agg_off: *const u8, agg_len: u32) -> (u32, i32);
+    pub fn verify_aggregate_seals(agg_off: *const u8, agg_len: u32) -> (super::SyscallStatus, i32);
 }

--- a/sdk/src/sys/debug.rs
+++ b/sdk/src/sys/debug.rs
@@ -1,6 +1,6 @@
 #[link(wasm_import_module = "debug")]
 extern "C" {
-    pub fn log(level: DebugLevel, message: *mut u8, message_len: u32) -> u32;
+    pub fn log(level: DebugLevel, message: *mut u8, message_len: u32) -> super::SyscallStatus;
 }
 
 #[repr(u8)]

--- a/sdk/src/sys/gas.rs
+++ b/sdk/src/sys/gas.rs
@@ -4,9 +4,9 @@ extern "C" {
     // We could also _not_ feed that through to the outside?
 
     /// Charge gas.
-    pub fn charge(name_off: *const u8, name_len: u32, amount: u64) -> u32;
+    pub fn charge(name_off: *const u8, name_len: u32, amount: u64) -> super::SyscallStatus;
 
     // Returns the amount of gas remaining.
     // TODO not implemented.
-    // pub fn remaining() -> (u32, u64);
+    // pub fn remaining() -> (super::SyscallStatus, u64);
 }

--- a/sdk/src/sys/ipld.rs
+++ b/sdk/src/sys/ipld.rs
@@ -32,18 +32,18 @@ extern "C" {
     /// - The reachable set is initialized to the root.
     /// - The reachable set is extended to include the direct children of loaded blocks until the
     ///   end of the invocation.
-    pub fn open(cid: *const u8) -> (u32, u32, u64, u32);
+    pub fn open(cid: *const u8) -> (super::SyscallStatus, u32, u64, u32);
 
     /// Creates a new block, returning the block's ID. The block's children must be in the reachable
     /// set. The new block isn't added to the reachable set until the CID is computed.
-    pub fn create(codec: u64, data: *const u8, len: u32) -> (u32, u32);
+    pub fn create(codec: u64, data: *const u8, len: u32) -> (super::SyscallStatus, u32);
 
     /// Reads the identified block into obuf, starting at offset, reading _at most_ len bytes.
     /// Returns the number of bytes read.
-    pub fn read(id: u32, offset: u32, obuf: *mut u8, max_len: u32) -> (u32, u32);
+    pub fn read(id: u32, offset: u32, obuf: *mut u8, max_len: u32) -> (super::SyscallStatus, u32);
 
     /// Returns the codec and size of the specified block.
-    pub fn stat(id: u32) -> (u32, u64, u32);
+    pub fn stat(id: u32) -> (super::SyscallStatus, u64, u32);
 
     // TODO: CID versions?
 
@@ -52,6 +52,11 @@ extern "C" {
     /// If the CID is longer than cid_max_len, no data is written and the actual size is returned.
     ///
     /// The returned CID is added to the reachable set.
-    pub fn cid(id: u32, hash_fun: u64, hash_len: u32, cid: *mut u8, cid_max_len: u32)
-        -> (u32, u32);
+    pub fn cid(
+        id: u32,
+        hash_fun: u64,
+        hash_len: u32,
+        cid: *mut u8,
+        cid_max_len: u32,
+    ) -> (super::SyscallStatus, u32);
 }

--- a/sdk/src/sys/message.rs
+++ b/sdk/src/sys/message.rs
@@ -2,15 +2,15 @@
 #[allow(improper_ctypes)]
 extern "C" {
     /// Returns the caller's actor ID.
-    pub fn caller() -> (u32, u64);
+    pub fn caller() -> (super::SyscallStatus, u64);
 
     /// Returns the receiver's actor ID (i.e. ourselves).
-    pub fn receiver() -> (u32, u64);
+    pub fn receiver() -> (super::SyscallStatus, u64);
 
     /// Returns the method number from the message.
-    pub fn method_number() -> (u32, u64);
+    pub fn method_number() -> (super::SyscallStatus, u64);
 
     /// Returns the value that was received, as little-Endian
     /// tuple of u64 values to be concatenated in a u128.
-    pub fn value_received() -> (u32, u64, u64);
+    pub fn value_received() -> (super::SyscallStatus, u64, u64);
 }

--- a/sdk/src/sys/mod.rs
+++ b/sdk/src/sys/mod.rs
@@ -1,3 +1,8 @@
+use std::convert::TryFrom;
+
+use fvm_shared::error::ExitCode;
+use num_traits::FromPrimitive;
+
 pub mod actor;
 pub mod crypto;
 #[cfg(feature = "debug")]
@@ -11,3 +16,13 @@ pub mod rand;
 pub mod send;
 pub mod sself;
 pub mod validation;
+
+#[repr(transparent)]
+pub struct SyscallStatus(u32);
+
+impl TryFrom<SyscallStatus> for ExitCode {
+    type Error = u32;
+    fn try_from(e: SyscallStatus) -> Result<ExitCode, u32> {
+        FromPrimitive::from_u32(e.0).ok_or(e.0)
+    }
+}

--- a/sdk/src/sys/network.rs
+++ b/sdk/src/sys/network.rs
@@ -2,12 +2,12 @@
 #[allow(improper_ctypes)]
 extern "C" {
     /// Gets the current epoch.
-    pub fn curr_epoch() -> (u32, u64);
+    pub fn curr_epoch() -> (super::SyscallStatus, u64);
 
     /// Gets the network version.
-    pub fn version() -> (u32, u32);
+    pub fn version() -> (super::SyscallStatus, u32);
 
     /// Gets the base fee for the epoch as little-Endian
     /// tuple of u64 values to be concatenated in a u128.
-    pub fn base_fee() -> (u32, u64, u64);
+    pub fn base_fee() -> (super::SyscallStatus, u64, u64);
 }

--- a/sdk/src/sys/rand.rs
+++ b/sdk/src/sys/rand.rs
@@ -10,7 +10,7 @@ extern "C" {
         entropy_offset: *const u8,
         entropy_len: u32,
         obuf: *mut u8,
-    ) -> u32;
+    ) -> super::SyscallStatus;
 
     /// Gets 32 bytes of randomness from the beacon system (currently Drand).
     /// The supplied output buffer must have at least 32 bytes of capacity.
@@ -22,5 +22,5 @@ extern "C" {
         entropy_offset: *const u8,
         entropy_len: u32,
         obuf: *mut u8,
-    ) -> u32;
+    ) -> super::SyscallStatus;
 }

--- a/sdk/src/sys/send.rs
+++ b/sdk/src/sys/send.rs
@@ -10,5 +10,5 @@ extern "C" {
         params: u32,
         value_hi: u64,
         value_lo: u64,
-    ) -> (u32, u32);
+    ) -> (super::SyscallStatus, u32);
 }

--- a/sdk/src/sys/sself.rs
+++ b/sdk/src/sys/sself.rs
@@ -5,15 +5,15 @@ extern "C" {
     ///
     /// If the CID doesn't fit in the specified maximum length (and/or the length is 0), this
     /// function returns the required size and does not update the cid buffer.
-    pub fn get_root(cid: *mut u8, cid_max_len: u32) -> (u32, u32);
+    pub fn get_root(cid: *mut u8, cid_max_len: u32) -> (super::SyscallStatus, u32);
 
     /// Sets the root CID for the calling actor. The new root must be in the reachable set.
-    pub fn set_root(cid: *const u8) -> u32;
+    pub fn set_root(cid: *const u8) -> super::SyscallStatus;
 
     /// Gets the current balance for the calling actor.
-    pub fn current_balance() -> (u32, u64, u64);
+    pub fn current_balance() -> (super::SyscallStatus, u64, u64);
 
     /// Destroys the calling actor, sending its current balance
     /// to the supplied address, which cannot be itself.
-    pub fn self_destruct(addr_off: *const u8, addr_len: u32) -> u32;
+    pub fn self_destruct(addr_off: *const u8, addr_len: u32) -> super::SyscallStatus;
 }

--- a/sdk/src/sys/validation.rs
+++ b/sdk/src/sys/validation.rs
@@ -1,17 +1,23 @@
 #[link(wasm_import_module = "validation")]
 extern "C" {
     /// Signals that this actor accepts calls from any other actor.
-    pub fn validate_immediate_caller_accept_any() -> u32;
+    pub fn validate_immediate_caller_accept_any() -> super::SyscallStatus;
 
     /// Validates that the call being processed originated at one
     /// of the listed addresses.
     ///
     /// The list of addreses is provided as a CBOR encoded list.
-    pub fn validate_immediate_caller_addr_one_of(addrs_offset: *const u8, addrs_len: u32) -> u32;
+    pub fn validate_immediate_caller_addr_one_of(
+        addrs_offset: *const u8,
+        addrs_len: u32,
+    ) -> super::SyscallStatus;
 
     /// Validates that the call being processed originated at an
     /// actor of one of the specified types.
     ///
     /// The list of CIDs is provided as a CBOR encoded list.
-    pub fn validate_immediate_caller_type_one_of(cids_offset: *const u8, cids_len: u32) -> u32;
+    pub fn validate_immediate_caller_type_one_of(
+        cids_offset: *const u8,
+        cids_len: u32,
+    ) -> super::SyscallStatus;
 }


### PR DESCRIPTION
The underlying error types are `repr(transparent)`, so they'll work fine
in the FFI boundary. but the types ensure we don't misinterpret them.

In the future, we can move to adding more types like:

- Block IDs.
- Boolean? But we can't do that unless we use 0 and 1 (negative 1 isn't
  valid).
- ActorID

Although many of these can just be type _aliases_. I used a transparent
tuple type here for extra safety so we don't misinterpret it.