### PR TITLE
organize imports with rustfmt

### DIFF
--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -1,20 +1,20 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use blockstore::Blockstore;
-use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
-
-use actors_runtime::actor_error;
-use fvm_shared::address::{Address, Protocol};
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
-
-use actors_runtime::ActorError;
 use actors_runtime::{
+    actor_error,
     builtin::singletons::SYSTEM_ACTOR_ADDR,
     runtime::{ActorCode, Runtime},
+    ActorError,
 };
+use blockstore::Blockstore;
+use fvm_shared::{
+    address::{Address, Protocol},
+    encoding::RawBytes,
+    MethodNum, METHOD_CONSTRUCTOR,
+};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
 
 pub use self::state::State;
 

--- a/actors/account/src/state.rs
+++ b/actors/account/src/state.rs
@@ -1,8 +1,10 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_shared::address::Address;
-use fvm_shared::encoding::{tuple::*, Cbor};
+use fvm_shared::{
+    address::Address,
+    encoding::{tuple::*, Cbor},
+};
 
 /// State includes the address for the actor
 #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/account/tests/account_actor_test.rs
+++ b/actors/account/tests/account_actor_test.rs
@@ -1,13 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use actors_runtime::builtin::{SYSTEM_ACTOR_ADDR, SYSTEM_ACTOR_CODE_ID};
-use actors_runtime::test_utils::*;
-use fvm_shared::address::Address;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::error::ExitCode;
-
+use actors_runtime::{
+    builtin::{SYSTEM_ACTOR_ADDR, SYSTEM_ACTOR_CODE_ID},
+    test_utils::*,
+};
 use fvm_actor_account::{Actor as AccountActor, State};
+use fvm_shared::{address::Address, encoding::RawBytes, error::ExitCode};
 
 macro_rules! account_tests {
     ($($name:ident: $value:expr,)*) => {

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -1,21 +1,19 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use actors_runtime::{
+    actor_error,
+    runtime::{ActorCode, Runtime},
+    ActorError, SYSTEM_ACTOR_ADDR,
+};
 use blockstore::Blockstore;
+use fvm_shared::{
+    econ::TokenAmount,
+    encoding::{tuple::*, RawBytes},
+    MethodNum, METHOD_CONSTRUCTOR,
+};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-
-use actors_runtime::actor_error;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::tuple::*;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
-
-use actors_runtime::ActorError;
-use actors_runtime::{
-    runtime::{ActorCode, Runtime},
-    SYSTEM_ACTOR_ADDR,
-};
 
 pub use self::state::{Entry, State};
 

--- a/actors/cron/src/state.rs
+++ b/actors/cron/src/state.rs
@@ -1,9 +1,11 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_shared::address::Address;
-use fvm_shared::encoding::{tuple::*, Cbor};
-use fvm_shared::MethodNum;
+use fvm_shared::{
+    address::Address,
+    encoding::{tuple::*, Cbor},
+    MethodNum,
+};
 
 /// Cron actor state which holds entries to call during epoch tick
 #[derive(Default, Serialize_tuple, Deserialize_tuple)]

--- a/actors/cron/tests/cron_actor_test.rs
+++ b/actors/cron/tests/cron_actor_test.rs
@@ -1,13 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use actors_runtime::test_utils::*;
-use actors_runtime::{SYSTEM_ACTOR_ADDR, SYSTEM_ACTOR_CODE_ID};
-use fvm_shared::address::Address;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::error::ExitCode;
-
+use actors_runtime::{test_utils::*, SYSTEM_ACTOR_ADDR, SYSTEM_ACTOR_CODE_ID};
 use fvm_actor_cron::{Actor as CronActor, ConstructorParams, Entry, State};
+use fvm_shared::{address::Address, encoding::RawBytes, error::ExitCode};
 
 fn construct_runtime() -> MockRuntime {
     MockRuntime {

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -1,24 +1,21 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use actors_runtime::{
+    actor_error,
+    runtime::{ActorCode, Runtime},
+    ActorDowncast, ActorError, MINER_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID, PAYCH_ACTOR_CODE_ID,
+    POWER_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR,
+};
 use blockstore::Blockstore;
 use cid::Cid;
+use fvm_shared::{
+    address::Address, encoding::RawBytes, error::ExitCode, MethodNum, METHOD_CONSTRUCTOR,
+};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 
-use actors_runtime::{actor_error, ActorError};
-use actors_runtime::{
-    runtime::{ActorCode, Runtime},
-    ActorDowncast, MINER_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID, PAYCH_ACTOR_CODE_ID,
-    POWER_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR,
-};
-use fvm_shared::address::Address;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::error::ExitCode;
-use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
-
-pub use self::state::State;
-pub use self::types::*;
+pub use self::{state::State, types::*};
 
 mod state;
 mod types;

--- a/actors/init/src/state.rs
+++ b/actors/init/src/state.rs
@@ -1,16 +1,15 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use actors_runtime::{make_empty_map, make_map_with_root_and_bitwidth, FIRST_NON_SINGLETON_ADDR};
 use anyhow::anyhow;
-
 use blockstore::Blockstore;
 use cid::Cid;
-
-use actors_runtime::{make_empty_map, make_map_with_root_and_bitwidth, FIRST_NON_SINGLETON_ADDR};
-use fvm_shared::address::{Address, Protocol};
-use fvm_shared::encoding::tuple::*;
-use fvm_shared::encoding::Cbor;
-use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
+use fvm_shared::{
+    address::{Address, Protocol},
+    encoding::{tuple::*, Cbor},
+    ActorID, HAMT_BIT_WIDTH,
+};
 use ipld_hamt::Error as HamtError;
 
 /// State is reponsible for creating

--- a/actors/init/src/types.rs
+++ b/actors/init/src/types.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-
-use fvm_shared::address::Address;
-use fvm_shared::encoding::{tuple::*, Cbor, RawBytes};
+use fvm_shared::{
+    address::Address,
+    encoding::{tuple::*, Cbor, RawBytes},
+};
 
 /// Init actor Constructor parameters
 #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -1,24 +1,20 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use cid::Cid;
-use serde::Serialize;
-
-use actors_runtime::test_utils::*;
 use actors_runtime::{
-    ActorError, Multimap, ACCOUNT_ACTOR_CODE_ID, FIRST_NON_SINGLETON_ADDR, MINER_ACTOR_CODE_ID,
-    MULTISIG_ACTOR_CODE_ID, PAYCH_ACTOR_CODE_ID, POWER_ACTOR_CODE_ID, STORAGE_POWER_ACTOR_ADDR,
-    SYSTEM_ACTOR_ADDR, SYSTEM_ACTOR_CODE_ID,
+    test_utils::*, ActorError, Multimap, ACCOUNT_ACTOR_CODE_ID, FIRST_NON_SINGLETON_ADDR,
+    MINER_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID, PAYCH_ACTOR_CODE_ID, POWER_ACTOR_CODE_ID,
+    STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, SYSTEM_ACTOR_CODE_ID,
 };
-use fvm_shared::address::Address;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::error::ExitCode;
-use fvm_shared::{HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR};
-
+use cid::Cid;
 use fvm_actor_init::{
     Actor as InitActor, ConstructorParams, ExecParams, ExecReturn, Method, State,
 };
+use fvm_shared::{
+    address::Address, econ::TokenAmount, encoding::RawBytes, error::ExitCode, HAMT_BIT_WIDTH,
+    METHOD_CONSTRUCTOR,
+};
+use serde::Serialize;
 
 fn construct_runtime() -> MockRuntime {
     MockRuntime {

--- a/actors/market/src/deal.rs
+++ b/actors/market/src/deal.rs
@@ -1,20 +1,18 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use actors_runtime::DealWeight;
 use cid::{Cid, Version};
-
-use fvm_shared::commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED};
 use fvm_shared::{
     address::Address,
     bigint::bigint_ser,
     clock::ChainEpoch,
+    commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED},
     crypto::signature::Signature,
     econ::TokenAmount,
     encoding::{tuple::*, Cbor},
     piece::PaddedPieceSize,
 };
-
-use actors_runtime::DealWeight;
 
 /// Cid prefix for piece Cids
 pub fn is_piece_cid(c: &Cid) -> bool {

--- a/actors/market/src/ext.rs
+++ b/actors/market/src/ext.rs
@@ -1,9 +1,7 @@
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::tuple::*;
-use fvm_shared::sector::StoragePower;
-use fvm_shared::smooth::FilterEstimate;
+use fvm_shared::{
+    address::Address, bigint::bigint_ser, econ::TokenAmount, encoding::tuple::*,
+    sector::StoragePower, smooth::FilterEstimate,
+};
 
 pub mod miner {
     use super::*;

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -3,35 +3,33 @@
 
 use std::collections::HashSet;
 
-use ahash::AHashMap;
-use blockstore::Blockstore;
-use num_derive::FromPrimitive;
-use num_traits::{FromPrimitive, Signed, Zero};
-
-use fvm_shared::address::Address;
-use fvm_shared::bigint::BigInt;
-use fvm_shared::clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED};
-use fvm_shared::deal::DealID;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{to_vec, Cbor, RawBytes};
-use fvm_shared::error::ExitCode;
-use fvm_shared::piece::PieceInfo;
-use fvm_shared::reward::ThisEpochRewardReturn;
-use fvm_shared::sector::StoragePower;
-use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND};
-
-use actors_runtime::{actor_error, ActorError};
 use actors_runtime::{
+    actor_error,
     runtime::{ActorCode, Runtime},
-    ActorDowncast, BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE, CRON_ACTOR_ADDR,
+    ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE, CRON_ACTOR_ADDR,
     MINER_ACTOR_CODE_ID, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
     VERIFIED_REGISTRY_ACTOR_ADDR,
 };
+use ahash::AHashMap;
+use blockstore::Blockstore;
+use fvm_shared::{
+    address::Address,
+    bigint::BigInt,
+    clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED},
+    deal::DealID,
+    econ::TokenAmount,
+    encoding::{to_vec, Cbor, RawBytes},
+    error::ExitCode,
+    piece::PieceInfo,
+    reward::ThisEpochRewardReturn,
+    sector::StoragePower,
+    MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND,
+};
+use num_derive::FromPrimitive;
+use num_traits::{FromPrimitive, Signed, Zero};
 
-pub use self::deal::*;
 use self::policy::*;
-pub use self::state::*;
-pub use self::types::*;
+pub use self::{deal::*, state::*, types::*};
 
 // export for testing
 mod deal;

--- a/actors/market/src/policy.rs
+++ b/actors/market/src/policy.rs
@@ -3,16 +3,12 @@
 
 use std::cmp::max;
 
-use num_traits::Zero;
-
-use fvm_shared::bigint::Integer;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::piece::PaddedPieceSize;
-use fvm_shared::sector::StoragePower;
-use fvm_shared::TOTAL_FILECOIN;
-
 use actors_runtime::{network::EPOCHS_IN_DAY, DealWeight};
+use fvm_shared::{
+    bigint::Integer, clock::ChainEpoch, econ::TokenAmount, piece::PaddedPieceSize,
+    sector::StoragePower, TOTAL_FILECOIN,
+};
+use num_traits::Zero;
 
 use super::deal::DealProposal;
 

--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -1,25 +1,23 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use actors_runtime::{
+    actor_error, make_empty_map, ActorDowncast, ActorError, Array, BalanceTable, Set, SetMultimap,
+};
 use anyhow::anyhow;
 use blockstore::Blockstore;
 use cid::Cid;
-use num_traits::{Signed, Zero};
-
-use actors_runtime::actor_error;
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::clock::{ChainEpoch, EPOCH_UNDEFINED};
-use fvm_shared::deal::DealID;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::tuple::*;
-use fvm_shared::encoding::Cbor;
-use fvm_shared::error::ExitCode;
-use fvm_shared::HAMT_BIT_WIDTH;
-
-use actors_runtime::{
-    make_empty_map, ActorDowncast, ActorError, Array, BalanceTable, Set, SetMultimap,
+use fvm_shared::{
+    address::Address,
+    bigint::bigint_ser,
+    clock::{ChainEpoch, EPOCH_UNDEFINED},
+    deal::DealID,
+    econ::TokenAmount,
+    encoding::{tuple::*, Cbor},
+    error::ExitCode,
+    HAMT_BIT_WIDTH,
 };
+use num_traits::{Signed, Zero};
 
 use super::{policy::*, types::*, DealProposal, DealState, DEAL_UPDATES_INTERVAL};
 

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -1,17 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use cid::Cid;
-
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::deal::DealID;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::tuple::*;
-use fvm_shared::sector::RegisteredSealProof;
-
 use actors_runtime::{Array, DealWeight};
+use cid::Cid;
+use fvm_shared::{
+    address::Address, bigint::bigint_ser, clock::ChainEpoch, deal::DealID, econ::TokenAmount,
+    encoding::tuple::*, sector::RegisteredSealProof,
+};
 
 use super::deal::{ClientDealProposal, DealProposal, DealState};
 

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -4,25 +4,19 @@
 use std::collections::HashMap;
 
 use actors_runtime::{
-    make_empty_map, runtime::Runtime, util::BALANCE_TABLE_BITWIDTH, ActorError, BalanceTable,
-    SetMultimap, ACCOUNT_ACTOR_CODE_ID, CALLER_TYPES_SIGNABLE, INIT_ACTOR_CODE_ID,
+    make_empty_map, runtime::Runtime, test_utils::*, util::BALANCE_TABLE_BITWIDTH, ActorError,
+    BalanceTable, SetMultimap, ACCOUNT_ACTOR_CODE_ID, CALLER_TYPES_SIGNABLE, INIT_ACTOR_CODE_ID,
     MINER_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID, STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
-
-use actors_runtime::test_utils::*;
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser::BigIntDe;
-use fvm_shared::clock::EPOCH_UNDEFINED;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::error::ExitCode;
-use fvm_shared::{HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR, METHOD_SEND};
-use ipld_amt::Amt;
-
 use fvm_actor_market::{
     ext, Actor as MarketActor, Method, State, WithdrawBalanceParams, PROPOSALS_AMT_BITWIDTH,
     STATES_AMT_BITWIDTH,
 };
+use fvm_shared::{
+    address::Address, bigint::bigint_ser::BigIntDe, clock::EPOCH_UNDEFINED, econ::TokenAmount,
+    encoding::RawBytes, error::ExitCode, HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR, METHOD_SEND,
+};
+use ipld_amt::Amt;
 
 const OWNER_ID: u64 = 101;
 const PROVIDER_ID: u64 = 102;

--- a/actors/miner/src/bitfield_queue.rs
+++ b/actors/miner/src/bitfield_queue.rs
@@ -3,11 +3,10 @@
 
 use std::collections::HashMap;
 
+use actors_runtime::{ActorDowncast, Array};
 use bitfield::BitField;
 use blockstore::Blockstore;
 use cid::Cid;
-
-use actors_runtime::{ActorDowncast, Array};
 use fvm_shared::clock::{ChainEpoch, QuantSpec};
 use ipld_amt::Error as AmtError;
 

--- a/actors/miner/src/deadline_state.rs
+++ b/actors/miner/src/deadline_state.rs
@@ -1,21 +1,24 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::{cmp, collections::HashMap, collections::HashSet};
+use std::{
+    cmp,
+    collections::{HashMap, HashSet},
+};
 
+use actors_runtime::{actor_error, ActorDowncast, ActorError, Array};
 use anyhow::anyhow;
 use bitfield::BitField;
 use blockstore::Blockstore;
 use cid::{multihash::Code, Cid};
+use fvm_shared::{
+    clock::{ChainEpoch, QuantSpec},
+    econ::TokenAmount,
+    encoding::{tuple::*, CborStore},
+    error::ExitCode,
+    sector::{PoStProof, SectorSize},
+};
 use num_traits::{Signed, Zero};
-
-use actors_runtime::{actor_error, ActorError};
-use actors_runtime::{ActorDowncast, Array};
-use fvm_shared::clock::{ChainEpoch, QuantSpec};
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{tuple::*, CborStore};
-use fvm_shared::error::ExitCode;
-use fvm_shared::sector::{PoStProof, SectorSize};
 
 use super::{
     BitFieldQueue, ExpirationSet, Partition, PartitionSectorMap, PoStPartition, PowerPair,

--- a/actors/miner/src/deadlines.rs
+++ b/actors/miner/src/deadlines.rs
@@ -1,14 +1,14 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use blockstore::Blockstore;
-
 use actors_runtime::Array;
-use fvm_shared::clock::{ChainEpoch, QuantSpec};
-use fvm_shared::sector::SectorNumber;
+use blockstore::Blockstore;
+use fvm_shared::{
+    clock::{ChainEpoch, QuantSpec},
+    sector::SectorNumber,
+};
 
-use super::policy::*;
-use super::{DeadlineInfo, Deadlines, Partition};
+use super::{policy::*, DeadlineInfo, Deadlines, Partition};
 
 pub fn new_deadline_info(
     proving_period_start: ChainEpoch,

--- a/actors/miner/src/expiration_queue.rs
+++ b/actors/miner/src/expiration_queue.rs
@@ -1,26 +1,28 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::convert::TryInto;
-use std::{collections::HashMap, collections::HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    convert::TryInto,
+};
 
+use actors_runtime::{ActorDowncast, Array};
 use anyhow::anyhow;
 use bitfield::BitField;
 use blockstore::Blockstore;
 use cid::Cid;
+use fvm_shared::{
+    bigint::bigint_ser,
+    clock::{ChainEpoch, QuantSpec},
+    econ::TokenAmount,
+    encoding::tuple::*,
+    sector::{SectorNumber, SectorSize},
+};
+use ipld_amt::{Error as AmtError, ValueMut};
 use num_traits::{Signed, Zero};
 
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::clock::{ChainEpoch, QuantSpec};
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::tuple::*;
-use fvm_shared::sector::{SectorNumber, SectorSize};
-use ipld_amt::{Error as AmtError, ValueMut};
-
-use crate::policy::ADDRESSED_SECTORS_MAX;
-use actors_runtime::{ActorDowncast, Array};
-
 use super::{power_for_sector, PowerPair, SectorOnChainInfo};
+use crate::policy::ADDRESSED_SECTORS_MAX;
 
 /// An internal limit on the cardinality of a bitfield in a queue entry.
 /// This must be at least large enough to support the maximum number of sectors in a partition.

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -1,12 +1,14 @@
 use actors_runtime::DealWeight;
 use cid::Cid;
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::deal::DealID;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{tuple::*, RawBytes};
-use fvm_shared::sector::{RegisteredSealProof, StoragePower};
-use fvm_shared::smooth::FilterEstimate;
+use fvm_shared::{
+    bigint::bigint_ser,
+    clock::ChainEpoch,
+    deal::DealID,
+    econ::TokenAmount,
+    encoding::{tuple::*, RawBytes},
+    sector::{RegisteredSealProof, StoragePower},
+    smooth::FilterEstimate,
+};
 
 pub mod account {
     pub const PUBKEY_ADDRESS_METHOD: u64 = 2;

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1,54 +1,11 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::collections::{hash_map::Entry, HashMap};
-use std::{iter, ops::Neg};
-
-use anyhow::anyhow;
-use bitfield::{BitField, UnvalidatedBitField, Validate};
-use blockstore::Blockstore;
-use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
-use cid::{multihash::Code, Cid};
-use log::{error, info, warn};
-use num_derive::FromPrimitive;
-use num_traits::{FromPrimitive, Signed, Zero};
-
-pub use bitfield_queue::*;
-pub use deadline_assignment::*;
-pub use deadline_info::*;
-pub use deadline_state::*;
-pub use deadlines::*;
-pub use expiration_queue::*;
-
-use fvm_shared::bigint::bigint_ser::BigIntSer;
-use fvm_shared::crypto::randomness::DomainSeparationTag::WindowedPoStChallengeSeed;
-use fvm_shared::encoding::{BytesDe, Cbor, CborStore};
-use fvm_shared::{
-    address::{Address, Payload, Protocol},
-    bigint::BigInt,
-    clock::ChainEpoch,
-    crypto::randomness::*,
-    deal::DealID,
-    econ::TokenAmount,
-    encoding::RawBytes,
-    error::*,
-    randomness::*,
-    sector::*,
-    MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND,
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    iter,
+    ops::Neg,
 };
-// The following errors are particular cases of illegal state.
-// They're not expected to ever happen, but if they do, distinguished codes can help us
-// diagnose the problem.
-use fvm_shared::error::ExitCode::ErrPlaceholder as ErrBalanceInvariantBroken;
-pub use monies::*;
-pub use partition_state::*;
-pub use policy::*;
-pub use sector_map::*;
-pub use sectors::*;
-pub use state::*;
-pub use termination::*;
-pub use types::*;
-pub use vesting_state::*;
 
 use actors_runtime::{
     actor_error, is_principal,
@@ -57,8 +14,48 @@ use actors_runtime::{
     CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
     STORAGE_POWER_ACTOR_ADDR,
 };
-use fvm_shared::reward::ThisEpochRewardReturn;
-use fvm_shared::smooth::FilterEstimate;
+use anyhow::anyhow;
+use bitfield::{BitField, UnvalidatedBitField, Validate};
+pub use bitfield_queue::*;
+use blockstore::Blockstore;
+use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
+use cid::{multihash::Code, Cid};
+pub use deadline_assignment::*;
+pub use deadline_info::*;
+pub use deadline_state::*;
+pub use deadlines::*;
+pub use expiration_queue::*;
+// The following errors are particular cases of illegal state.
+// They're not expected to ever happen, but if they do, distinguished codes can help us
+// diagnose the problem.
+use fvm_shared::error::ExitCode::ErrPlaceholder as ErrBalanceInvariantBroken;
+use fvm_shared::{
+    address::{Address, Payload, Protocol},
+    bigint::{bigint_ser::BigIntSer, BigInt},
+    clock::ChainEpoch,
+    crypto::randomness::{DomainSeparationTag::WindowedPoStChallengeSeed, *},
+    deal::DealID,
+    econ::TokenAmount,
+    encoding::{BytesDe, Cbor, CborStore, RawBytes},
+    error::*,
+    randomness::*,
+    reward::ThisEpochRewardReturn,
+    sector::*,
+    smooth::FilterEstimate,
+    MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND,
+};
+use log::{error, info, warn};
+pub use monies::*;
+use num_derive::FromPrimitive;
+use num_traits::{FromPrimitive, Signed, Zero};
+pub use partition_state::*;
+pub use policy::*;
+pub use sector_map::*;
+pub use sectors::*;
+pub use state::*;
+pub use termination::*;
+pub use types::*;
+pub use vesting_state::*;
 
 use crate::Code::Blake2b256;
 

--- a/actors/miner/src/monies.rs
+++ b/actors/miner/src/monies.rs
@@ -3,18 +3,18 @@
 
 use std::cmp::{self, max};
 
+use actors_runtime::{network::EPOCHS_IN_DAY, EXPECTED_LEADERS_PER_EPOCH};
+use fvm_shared::{
+    bigint::{num_integer::div_floor, BigInt, Integer},
+    clock::ChainEpoch,
+    econ::TokenAmount,
+    math::PRECISION,
+    sector::StoragePower,
+    smooth::{self, FilterEstimate},
+    FILECOIN_PRECISION,
+};
 use lazy_static::lazy_static;
 use num_traits::Zero;
-
-use fvm_shared::bigint::{num_integer::div_floor, BigInt, Integer};
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::math::PRECISION;
-use fvm_shared::sector::StoragePower;
-use fvm_shared::smooth::{self, FilterEstimate};
-use fvm_shared::FILECOIN_PRECISION;
-
-use actors_runtime::{network::EPOCHS_IN_DAY, EXPECTED_LEADERS_PER_EPOCH};
 
 use super::{VestSpec, REWARD_VESTING_SPEC};
 

--- a/actors/miner/src/partition_state.rs
+++ b/actors/miner/src/partition_state.rs
@@ -3,20 +3,20 @@
 
 use std::ops::{self, Neg};
 
+use actors_runtime::{actor_error, ActorDowncast, Array};
 use anyhow::anyhow;
 use bitfield::{BitField, UnvalidatedBitField, Validate};
 use blockstore::Blockstore;
 use cid::Cid;
+use fvm_shared::{
+    bigint::bigint_ser,
+    clock::{ChainEpoch, QuantSpec, NO_QUANTIZATION},
+    econ::TokenAmount,
+    encoding::tuple::*,
+    error::ExitCode,
+    sector::{SectorSize, StoragePower},
+};
 use num_traits::{Signed, Zero};
-
-use actors_runtime::{actor_error, ActorDowncast, Array};
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::clock::{QuantSpec, NO_QUANTIZATION};
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::tuple::*;
-use fvm_shared::error::ExitCode;
-use fvm_shared::sector::{SectorSize, StoragePower};
 
 use super::{
     power_for_sectors, select_sectors, validate_partition_contains_sectors, BitFieldQueue,

--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -1,19 +1,18 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use cid::{Cid, Version};
 use std::cmp;
 
-use fvm_shared::bigint::{BigInt, Integer};
-use fvm_shared::clock::{ChainEpoch, EPOCH_DURATION_SECONDS};
-use fvm_shared::commcid::{FIL_COMMITMENT_SEALED, POSEIDON_BLS12_381_A1_FC1};
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::sector::{
-    RegisteredPoStProof, RegisteredSealProof, SectorQuality, SectorSize, StoragePower,
-};
-use fvm_shared::version::NetworkVersion;
-
 use actors_runtime::{network::*, DealWeight, EXPECTED_LEADERS_PER_EPOCH};
+use cid::{Cid, Version};
+use fvm_shared::{
+    bigint::{BigInt, Integer},
+    clock::{ChainEpoch, EPOCH_DURATION_SECONDS},
+    commcid::{FIL_COMMITMENT_SEALED, POSEIDON_BLS12_381_A1_FC1},
+    econ::TokenAmount,
+    sector::{RegisteredPoStProof, RegisteredSealProof, SectorQuality, SectorSize, StoragePower},
+    version::NetworkVersion,
+};
 
 use super::{types::SectorOnChainInfo, PowerPair, BASE_REWARD_FOR_DISPUTED_WINDOW_POST};
 

--- a/actors/miner/src/sectors.rs
+++ b/actors/miner/src/sectors.rs
@@ -3,15 +3,16 @@
 
 use std::collections::HashSet;
 
-use actors_runtime::{actor_error, ActorError};
-use actors_runtime::{ActorDowncast, Array};
+use actors_runtime::{actor_error, ActorDowncast, ActorError, Array};
 use ahash::AHashSet;
 use anyhow::anyhow;
 use bitfield::BitField;
 use blockstore::Blockstore;
 use cid::Cid;
-use fvm_shared::error::ExitCode;
-use fvm_shared::sector::{SectorNumber, MAX_SECTOR_NUMBER};
+use fvm_shared::{
+    error::ExitCode,
+    sector::{SectorNumber, MAX_SECTOR_NUMBER},
+};
 use ipld_amt::Error as AmtError;
 
 use super::SectorOnChainInfo;

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -1,30 +1,29 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::cmp;
-use std::{collections::HashMap, ops::Neg};
-
-use anyhow::anyhow;
-use bitfield::BitField;
-use blockstore::Blockstore;
-use cid::{multihash::Code, Cid};
-use num_traits::{Signed, Zero};
-
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED};
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{serde_bytes, tuple::*, BytesDe, Cbor, CborStore};
-use fvm_shared::error::ExitCode;
-use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, SectorSize, MAX_SECTOR_NUMBER};
-use fvm_shared::HAMT_BIT_WIDTH;
-use ipld_amt::Error as AmtError;
-use ipld_hamt::Error as HamtError;
+use std::{cmp, collections::HashMap, ops::Neg};
 
 use actors_runtime::{
     actor_error, make_empty_map, make_map_with_root_and_bitwidth, u64_key, ActorDowncast,
     ActorError, Array,
 };
+use anyhow::anyhow;
+use bitfield::BitField;
+use blockstore::Blockstore;
+use cid::{multihash::Code, Cid};
+use fvm_shared::{
+    address::Address,
+    bigint::bigint_ser,
+    clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED},
+    econ::TokenAmount,
+    encoding::{serde_bytes, tuple::*, BytesDe, Cbor, CborStore},
+    error::ExitCode,
+    sector::{RegisteredPoStProof, SectorNumber, SectorSize, MAX_SECTOR_NUMBER},
+    HAMT_BIT_WIDTH,
+};
+use ipld_amt::Error as AmtError;
+use ipld_hamt::Error as HamtError;
+use num_traits::{Signed, Zero};
 
 use super::{
     assign_deadlines, deadline_is_mutable, deadlines::new_deadline_info,

--- a/actors/miner/src/termination.rs
+++ b/actors/miner/src/termination.rs
@@ -4,7 +4,6 @@
 use std::{collections::HashMap, ops::AddAssign};
 
 use bitfield::BitField;
-
 use fvm_shared::clock::ChainEpoch;
 
 #[derive(Default)]

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -1,19 +1,19 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use actors_runtime::DealWeight;
 use bitfield::UnvalidatedBitField;
 use cid::Cid;
-
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::deal::DealID;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{serde_bytes, tuple::*, BytesDe};
-use fvm_shared::randomness::Randomness;
-use fvm_shared::sector::{PoStProof, RegisteredPoStProof, RegisteredSealProof, SectorNumber};
-
-use actors_runtime::DealWeight;
+use fvm_shared::{
+    address::Address,
+    bigint::bigint_ser,
+    clock::ChainEpoch,
+    deal::DealID,
+    econ::TokenAmount,
+    encoding::{serde_bytes, tuple::*, BytesDe},
+    randomness::Randomness,
+    sector::{PoStProof, RegisteredPoStProof, RegisteredSealProof, SectorNumber},
+};
 
 pub type CronEvent = i64;
 pub const CRON_EVENT_WORKER_KEY_CHANGE: CronEvent = 0;

--- a/actors/miner/src/vesting_state.rs
+++ b/actors/miner/src/vesting_state.rs
@@ -3,12 +3,13 @@
 
 use std::collections::HashMap;
 
+use fvm_shared::{
+    bigint::{bigint_ser, Integer},
+    clock::{ChainEpoch, QuantSpec},
+    econ::TokenAmount,
+    encoding::tuple::*,
+};
 use num_traits::Zero;
-
-use fvm_shared::bigint::{bigint_ser, Integer};
-use fvm_shared::clock::{ChainEpoch, QuantSpec};
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::tuple::*;
 
 use super::VestSpec;
 

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -3,26 +3,24 @@
 
 use std::collections::HashSet;
 
+use actors_runtime::{
+    actor_error, make_empty_map, make_map_with_root, resolve_to_id_addr,
+    runtime::{ActorCode, Runtime, Syscalls},
+    ActorDowncast, ActorError, Map, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR,
+};
 use blockstore::Blockstore;
+use fvm_shared::{
+    address::Address,
+    bigint::Sign,
+    econ::TokenAmount,
+    encoding::{to_vec, RawBytes},
+    error::ExitCode,
+    MethodNum, HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR,
+};
 use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Signed};
 
-use actors_runtime::{actor_error, ActorError};
-use fvm_shared::address::Address;
-use fvm_shared::bigint::Sign;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{to_vec, RawBytes};
-use fvm_shared::error::ExitCode;
-use fvm_shared::{MethodNum, HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR};
-
-use actors_runtime::{
-    make_empty_map, make_map_with_root, resolve_to_id_addr,
-    runtime::{ActorCode, Runtime, Syscalls},
-    ActorDowncast, Map, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR,
-};
-
-pub use self::state::*;
-pub use self::types::*;
+pub use self::{state::*, types::*};
 
 /// Export the wasm binary
 #[cfg(not(feature = "runtime-wasm"))]

--- a/actors/multisig/src/state.rs
+++ b/actors/multisig/src/state.rs
@@ -4,18 +4,18 @@
 use anyhow::anyhow;
 use blockstore::Blockstore;
 use cid::Cid;
+use fvm_shared::{
+    address::Address,
+    bigint::{bigint_ser, Integer},
+    clock::ChainEpoch,
+    econ::TokenAmount,
+    encoding::{tuple::*, Cbor},
+};
 use indexmap::IndexMap;
 use num_traits::Zero;
 
-use fvm_shared::address::Address;
-use fvm_shared::bigint::{bigint_ser, Integer};
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{tuple::*, Cbor};
-
-use crate::make_map_with_root;
-
 use super::{types::Transaction, TxnID};
+use crate::make_map_with_root;
 
 /// Multisig actor state
 #[derive(Serialize_tuple, Deserialize_tuple, Clone)]

--- a/actors/multisig/src/types.rs
+++ b/actors/multisig/src/types.rs
@@ -1,18 +1,18 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fvm_shared::{
+    address::Address,
+    bigint::bigint_ser,
+    clock::ChainEpoch,
+    econ::TokenAmount,
+    encoding::{serde_bytes, tuple::*, RawBytes},
+    error::ExitCode,
+    MethodNum,
+};
 use integer_encoding::VarInt;
 use ipld_hamt::BytesKey;
 use serde::{Deserialize, Serialize};
-
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::encoding::{serde_bytes, tuple::*};
-use fvm_shared::error::ExitCode;
-use fvm_shared::MethodNum;
 
 /// SignersMax is the maximum number of signers allowed in a multisig. If more
 /// are required, please use a combining tree of multisigs.

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -1,27 +1,27 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use actors_runtime::{
+    actor_error, resolve_to_id_addr,
+    runtime::{ActorCode, Runtime},
+    ActorDowncast, ActorError, Array, ACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID,
+};
 use blockstore::Blockstore;
+use fvm_shared::{
+    address::Address,
+    bigint::{BigInt, Sign},
+    econ::TokenAmount,
+    encoding::RawBytes,
+    error::{ExitCode, ExitCode::ErrTooManyProveCommits as ErrChannelStateUpdateAfterSettled},
+    MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND,
+};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 
-use fvm_shared::address::Address;
-use fvm_shared::bigint::{BigInt, Sign};
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::error::ExitCode;
-use fvm_shared::error::ExitCode::ErrTooManyProveCommits as ErrChannelStateUpdateAfterSettled;
-use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND};
-
-use actors_runtime::{actor_error, ActorError};
-use actors_runtime::{
-    resolve_to_id_addr,
-    runtime::{ActorCode, Runtime},
-    ActorDowncast, Array, ACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID,
+pub use self::{
+    state::{LaneState, Merge, State},
+    types::*,
 };
-
-pub use self::state::{LaneState, Merge, State};
-pub use self::types::*;
 
 /// Export the wasm binary
 #[cfg(not(feature = "runtime-wasm"))]

--- a/actors/paych/src/state.rs
+++ b/actors/paych/src/state.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-
-use fvm_shared::address::Address;
-use fvm_shared::bigint::{bigint_ser, BigInt};
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::tuple::*;
-use fvm_shared::encoding::Cbor;
+use fvm_shared::{
+    address::Address,
+    bigint::{bigint_ser, BigInt},
+    clock::ChainEpoch,
+    econ::TokenAmount,
+    encoding::{tuple::*, Cbor},
+};
 
 /// A given payment channel actor is established by `from`
 /// to enable off-chain microtransactions to `to` address

--- a/actors/paych/src/types.rs
+++ b/actors/paych/src/types.rs
@@ -1,14 +1,15 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_shared::address::Address;
-use fvm_shared::bigint::{bigint_ser, BigInt};
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::crypto::signature::Signature;
-use fvm_shared::encoding::{error::Error, serde_bytes, to_vec, tuple::*, RawBytes};
-use fvm_shared::MethodNum;
-
 use actors_runtime::network::EPOCHS_IN_HOUR;
+use fvm_shared::{
+    address::Address,
+    bigint::{bigint_ser, BigInt},
+    clock::ChainEpoch,
+    crypto::signature::Signature,
+    encoding::{error::Error, serde_bytes, to_vec, tuple::*, RawBytes},
+    MethodNum,
+};
 
 use super::Merge;
 

--- a/actors/paych/tests/paych_actor_test.rs
+++ b/actors/paych/tests/paych_actor_test.rs
@@ -3,29 +3,23 @@
 
 use std::collections::HashMap;
 
+use actors_runtime::{
+    test_utils::*, ACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_ADDR, INIT_ACTOR_CODE_ID,
+    MULTISIG_ACTOR_CODE_ID,
+};
 use anyhow::anyhow;
 use cid::Cid;
 use derive_builder::Builder;
-
-use actors_runtime::test_utils::*;
-use actors_runtime::{
-    ACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_ADDR, INIT_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID,
-};
-use fvm_shared::address::Address;
-use fvm_shared::bigint::BigInt;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::crypto::signature::Signature;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::error::ExitCode;
-use fvm_shared::METHOD_CONSTRUCTOR;
-use ipld_amt::Amt;
-
 use fvm_actor_paych::{
     Actor as PaychActor, ConstructorParams, LaneState, Merge, Method, ModVerifyParams,
     PaymentVerifyParams, SignedVoucher, State as PState, UpdateChannelStateParams, MAX_LANE,
     SETTLE_DELAY,
 };
+use fvm_shared::{
+    address::Address, bigint::BigInt, clock::ChainEpoch, crypto::signature::Signature,
+    econ::TokenAmount, encoding::RawBytes, error::ExitCode, METHOD_CONSTRUCTOR,
+};
+use ipld_amt::Amt;
 
 const PAYCH_ID: u64 = 100;
 const PAYER_ID: u64 = 102;

--- a/actors/power/src/ext.rs
+++ b/actors/power/src/ext.rs
@@ -1,7 +1,9 @@
 use cid::Cid;
-use fvm_shared::address::Address;
-use fvm_shared::encoding::{serde_bytes, tuple::*, BytesDe, RawBytes};
-use fvm_shared::sector::{RegisteredPoStProof, SectorNumber};
+use fvm_shared::{
+    address::Address,
+    encoding::{serde_bytes, tuple::*, BytesDe, RawBytes},
+    sector::{RegisteredPoStProof, SectorNumber},
+};
 
 pub mod init {
     use super::*;

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -1,33 +1,30 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use actors_runtime::{
+    actor_error, make_map_with_root_and_bitwidth,
+    runtime::{ActorCode, Runtime},
+    ActorDowncast, ActorError, Multimap, CALLER_TYPES_SIGNABLE, CRON_ACTOR_ADDR, INIT_ACTOR_ADDR,
+    MINER_ACTOR_CODE_ID, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+};
 use ahash::AHashSet;
 use blockstore::Blockstore;
 use ext::init;
+use fvm_shared::{
+    address::Address,
+    bigint::bigint_ser::{BigIntDe, BigIntSer},
+    econ::TokenAmount,
+    encoding::RawBytes,
+    error::ExitCode,
+    sector::SealVerifyInfo,
+    MethodNum, HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR,
+};
 use indexmap::IndexMap;
 use log::{debug, error};
 use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Signed};
 
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser::{BigIntDe, BigIntSer};
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::error::ExitCode;
-use fvm_shared::sector::SealVerifyInfo;
-use fvm_shared::{MethodNum, HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR};
-
-use actors_runtime::{actor_error, ActorError};
-use actors_runtime::{
-    make_map_with_root_and_bitwidth,
-    runtime::{ActorCode, Runtime},
-    ActorDowncast, Multimap, CALLER_TYPES_SIGNABLE, CRON_ACTOR_ADDR, INIT_ACTOR_ADDR,
-    MINER_ACTOR_CODE_ID, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
-};
-
-pub use self::policy::*;
-pub use self::state::*;
-pub use self::types::*;
+pub use self::{policy::*, state::*, types::*};
 
 /// Export the wasm binary
 #[cfg(not(feature = "runtime-wasm"))]

--- a/actors/power/src/state.rs
+++ b/actors/power/src/state.rs
@@ -3,28 +3,28 @@
 
 use std::ops::Neg;
 
+use actors_runtime::{
+    actor_error, consensus_miner_min_power, make_empty_map, make_map_with_root,
+    make_map_with_root_and_bitwidth, ActorDowncast, ActorError, Map, Multimap,
+};
 use anyhow::{anyhow, Context};
 use blockstore::Blockstore;
 use cid::Cid;
+use fvm_shared::{
+    address::Address,
+    bigint::{bigint_ser, BigInt},
+    clock::ChainEpoch,
+    econ::TokenAmount,
+    encoding::{tuple::*, Cbor, RawBytes},
+    error::ExitCode,
+    sector::{RegisteredPoStProof, StoragePower},
+    smooth::{AlphaBetaFilter, FilterEstimate, DEFAULT_ALPHA, DEFAULT_BETA},
+    HAMT_BIT_WIDTH,
+};
 use integer_encoding::VarInt;
+use ipld_hamt::BytesKey;
 use lazy_static::lazy_static;
 use num_traits::Signed;
-
-use actors_runtime::{actor_error, ActorError};
-use actors_runtime::{
-    consensus_miner_min_power, make_empty_map, make_map_with_root, make_map_with_root_and_bitwidth,
-    ActorDowncast, Map, Multimap,
-};
-use fvm_shared::address::Address;
-use fvm_shared::bigint::{bigint_ser, BigInt};
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{tuple::*, Cbor, RawBytes};
-use fvm_shared::error::ExitCode;
-use fvm_shared::sector::{RegisteredPoStProof, StoragePower};
-use fvm_shared::smooth::{AlphaBetaFilter, FilterEstimate, DEFAULT_ALPHA, DEFAULT_BETA};
-use fvm_shared::HAMT_BIT_WIDTH;
-use ipld_hamt::BytesKey;
 
 use super::{CONSENSUS_MINER_MIN_MINERS, CRON_QUEUE_AMT_BITWIDTH, CRON_QUEUE_HAMT_BITWIDTH};
 

--- a/actors/power/src/types.rs
+++ b/actors/power/src/types.rs
@@ -1,13 +1,15 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{serde_bytes, tuple::*, BytesDe, Cbor, RawBytes};
-use fvm_shared::sector::{RegisteredPoStProof, StoragePower};
-use fvm_shared::smooth::FilterEstimate;
+use fvm_shared::{
+    address::Address,
+    bigint::bigint_ser,
+    clock::ChainEpoch,
+    econ::TokenAmount,
+    encoding::{serde_bytes, tuple::*, BytesDe, Cbor, RawBytes},
+    sector::{RegisteredPoStProof, StoragePower},
+    smooth::FilterEstimate,
+};
 
 pub type SectorTermination = i64;
 

--- a/actors/reward/src/expneg.rs
+++ b/actors/reward/src/expneg.rs
@@ -1,10 +1,11 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fvm_shared::{
+    bigint::{BigInt, Integer},
+    math::{poly_parse, poly_val, PRECISION},
+};
 use lazy_static::lazy_static;
-
-use fvm_shared::bigint::{BigInt, Integer};
-use fvm_shared::math::{poly_parse, poly_val, PRECISION};
 
 lazy_static! {
     static ref EXP_NUM_COEF: Vec<BigInt> = poly_parse(&[

--- a/actors/reward/src/ext.rs
+++ b/actors/reward/src/ext.rs
@@ -1,6 +1,4 @@
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::tuple::*;
+use fvm_shared::{bigint::bigint_ser, econ::TokenAmount, encoding::tuple::*};
 
 pub mod miner {
     use super::*;

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -1,29 +1,29 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use actors_runtime::{
+    actor_error,
+    runtime::{ActorCode, Runtime},
+    ActorError, BURNT_FUNDS_ACTOR_ADDR, EXPECTED_LEADERS_PER_EPOCH, STORAGE_POWER_ACTOR_ADDR,
+    SYSTEM_ACTOR_ADDR,
+};
 use blockstore::Blockstore;
+use fvm_shared::{
+    bigint::{bigint_ser::BigIntDe, Integer, Sign},
+    econ::TokenAmount,
+    encoding::RawBytes,
+    sector::StoragePower,
+    MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND,
+};
 use log::{error, warn};
 use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Signed};
 
-use actors_runtime::actor_error;
-use fvm_shared::bigint::Sign;
-use fvm_shared::bigint::{bigint_ser::BigIntDe, Integer};
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::sector::StoragePower;
-use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND};
-
-use actors_runtime::ActorError;
-use actors_runtime::{
-    runtime::{ActorCode, Runtime},
-    BURNT_FUNDS_ACTOR_ADDR, EXPECTED_LEADERS_PER_EPOCH, STORAGE_POWER_ACTOR_ADDR,
-    SYSTEM_ACTOR_ADDR,
+pub use self::{
+    logic::*,
+    state::{Reward, State, VestingFunction},
+    types::*,
 };
-
-pub use self::logic::*;
-pub use self::state::{Reward, State, VestingFunction};
-pub use self::types::*;
 
 /// Export the wasm binary
 #[cfg(not(feature = "runtime-wasm"))]

--- a/actors/reward/src/logic.rs
+++ b/actors/reward/src/logic.rs
@@ -3,14 +3,15 @@
 
 use std::str::FromStr;
 
+use fvm_shared::{
+    bigint::{BigInt, Integer},
+    clock::ChainEpoch,
+    econ::TokenAmount,
+    math::PRECISION,
+    sector::StoragePower,
+    FILECOIN_PRECISION,
+};
 use lazy_static::lazy_static;
-
-use fvm_shared::bigint::{BigInt, Integer};
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::math::PRECISION;
-use fvm_shared::sector::StoragePower;
-use fvm_shared::FILECOIN_PRECISION;
 
 use super::expneg::expneg;
 

--- a/actors/reward/src/state.rs
+++ b/actors/reward/src/state.rs
@@ -1,15 +1,16 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fvm_shared::{
+    bigint::{bigint_ser, Integer},
+    clock::{ChainEpoch, EPOCH_UNDEFINED},
+    econ::TokenAmount,
+    encoding::{repr::*, tuple::*, Cbor},
+    sector::{Spacetime, StoragePower},
+    smooth::{AlphaBetaFilter, FilterEstimate, DEFAULT_ALPHA, DEFAULT_BETA},
+};
 use lazy_static::lazy_static;
 use num_derive::FromPrimitive;
-
-use fvm_shared::bigint::{bigint_ser, Integer};
-use fvm_shared::clock::{ChainEpoch, EPOCH_UNDEFINED};
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{repr::*, tuple::*, Cbor};
-use fvm_shared::sector::{Spacetime, StoragePower};
-use fvm_shared::smooth::{AlphaBetaFilter, FilterEstimate, DEFAULT_ALPHA, DEFAULT_BETA};
 
 use super::logic::*;
 

--- a/actors/reward/src/types.rs
+++ b/actors/reward/src/types.rs
@@ -1,10 +1,7 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::tuple::*;
+use fvm_shared::{address::Address, bigint::bigint_ser, econ::TokenAmount, encoding::tuple::*};
 
 #[derive(Clone, Debug, PartialEq, Serialize_tuple, Deserialize_tuple)]
 pub struct AwardBlockRewardParams {

--- a/actors/reward/tests/reward_actor_test.rs
+++ b/actors/reward/tests/reward_actor_test.rs
@@ -1,28 +1,20 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use lazy_static::lazy_static;
-use num_traits::FromPrimitive;
-
+use actors_runtime::{
+    test_utils::*, ActorError, BURNT_FUNDS_ACTOR_ADDR, POWER_ACTOR_CODE_ID, REWARD_ACTOR_ADDR,
+    STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, SYSTEM_ACTOR_CODE_ID,
+};
 use fvm_actor_reward::{
     ext, Actor as RewardActor, AwardBlockRewardParams, Method, State, ThisEpochRewardReturn,
     BASELINE_INITIAL_VALUE, PENALTY_MULTIPLIER,
 };
-
-use actors_runtime::test_utils::*;
-use actors_runtime::{
-    ActorError, BURNT_FUNDS_ACTOR_ADDR, POWER_ACTOR_CODE_ID, REWARD_ACTOR_ADDR,
-    STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, SYSTEM_ACTOR_CODE_ID,
+use fvm_shared::{
+    address::Address, bigint::bigint_ser::BigIntSer, clock::ChainEpoch, econ::TokenAmount,
+    encoding::RawBytes, error::ExitCode, sector::StoragePower, METHOD_CONSTRUCTOR, METHOD_SEND,
 };
-
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser::BigIntSer;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::error::ExitCode;
-use fvm_shared::sector::StoragePower;
-use fvm_shared::{METHOD_CONSTRUCTOR, METHOD_SEND};
+use lazy_static::lazy_static;
+use num_traits::FromPrimitive;
 
 lazy_static! {
     static ref EPOCH_ZERO_REWARD: TokenAmount =
@@ -79,10 +71,7 @@ mod construction_tests {
 }
 
 mod test_award_block_reward {
-    use fvm_shared::encoding::RawBytes;
-    use fvm_shared::error::ExitCode;
-    use fvm_shared::sector::StoragePower;
-    use fvm_shared::METHOD_SEND;
+    use fvm_shared::{encoding::RawBytes, error::ExitCode, sector::StoragePower, METHOD_SEND};
 
     use super::*;
 

--- a/actors/runtime/src/builtin/codes.rs
+++ b/actors/runtime/src/builtin/codes.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::anyhow;
-use cid::multihash::{Code, MultihashDigest};
-use cid::Cid;
+use cid::{
+    multihash::{Code, MultihashDigest},
+    Cid,
+};
 
 pub const SYSTEM_ACTOR_CODE_ID_NAME: &str = "fil/4/system";
 pub const INIT_ACTOR_CODE_ID_NAME: &str = "fil/4/init";

--- a/actors/runtime/src/builtin/mod.rs
+++ b/actors/runtime/src/builtin/mod.rs
@@ -1,11 +1,7 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-pub use self::codes::*;
-pub use self::network::*;
-pub use self::sector::*;
-pub use self::shared::*;
-pub use self::singletons::*;
+pub use self::{codes::*, network::*, sector::*, shared::*, singletons::*};
 
 mod codes;
 pub mod network;

--- a/actors/runtime/src/builtin/network.rs
+++ b/actors/runtime/src/builtin/network.rs
@@ -1,9 +1,8 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_shared::bigint::BigInt;
-use fvm_shared::clock::EPOCH_DURATION_SECONDS;
 pub use fvm_shared::BLOCKS_PER_EPOCH as EXPECTED_LEADERS_PER_EPOCH;
+use fvm_shared::{bigint::BigInt, clock::EPOCH_DURATION_SECONDS};
 
 pub const SECONDS_IN_HOUR: i64 = 3600;
 pub const SECONDS_IN_DAY: i64 = 86400;

--- a/actors/runtime/src/builtin/shared.rs
+++ b/actors/runtime/src/builtin/shared.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use blockstore::Blockstore;
-
-use fvm_shared::address::Address;
-use fvm_shared::METHOD_SEND;
+use fvm_shared::{address::Address, METHOD_SEND};
 
 use crate::runtime::Runtime;
 

--- a/actors/runtime/src/builtin/singletons.rs
+++ b/actors/runtime/src/builtin/singletons.rs
@@ -1,8 +1,7 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_shared::address::Address;
-use fvm_shared::ActorID;
+use fvm_shared::{address::Address, ActorID};
 
 lazy_static! {
     pub static ref SYSTEM_ACTOR_ADDR: Address         = Address::new_id(0);

--- a/actors/runtime/src/lib.rs
+++ b/actors/runtime/src/lib.rs
@@ -26,23 +26,19 @@ extern crate lazy_static;
 extern crate serde;
 
 use blockstore::Blockstore;
+use builtin::HAMT_BIT_WIDTH;
 use cid::Cid;
+use fvm_shared::bigint::BigInt;
+pub use fvm_shared::BLOCKS_PER_EPOCH as EXPECTED_LEADERS_PER_EPOCH;
+pub use ipld_amt;
 use ipld_amt::Amt;
+pub use ipld_hamt;
+use ipld_hamt::{BytesKey, Error as HamtError, Hamt};
 use serde::{de::DeserializeOwned, Serialize};
 use unsigned_varint::decode::Error as UVarintError;
 
+pub use self::{actor_error::*, builtin::*, util::*};
 use crate::runtime::Runtime;
-use builtin::HAMT_BIT_WIDTH;
-pub use ipld_amt;
-pub use ipld_hamt;
-use ipld_hamt::{BytesKey, Error as HamtError, Hamt};
-
-pub use self::actor_error::*;
-pub use self::builtin::*;
-pub use self::util::*;
-
-use fvm_shared::bigint::BigInt;
-pub use fvm_shared::BLOCKS_PER_EPOCH as EXPECTED_LEADERS_PER_EPOCH;
 
 pub mod actor_error;
 pub mod builtin;

--- a/actors/runtime/src/runtime/actor_code.rs
+++ b/actors/runtime/src/runtime/actor_code.rs
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use blockstore::Blockstore;
+use fvm_shared::{encoding::RawBytes, MethodNum};
 
-use crate::ActorError;
-use crate::Runtime;
-
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::MethodNum;
+use crate::{ActorError, Runtime};
 
 /// Interface for invoking methods on an Actor
 pub trait ActorCode {

--- a/actors/runtime/src/runtime/mod.rs
+++ b/actors/runtime/src/runtime/mod.rs
@@ -5,25 +5,24 @@ use std::collections::HashMap;
 
 use blockstore::Blockstore;
 use cid::Cid;
-
-use fvm_shared::address::Address;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::crypto::randomness::DomainSeparationTag;
-use fvm_shared::crypto::signature::Signature;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{blake2b_256, de, Cbor, RawBytes};
-use fvm_shared::error::ExitCode;
-use fvm_shared::piece::PieceInfo;
-use fvm_shared::randomness::Randomness;
-use fvm_shared::sector::{
-    AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
+use fvm_shared::{
+    address::Address,
+    clock::ChainEpoch,
+    crypto::{randomness::DomainSeparationTag, signature::Signature},
+    econ::TokenAmount,
+    encoding::{blake2b_256, de, Cbor, RawBytes},
+    error::ExitCode,
+    piece::PieceInfo,
+    randomness::Randomness,
+    sector::{
+        AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
+    },
+    version::NetworkVersion,
+    MethodNum,
 };
-use fvm_shared::version::NetworkVersion;
-use fvm_shared::MethodNum;
-
-use crate::ActorError;
 
 pub use self::actor_code::*;
+use crate::ActorError;
 mod actor_code;
 
 #[cfg(feature = "runtime-wasm")]

--- a/actors/runtime/src/runtime/sdk.rs
+++ b/actors/runtime/src/runtime/sdk.rs
@@ -1,9 +1,10 @@
-use cid::{multihash::Code, Cid};
-use fvm_sdk::ipld;
 use std::convert::TryFrom;
 
-use crate::{actor_error, ActorError};
 use blockstore::{Block, Blockstore};
+use cid::{multihash::Code, Cid};
+use fvm_sdk::ipld;
+
+use crate::{actor_error, ActorError};
 
 /// A blockstore suitable for use within actors.
 pub struct ActorBlockstore;

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -1,30 +1,35 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::cell::{Cell, RefCell};
-use std::collections::{HashMap, VecDeque};
+use std::{
+    cell::{Cell, RefCell},
+    collections::{HashMap, VecDeque},
+};
 
 use anyhow::anyhow;
 use blockstore::MemoryBlockstore;
 use cid::{multihash::Code, Cid};
-
-use crate::runtime::{ActorCode, ConsensusFault, MessageInfo, Runtime, Syscalls};
-use crate::{actor_error, ActorError};
-use fvm_shared::address::{Address, Protocol};
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::crypto::randomness::DomainSeparationTag;
-use fvm_shared::crypto::signature::Signature;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::de::DeserializeOwned;
-use fvm_shared::encoding::{blake2b_256, Cbor, CborStore, RawBytes};
-use fvm_shared::error::ExitCode;
-use fvm_shared::piece::PieceInfo;
-use fvm_shared::randomness::Randomness;
-use fvm_shared::sector::{
-    AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
+use fvm_shared::{
+    address::{Address, Protocol},
+    clock::ChainEpoch,
+    crypto::{randomness::DomainSeparationTag, signature::Signature},
+    econ::TokenAmount,
+    encoding::{blake2b_256, de::DeserializeOwned, Cbor, CborStore, RawBytes},
+    error::ExitCode,
+    piece::PieceInfo,
+    randomness::Randomness,
+    sector::{
+        AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
+    },
+    version::NetworkVersion,
+    MethodNum,
 };
-use fvm_shared::version::NetworkVersion;
-use fvm_shared::MethodNum;
+
+use crate::{
+    actor_error,
+    runtime::{ActorCode, ConsensusFault, MessageInfo, Runtime, Syscalls},
+    ActorError,
+};
 
 pub struct MockRuntime {
     pub epoch: ChainEpoch,

--- a/actors/runtime/src/util/balance_table.rs
+++ b/actors/runtime/src/util/balance_table.rs
@@ -3,12 +3,9 @@
 
 use blockstore::Blockstore;
 use cid::Cid;
-use num_traits::{Signed, Zero};
-
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser::BigIntDe;
-use fvm_shared::econ::TokenAmount;
+use fvm_shared::{address::Address, bigint::bigint_ser::BigIntDe, econ::TokenAmount};
 use ipld_hamt::Error;
+use num_traits::{Signed, Zero};
 
 use crate::{make_empty_map, make_map_with_root_and_bitwidth, Map};
 

--- a/actors/runtime/src/util/chaos/mod.rs
+++ b/actors/runtime/src/util/chaos/mod.rs
@@ -3,18 +3,19 @@
 
 use blockstore::Blockstore;
 use cid::Cid;
+use fvm_shared::{
+    address::Address, encoding::RawBytes, error::ExitCode, MethodNum, METHOD_CONSTRUCTOR,
+};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-
-use fvm_shared::address::Address;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::error::ExitCode;
-use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
 pub use state::*;
 pub use types::*;
 
-use crate::runtime::{ActorCode, Runtime};
-use crate::{actor_error, ActorError};
+use crate::{
+    actor_error,
+    runtime::{ActorCode, Runtime},
+    ActorError,
+};
 
 mod state;
 mod types;

--- a/actors/runtime/src/util/chaos/types.rs
+++ b/actors/runtime/src/util/chaos/types.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::tuple::*;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::error::ExitCode;
+use fvm_shared::{
+    address::Address,
+    bigint::bigint_ser,
+    clock::ChainEpoch,
+    econ::TokenAmount,
+    encoding::{tuple::*, RawBytes},
+    error::ExitCode,
+};
 
 use super::state::State;
 

--- a/actors/runtime/src/util/downcast.rs
+++ b/actors/runtime/src/util/downcast.rs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::anyhow;
-
-use crate::ActorError;
-use fvm_shared::encoding::{error::Error as CborError, Error as EncodingError};
-use fvm_shared::error::ExitCode;
+use fvm_shared::{
+    encoding::{error::Error as CborError, Error as EncodingError},
+    error::ExitCode,
+};
 use ipld_amt::Error as AmtError;
 use ipld_hamt::Error as HamtError;
+
+use crate::ActorError;
 
 /// Trait to allow multiple error types to be able to be downcasted into an `ActorError`.
 pub trait ActorDowncast {

--- a/actors/runtime/src/util/mod.rs
+++ b/actors/runtime/src/util/mod.rs
@@ -1,12 +1,13 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-pub use self::balance_table::BalanceTable;
-pub use self::balance_table::BALANCE_TABLE_BITWIDTH;
-pub use self::downcast::*;
-pub use self::multimap::*;
-pub use self::set::Set;
-pub use self::set_multimap::SetMultimap;
+pub use self::{
+    balance_table::{BalanceTable, BALANCE_TABLE_BITWIDTH},
+    downcast::*,
+    multimap::*,
+    set::Set,
+    set_multimap::SetMultimap,
+};
 
 mod balance_table;
 pub mod chaos;

--- a/actors/runtime/src/util/multimap.rs
+++ b/actors/runtime/src/util/multimap.rs
@@ -3,12 +3,10 @@
 
 use blockstore::Blockstore;
 use cid::Cid;
+use ipld_hamt::Error;
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::Array;
-use ipld_hamt::Error;
-
-use crate::{make_empty_map, make_map_with_root_and_bitwidth, BytesKey, Map};
+use crate::{make_empty_map, make_map_with_root_and_bitwidth, Array, BytesKey, Map};
 
 /// Multimap stores multiple values per key in a Hamt of Amts.
 /// The order of insertion of values for each key is retained.

--- a/actors/runtime/src/util/set.rs
+++ b/actors/runtime/src/util/set.rs
@@ -3,7 +3,6 @@
 
 use blockstore::Blockstore;
 use cid::Cid;
-
 use fvm_shared::HAMT_BIT_WIDTH;
 use ipld_hamt::Error;
 

--- a/actors/runtime/src/util/set_multimap.rs
+++ b/actors/runtime/src/util/set_multimap.rs
@@ -5,15 +5,11 @@ use std::borrow::Borrow;
 
 use blockstore::Blockstore;
 use cid::Cid;
-
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::deal::DealID;
-use fvm_shared::HAMT_BIT_WIDTH;
+use fvm_shared::{clock::ChainEpoch, deal::DealID, HAMT_BIT_WIDTH};
 use ipld_hamt::Error;
 
-use crate::{make_empty_map, make_map_with_root, parse_uint_key, u64_key, Map};
-
 use super::Set;
+use crate::{make_empty_map, make_map_with_root, parse_uint_key, u64_key, Map};
 
 /// SetMultimap is a hamt with values that are also a hamt but are of the set variant.
 /// This allows hash sets to be indexable by an address.

--- a/actors/runtime/src/util/unmarshallable.rs
+++ b/actors/runtime/src/util/unmarshallable.rs
@@ -1,11 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use serde::de::{self, Deserializer};
-use serde::ser::{self, Serializer};
-use serde::{Deserialize, Serialize};
-
 use fvm_shared::encoding::Cbor;
+use serde::{
+    de::{self, Deserializer},
+    ser::{self, Serializer},
+    Deserialize, Serialize,
+};
 
 pub struct UnmarshallableCBOR;
 

--- a/actors/runtime/tests/alpha_beta_filter_test.rs
+++ b/actors/runtime/tests/alpha_beta_filter_test.rs
@@ -1,15 +1,15 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use num_traits::sign::Signed;
-
 use actors_runtime::EPOCHS_IN_DAY;
-use fvm_shared::bigint::{BigInt, Integer};
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::math::{poly_parse, PRECISION};
-use fvm_shared::sector::StoragePower;
-use fvm_shared::smooth::extrapolated_cum_sum_of_ratio as ecsor;
-use fvm_shared::smooth::*;
+use fvm_shared::{
+    bigint::{BigInt, Integer},
+    clock::ChainEpoch,
+    math::{poly_parse, PRECISION},
+    sector::StoragePower,
+    smooth::{extrapolated_cum_sum_of_ratio as ecsor, *},
+};
+use num_traits::sign::Signed;
 
 const ERR_BOUND: u64 = 350;
 

--- a/actors/runtime/tests/balance_table_test.rs
+++ b/actors/runtime/tests/balance_table_test.rs
@@ -3,8 +3,7 @@
 
 use actors_runtime::BalanceTable;
 use blockstore::MemoryBlockstore;
-use fvm_shared::address::Address;
-use fvm_shared::econ::TokenAmount;
+use fvm_shared::{address::Address, econ::TokenAmount};
 
 // Ported test from specs-actors
 #[test]

--- a/actors/runtime/tests/multimap_test.rs
+++ b/actors/runtime/tests/multimap_test.rs
@@ -3,8 +3,7 @@
 
 use actors_runtime::Multimap;
 use blockstore::MemoryBlockstore;
-use fvm_shared::address::Address;
-use fvm_shared::HAMT_BIT_WIDTH;
+use fvm_shared::{address::Address, HAMT_BIT_WIDTH};
 use ipld_amt::Amt;
 
 #[test]

--- a/actors/system/src/lib.rs
+++ b/actors/system/src/lib.rs
@@ -1,20 +1,19 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use actors_runtime::{
+    actor_error,
+    runtime::{ActorCode, Runtime},
+    ActorError, SYSTEM_ACTOR_ADDR,
+};
 use blockstore::Blockstore;
+use fvm_shared::{
+    encoding::{Cbor, RawBytes},
+    MethodNum, METHOD_CONSTRUCTOR,
+};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
-
-use actors_runtime::actor_error;
-use fvm_shared::encoding::{Cbor, RawBytes};
-use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
-
-use actors_runtime::ActorError;
-use actors_runtime::{
-    runtime::{ActorCode, Runtime},
-    SYSTEM_ACTOR_ADDR,
-};
 
 /// Export the wasm binary
 #[cfg(not(feature = "runtime-wasm"))]

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -1,25 +1,20 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use actors_runtime::{
+    actor_error, make_map_with_root_and_bitwidth, resolve_to_id_addr,
+    runtime::{ActorCode, Runtime},
+    ActorDowncast, ActorError, STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+};
 use blockstore::Blockstore;
+use fvm_shared::{
+    address::Address, bigint::bigint_ser::BigIntDe, encoding::RawBytes, error::ExitCode, MethodNum,
+    HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR,
+};
 use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Signed};
 
-use actors_runtime::{actor_error, ActorError};
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser::BigIntDe;
-use fvm_shared::encoding::RawBytes;
-use fvm_shared::error::ExitCode;
-use fvm_shared::{MethodNum, HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR};
-
-use actors_runtime::{
-    make_map_with_root_and_bitwidth, resolve_to_id_addr,
-    runtime::{ActorCode, Runtime},
-    ActorDowncast, STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
-};
-
-pub use self::state::State;
-pub use self::types::*;
+pub use self::{state::State, types::*};
 
 /// Export the wasm binary
 #[cfg(not(feature = "runtime-wasm"))]

--- a/actors/verifreg/src/state.rs
+++ b/actors/verifreg/src/state.rs
@@ -1,14 +1,14 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use actors_runtime::make_empty_map;
 use blockstore::Blockstore;
 use cid::Cid;
-
-use fvm_shared::address::Address;
-use fvm_shared::encoding::{tuple::*, Cbor};
-use fvm_shared::HAMT_BIT_WIDTH;
-
-use actors_runtime::make_empty_map;
+use fvm_shared::{
+    address::Address,
+    encoding::{tuple::*, Cbor},
+    HAMT_BIT_WIDTH,
+};
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct State {

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -1,13 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fvm_shared::{address::Address, bigint::bigint_ser, encoding::tuple::*, sector::StoragePower};
 use lazy_static::lazy_static;
 use num_traits::FromPrimitive;
-
-use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::encoding::tuple::*;
-use fvm_shared::sector::StoragePower;
 
 #[cfg(not(feature = "devnet"))]
 lazy_static! {

--- a/examples/blockstore-cgo/user/src/lib.rs
+++ b/examples/blockstore-cgo/user/src/lib.rs
@@ -1,7 +1,8 @@
-use blockstore::cgo::CgoBlockstore;
-use blockstore::{Block, Blockstore as _};
-use cid::multihash::{Code, MultihashDigest};
-use cid::Cid;
+use blockstore::{cgo::CgoBlockstore, Block, Blockstore as _};
+use cid::{
+    multihash::{Code, MultihashDigest},
+    Cid,
+};
 
 #[no_mangle]
 pub extern "C" fn write_blocks(store: i32, count: i32) -> i32 {

--- a/fvm/src/account_actor.rs
+++ b/fvm/src/account_actor.rs
@@ -3,15 +3,18 @@
 //! concrete actor must eventually go. (TODO)
 
 use cid::Cid;
+use fvm_shared::{
+    address::Address,
+    bigint::Zero,
+    econ::TokenAmount,
+    encoding::{tuple::*, Cbor},
+};
 use lazy_static::lazy_static;
 
-use fvm_shared::address::Address;
-use fvm_shared::bigint::Zero;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{tuple::*, Cbor};
-
-use crate::builtin::{ACCOUNT_ACTOR_CODE_ID, EMPTY_ARR_CID};
-use crate::state_tree::ActorState;
+use crate::{
+    builtin::{ACCOUNT_ACTOR_CODE_ID, EMPTY_ARR_CID},
+    state_tree::ActorState,
+};
 
 pub const SYSTEM_ACTOR_ID: u64 = 0;
 

--- a/fvm/src/builtin.rs
+++ b/fvm/src/builtin.rs
@@ -1,4 +1,7 @@
-use cid::{multihash::Code, multihash::MultihashDigest, Cid};
+use cid::{
+    multihash::{Code, MultihashDigest},
+    Cid,
+};
 use fvm_shared::encoding::{to_vec, DAG_CBOR};
 use lazy_static::lazy_static;
 

--- a/fvm/src/externs/cgo.rs
+++ b/fvm/src/externs/cgo.rs
@@ -1,8 +1,7 @@
 #![allow(unused)] // TODO: remove this when we implement these
-use cid::Cid;
-
 use anyhow::Result;
 use blockstore::cgo::CgoBlockstore;
+use cid::Cid;
 use fvm_shared::{
     address::Address,
     clock::ChainEpoch,

--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -1,11 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::{kernel::SyscallError, syscall_error};
-
-pub use self::charge::GasCharge;
 pub(crate) use self::outputs::GasOutputs;
-pub use self::price_list::{price_list_by_epoch, PriceList};
+pub use self::{
+    charge::GasCharge,
+    price_list::{price_list_by_epoch, PriceList},
+};
+use crate::{kernel::SyscallError, syscall_error};
 
 mod charge;
 mod outputs;

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -2,18 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use ahash::AHashMap;
+use fvm_shared::{
+    clock::ChainEpoch,
+    crypto::signature::SignatureType,
+    econ::TokenAmount,
+    piece::PieceInfo,
+    sector::{
+        AggregateSealVerifyProofAndInfos, RegisteredPoStProof, RegisteredSealProof, SealVerifyInfo,
+        WindowPoStVerifyInfo,
+    },
+    MethodNum, METHOD_SEND,
+};
 use lazy_static::lazy_static;
 use num_traits::Zero;
-
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::crypto::signature::SignatureType;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::piece::PieceInfo;
-use fvm_shared::sector::{
-    AggregateSealVerifyProofAndInfos, RegisteredPoStProof, RegisteredSealProof, SealVerifyInfo,
-    WindowPoStVerifyInfo,
-};
-use fvm_shared::{MethodNum, METHOD_SEND};
 
 use super::GasCharge;
 

--- a/fvm/src/init_actor.rs
+++ b/fvm/src/init_actor.rs
@@ -10,11 +10,11 @@
 use anyhow::Context;
 use blockstore::Blockstore;
 use cid::Cid;
-
-use fvm_shared::address::{Address, Payload};
-use fvm_shared::encoding::Cbor;
-use fvm_shared::encoding::{tuple::*, CborStore};
-use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
+use fvm_shared::{
+    address::{Address, Payload},
+    encoding::{tuple::*, Cbor, CborStore},
+    ActorID, HAMT_BIT_WIDTH,
+};
 use ipld_hamt::Hamt;
 
 use crate::state_tree::{ActorState, StateTree};

--- a/fvm/src/kernel/blocks.rs
+++ b/fvm/src/kernel/blocks.rs
@@ -1,5 +1,4 @@
-use std::convert::TryInto;
-use std::rc::Rc;
+use std::{convert::TryInto, rc::Rc};
 
 use cid::Cid;
 use thiserror::Error;

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -1,24 +1,24 @@
 use std::collections::HashMap;
 
-use cid::Cid;
-use fvm_shared::error::ExitCode;
-
 pub use blocks::{BlockError, BlockId, BlockStat};
-use fvm_shared::address::Address;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::consensus::ConsensusFault;
-use fvm_shared::crypto::randomness::DomainSeparationTag;
-use fvm_shared::crypto::signature::Signature;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::message::Message;
-use fvm_shared::piece::PieceInfo;
-use fvm_shared::randomness::Randomness;
-use fvm_shared::receipt::Receipt;
-use fvm_shared::sector::{
-    AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
+use cid::Cid;
+use fvm_shared::{
+    address::Address,
+    clock::ChainEpoch,
+    consensus::ConsensusFault,
+    crypto::{randomness::DomainSeparationTag, signature::Signature},
+    econ::TokenAmount,
+    error::ExitCode,
+    message::Message,
+    piece::PieceInfo,
+    randomness::Randomness,
+    receipt::Receipt,
+    sector::{
+        AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
+    },
+    version::NetworkVersion,
+    ActorID, MethodNum,
 };
-use fvm_shared::version::NetworkVersion;
-use fvm_shared::{ActorID, MethodNum};
 
 mod blocks;
 pub mod default;

--- a/fvm/src/machine.rs
+++ b/fvm/src/machine.rs
@@ -1,31 +1,35 @@
-use std::ops::{Deref, DerefMut};
-use std::result::Result as StdResult;
+use std::{
+    ops::{Deref, DerefMut},
+    result::Result as StdResult,
+};
 
 use anyhow::{anyhow, Context};
+use blockstore::Blockstore;
 use cid::Cid;
+use fvm_shared::{
+    address::Address,
+    bigint::{BigInt, Sign},
+    clock::ChainEpoch,
+    econ::TokenAmount,
+    encoding::{Cbor, RawBytes},
+    error::ExitCode,
+    message::Message,
+    receipt::Receipt,
+    version::NetworkVersion,
+    ActorID,
+};
 use num_traits::{Signed, Zero};
 use wasmtime::{Engine, Module};
 
-use blockstore::Blockstore;
-use fvm_shared::address::Address;
-use fvm_shared::bigint::{BigInt, Sign};
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{Cbor, RawBytes};
-use fvm_shared::error::ExitCode;
-use fvm_shared::message::Message;
-use fvm_shared::receipt::Receipt;
-use fvm_shared::version::NetworkVersion;
-use fvm_shared::ActorID;
-
-use crate::account_actor::is_account_actor;
-use crate::call_manager::CallManager;
-use crate::externs::Externs;
-use crate::gas::{price_list_by_epoch, GasCharge, GasOutputs, PriceList};
-use crate::kernel::{ClassifyResult, Context as _, ExecutionError, Result, SyscallError};
-use crate::state_tree::{ActorState, StateTree};
-use crate::syscall_error;
-use crate::Config;
+use crate::{
+    account_actor::is_account_actor,
+    call_manager::CallManager,
+    externs::Externs,
+    gas::{price_list_by_epoch, GasCharge, GasOutputs, PriceList},
+    kernel::{ClassifyResult, Context as _, ExecutionError, Result, SyscallError},
+    state_tree::{ActorState, StateTree},
+    syscall_error, Config,
+};
 
 pub const REWARD_ACTOR_ADDR: Address = Address::new_id(2);
 /// Distinguished AccountActor that is the destination of all burnt funds.

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -1,25 +1,26 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::cell::RefCell;
-use std::collections::HashMap;
+use std::{cell::RefCell, collections::HashMap};
 
 use anyhow::{anyhow, Context as _};
 use blockstore::Blockstore;
 use cid::{multihash, Cid};
-
-use fvm_shared::address::{Address, Payload};
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{tuple::*, CborStore};
-use fvm_shared::state::{StateInfo0, StateRoot, StateTreeVersion};
-use fvm_shared::ActorID;
-
+use fvm_shared::{
+    address::{Address, Payload},
+    bigint::bigint_ser,
+    econ::TokenAmount,
+    encoding::{tuple::*, CborStore},
+    state::{StateInfo0, StateRoot, StateTreeVersion},
+    ActorID,
+};
 use ipld_hamt::Hamt;
 
-use crate::init_actor::State as InitActorState;
-use crate::kernel::{ClassifyResult, Context as _, ExecutionError, Result};
-use crate::syscall_error;
+use crate::{
+    init_actor::State as InitActorState,
+    kernel::{ClassifyResult, Context as _, ExecutionError, Result},
+    syscall_error,
+};
 
 /// State tree implementation using hamt. This structure is not threadsafe and should only be used
 /// in sync contexts.
@@ -510,9 +511,8 @@ pub mod json {
 
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
-    use crate::TokenAmount;
-
     use super::*;
+    use crate::TokenAmount;
 
     /// Wrapper for serializing and deserializing a SignedMessage from JSON.
     #[derive(Deserialize, Serialize)]

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -1,7 +1,11 @@
-use crate::kernel::{ClassifyResult, Result};
-use crate::syscalls::context::Context;
-use crate::{syscall_error, Kernel};
 use wasmtime::Caller;
+
+use crate::{
+    kernel::{ClassifyResult, Result},
+    syscall_error,
+    syscalls::context::Context,
+    Kernel,
+};
 
 pub fn resolve_address(
     caller: &mut Caller<'_, impl Kernel>,

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -1,22 +1,27 @@
 // TODO: remove this when we hookup these syscalls.
 #![allow(unused)]
 
-use crate::kernel::{BlockId, ClassifyResult, ExecutionError, Result, SyscallError};
-use crate::{syscall_error, Kernel};
+use std::collections::HashMap;
+
 use anyhow::Context as _;
 use cid::Cid;
-use fvm_shared::address::Address;
-use fvm_shared::crypto::signature::Signature;
-use fvm_shared::encoding::{Cbor, DAG_CBOR};
-use fvm_shared::error::ExitCode::SysErrIllegalArgument;
-use fvm_shared::piece::PieceInfo;
-use fvm_shared::sector::{
-    AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
+use fvm_shared::{
+    address::Address,
+    crypto::signature::Signature,
+    encoding::{Cbor, DAG_CBOR},
+    error::ExitCode::SysErrIllegalArgument,
+    piece::PieceInfo,
+    sector::{
+        AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
+    },
 };
-use std::collections::HashMap;
 use wasmtime::{Caller, Trap};
 
 use super::Context;
+use crate::{
+    kernel::{BlockId, ClassifyResult, ExecutionError, Result, SyscallError},
+    syscall_error, Kernel,
+};
 
 /// Verifies that a signature is valid for an address and plaintext.
 ///

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -2,13 +2,14 @@ use std::sync::Mutex;
 
 use anyhow::Context;
 use derive_more::Display;
-use fvm_shared::error::ExitCode;
-use fvm_shared::receipt::Receipt;
+use fvm_shared::{error::ExitCode, receipt::Receipt};
 use num_traits::FromPrimitive;
 use wasmtime::{Caller, Linker, Trap, WasmRet, WasmTy};
 
-use crate::kernel::{ClassifyResult, ExecutionError, SyscallError};
-use crate::Kernel;
+use crate::{
+    kernel::{ClassifyResult, ExecutionError, SyscallError},
+    Kernel,
+};
 
 // TODO: we should consider implementing a proc macro attribute for syscall functions instead of
 // this type nonsense. But this was faster and will "work" for now.

--- a/fvm/src/syscalls/gas.rs
+++ b/fvm/src/syscalls/gas.rs
@@ -1,8 +1,12 @@
-use crate::kernel::{ClassifyResult, Result};
-use crate::syscalls::context::Context;
-use crate::Kernel;
 use std::str;
+
 use wasmtime::Caller;
+
+use crate::{
+    kernel::{ClassifyResult, Result},
+    syscalls::context::Context,
+    Kernel,
+};
 
 pub fn charge_gas(
     caller: &mut Caller<'_, impl Kernel>,

--- a/fvm/src/syscalls/ipld.rs
+++ b/fvm/src/syscalls/ipld.rs
@@ -2,12 +2,11 @@ use anyhow::Context as _;
 use cid::{self, Cid};
 use wasmtime::{self, Caller};
 
+use super::Context as _;
 use crate::{
     kernel::{ClassifyResult, Result},
     Kernel,
 };
-
-use super::Context as _;
 
 // Computes the encoded size of a varint.
 // TODO: move this to the varint crate.

--- a/fvm/src/syscalls/message.rs
+++ b/fvm/src/syscalls/message.rs
@@ -1,7 +1,7 @@
-use crate::kernel::{Kernel, Result};
 use wasmtime::Caller;
 
 use super::Context;
+use crate::kernel::{Kernel, Result};
 
 pub fn caller(caller: &mut Caller<'_, impl Kernel>) -> Result<u64> {
     Ok(caller.kernel().msg_caller())

--- a/fvm/src/syscalls/network.rs
+++ b/fvm/src/syscalls/network.rs
@@ -1,8 +1,7 @@
 use wasmtime::Caller;
 
-use crate::kernel::{Kernel, Result};
-
 use super::Context;
+use crate::kernel::{Kernel, Result};
 
 pub fn epoch(caller: &mut Caller<'_, impl Kernel>) -> Result<u64> {
     Ok(caller.kernel().network_epoch() as u64)

--- a/fvm/src/syscalls/rand.rs
+++ b/fvm/src/syscalls/rand.rs
@@ -1,13 +1,13 @@
-use crate::{
-    kernel::{ClassifyResult, Result},
-    Kernel,
-};
 use anyhow::Context as _;
 use fvm_shared::crypto::randomness::DomainSeparationTag;
 use num_traits::FromPrimitive;
 use wasmtime::Caller;
 
 use super::Context;
+use crate::{
+    kernel::{ClassifyResult, Result},
+    Kernel,
+};
 
 const RAND_LEN: usize = 32;
 

--- a/fvm/src/syscalls/send.rs
+++ b/fvm/src/syscalls/send.rs
@@ -1,13 +1,14 @@
-use crate::kernel::BlockId;
-use crate::{
-    kernel::{ClassifyResult, Result},
-    Kernel,
+use fvm_shared::{
+    encoding::{to_vec, DAG_CBOR},
+    message::Message,
 };
-use fvm_shared::encoding::{to_vec, DAG_CBOR};
-use fvm_shared::message::Message;
 use wasmtime::Caller;
 
 use super::Context;
+use crate::{
+    kernel::{BlockId, ClassifyResult, Result},
+    Kernel,
+};
 
 /// Send a message to another actor. The result is placed as a CBOR-encoded
 /// receipt in the block registry, and can be retrieved by the returned BlockId.

--- a/fvm/src/syscalls/sself.rs
+++ b/fvm/src/syscalls/sself.rs
@@ -1,6 +1,7 @@
+use wasmtime::Caller;
+
 use super::{Context, MAX_CID_LEN};
 use crate::kernel::{ClassifyResult, Kernel, Result};
-use wasmtime::Caller;
 
 pub fn root(caller: &mut Caller<'_, impl Kernel>, obuf_off: u32) -> Result<()> {
     let (kernel, mut memory) = caller.kernel_and_memory()?;

--- a/fvm/src/syscalls/validation.rs
+++ b/fvm/src/syscalls/validation.rs
@@ -1,9 +1,9 @@
-use crate::kernel::{ClassifyResult, Kernel, Result};
 use cid::Cid;
 use fvm_shared::address::Address;
 use wasmtime::Caller;
 
 use super::Context;
+use crate::kernel::{ClassifyResult, Kernel, Result};
 
 pub fn validate_immediate_caller_accept_any(caller: &mut Caller<'_, impl Kernel>) -> Result<()> {
     caller.kernel().validate_immediate_caller_accept_any()?;

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -1,17 +1,15 @@
-use num_traits::FromPrimitive;
-
 use anyhow::Context as _;
 use fvm_shared::error::ExitCode;
+use num_traits::FromPrimitive;
 use wasmtime::{Caller, Trap};
-
-use crate::{
-    kernel::{ClassifyResult, ExecutionError},
-    Kernel,
-};
 
 use super::{
     error::{trap_from_code, trap_from_error},
     Context as _,
+};
+use crate::{
+    kernel::{ClassifyResult, ExecutionError},
+    Kernel,
 };
 
 pub fn abort(

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -1,17 +1,18 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use anyhow::anyhow;
+use blockstore::Blockstore;
+use cid::{multihash::Code, Cid};
+use fvm_shared::encoding::{de::DeserializeOwned, ser::Serialize, CborStore};
+use itertools::sorted;
+
 use super::ValueMut;
 use crate::{
     init_sized_vec,
     node::{CollapsedNode, Link},
     nodes_for_height, Error, Node, Root, DEFAULT_BIT_WIDTH, MAX_HEIGHT, MAX_INDEX,
 };
-use anyhow::anyhow;
-use blockstore::Blockstore;
-use cid::{multihash::Code, Cid};
-use fvm_shared::encoding::{de::DeserializeOwned, ser::Serialize, CborStore};
-use itertools::sorted;
 
 /// Array Mapped Trie allows for the insertion and persistence of data, serializable to a CID.
 ///

--- a/ipld/amt/src/error.rs
+++ b/ipld/amt/src/error.rs
@@ -1,12 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::error::Error as StdError;
+
 use anyhow::anyhow;
 use cid::Error as CidError;
-use std::error::Error as StdError;
-use thiserror::Error;
-
 use fvm_shared::encoding::Error as EncodingError;
+use thiserror::Error;
 
 /// AMT Error
 #[derive(Debug, Error)]

--- a/ipld/amt/src/lib.rs
+++ b/ipld/amt/src/lib.rs
@@ -12,11 +12,8 @@ mod node;
 mod root;
 mod value_mut;
 
-pub use self::amt::Amt;
-pub use self::error::Error;
-pub(crate) use self::node::Node;
-pub(crate) use self::root::Root;
-pub use self::value_mut::ValueMut;
+pub use self::{amt::Amt, error::Error, value_mut::ValueMut};
+pub(crate) use self::{node::Node, root::Root};
 
 const DEFAULT_BIT_WIDTH: usize = 3;
 const MAX_HEIGHT: usize = 64;

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -1,8 +1,6 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::ValueMut;
-use crate::{bmap_bytes, init_sized_vec, nodes_for_height, Error};
 use anyhow::anyhow;
 use blockstore::Blockstore;
 use cid::{multihash::Code, Cid};
@@ -12,6 +10,9 @@ use serde::{
     de::{self, DeserializeOwned},
     ser, Deserialize, Serialize,
 };
+
+use super::ValueMut;
+use crate::{bmap_bytes, init_sized_vec, nodes_for_height, Error};
 
 /// This represents a link to another Node
 #[derive(Debug)]
@@ -544,8 +545,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use fvm_shared::encoding::{from_slice, to_vec};
+
+    use super::*;
 
     #[test]
     fn serialize_node_symmetric() {

--- a/ipld/amt/src/root.rs
+++ b/ipld/amt/src/root.rs
@@ -1,11 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::{init_sized_vec, node::CollapsedNode, Node};
 use serde::{
     de::{self, Deserialize},
     ser::{self, Serialize},
 };
+
+use crate::{init_sized_vec, node::CollapsedNode, Node};
 
 /// Root of an AMT vector, can be serialized and keeps track of height and count
 #[derive(PartialEq, Debug)]
@@ -62,8 +63,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use fvm_shared::encoding::{from_slice, to_vec};
+
+    use super::*;
 
     #[test]
     fn serialize_symmetric() {

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -1,13 +1,14 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::fmt::Debug;
+
 use blockstore::{
     tracking::{BSStats, TrackingBlockstore},
     Blockstore,
 };
 use fvm_shared::encoding::{de::DeserializeOwned, ser::Serialize, BytesDe};
 use ipld_amt::{Amt, Error, MAX_INDEX};
-use std::fmt::Debug;
 
 fn assert_get<V, BS>(a: &Amt<V, BS>, i: usize, v: &V)
 where

--- a/ipld/bitfield/benches/benchmarks/main.rs
+++ b/ipld/bitfield/benches/benchmarks/main.rs
@@ -4,9 +4,8 @@
 mod examples;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use forest_bitfield::BitField;
-
 use examples::{example1, example2};
+use forest_bitfield::BitField;
 
 fn len(c: &mut Criterion) {
     let bf = example1();

--- a/ipld/bitfield/src/iter/combine.rs
+++ b/ipld/bitfield/src/iter/combine.rs
@@ -45,8 +45,9 @@
 //! These ranges are combined into a proper range iterator by merging overlapping
 //! ranges.
 
-use super::RangeIterator;
 use std::{cmp, iter, ops::Range};
+
+use super::RangeIterator;
 
 /// A trait for defining how two range iterators can be combined into a single new range iterator.
 ///

--- a/ipld/bitfield/src/iter/mod.rs
+++ b/ipld/bitfield/src/iter/mod.rs
@@ -3,8 +3,9 @@
 
 mod combine;
 
-use combine::{Combine, Cut, Difference, Intersection, SymmetricDifference, Union};
 use std::{iter, ops::Range};
+
+use combine::{Combine, Cut, Difference, Intersection, SymmetricDifference, Union};
 
 /// A trait for iterators over `Range<usize>`.
 ///

--- a/ipld/bitfield/src/lib.rs
+++ b/ipld/bitfield/src/lib.rs
@@ -5,14 +5,14 @@ pub mod iter;
 mod rleplus;
 mod unvalidated;
 
-pub use unvalidated::{UnvalidatedBitField, Validate};
-
-use ahash::AHashSet;
-use iter::{ranges_from_bits, RangeIterator};
 use std::{
     iter::FromIterator,
     ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Range, Sub, SubAssign},
 };
+
+use ahash::AHashSet;
+use iter::{ranges_from_bits, RangeIterator};
+pub use unvalidated::{UnvalidatedBitField, Validate};
 
 type Result<T> = std::result::Result<T, &'static str>;
 
@@ -329,10 +329,10 @@ macro_rules! bitfield {
 
 #[cfg(feature = "json")]
 pub mod json {
+    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+
     use super::*;
     use crate::iter::Ranges;
-    use serde::ser::SerializeSeq;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     #[derive(Deserialize, Serialize, Debug, PartialEq)]
     #[serde(transparent)]

--- a/ipld/bitfield/src/rleplus/mod.rs
+++ b/ipld/bitfield/src/rleplus/mod.rs
@@ -64,12 +64,13 @@
 mod reader;
 mod writer;
 
+use std::borrow::Cow;
+
 pub use reader::BitReader;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub use writer::BitWriter;
 
 use super::{BitField, Result};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::borrow::Cow;
 
 // MaxEncodedSize is the maximum encoded size of a bitfield. When expanded into
 // a slice of runs, a bitfield of this size should not exceed 2MiB of memory.
@@ -183,13 +184,13 @@ impl BitField {
 
 #[cfg(test)]
 mod tests {
+    use rand::{Rng, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+
     use super::{
         super::{bitfield, ranges_from_bits},
         BitField, BitWriter,
     };
-
-    use rand::{Rng, SeedableRng};
-    use rand_xorshift::XorShiftRng;
 
     #[test]
     fn test() {

--- a/ipld/bitfield/src/rleplus/reader.rs
+++ b/ipld/bitfield/src/rleplus/reader.rs
@@ -172,9 +172,10 @@ mod tests {
 
     #[test]
     fn roundtrip() {
-        use super::super::BitWriter;
         use rand::{Rng, SeedableRng};
         use rand_xorshift::XorShiftRng;
+
+        use super::super::BitWriter;
 
         let mut rng = XorShiftRng::seed_from_u64(5);
 

--- a/ipld/bitfield/src/unvalidated.rs
+++ b/ipld/bitfield/src/unvalidated.rs
@@ -1,9 +1,10 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::{BitField, Result};
 use fvm_shared::encoding::serde_bytes;
 use serde::{Deserialize, Deserializer, Serialize};
+
+use super::{BitField, Result};
 
 /// A trait for types that can produce a `&BitField` (or fail to do so).
 /// Generalizes over `&BitField` and `&mut UnvalidatedBitField`.

--- a/ipld/bitfield/tests/bitfield_tests.rs
+++ b/ipld/bitfield/tests/bitfield_tests.rs
@@ -1,12 +1,13 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::iter::FromIterator;
+
 use ahash::AHashSet;
 use forest_bitfield::{bitfield, BitField};
 use fvm_shared::encoding;
 use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
-use std::iter::FromIterator;
 
 fn random_indices(range: usize, seed: u64) -> Vec<usize> {
     let mut rng = XorShiftRng::seed_from_u64(seed);

--- a/ipld/hamt/src/bitfield.rs
+++ b/ipld/hamt/src/bitfield.rs
@@ -1,13 +1,14 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::u64;
+
 use byteorder::{BigEndian, ByteOrder};
 use fvm_shared::encoding::{
     de::{Deserialize, Deserializer},
     ser::{Serialize, Serializer},
     serde_bytes,
 };
-use std::u64;
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Bitfield([u64; 4]);
@@ -143,8 +144,9 @@ impl std::fmt::Binary for Bitfield {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use fvm_shared::encoding::{from_slice, to_vec};
+
+    use super::*;
 
     #[test]
     fn test_bitfield() {

--- a/ipld/hamt/src/error.rs
+++ b/ipld/hamt/src/error.rs
@@ -1,8 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_shared::encoding::Error as EncodingError;
 use std::error::Error as StdError;
+
+use fvm_shared::encoding::Error as EncodingError;
 use thiserror::Error;
 
 /// HAMT Error

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -1,15 +1,15 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::node::Node;
-use crate::{Error, Hash, HashAlgorithm, Sha256, DEFAULT_BIT_WIDTH};
+use std::{borrow::Borrow, marker::PhantomData};
+
 use blockstore::Blockstore;
 use cid::{multihash::Code, Cid};
 use forest_hash_utils::BytesKey;
 use fvm_shared::encoding::CborStore;
 use serde::{de::DeserializeOwned, Serialize, Serializer};
-use std::borrow::Borrow;
-use std::marker::PhantomData;
+
+use crate::{node::Node, Error, Hash, HashAlgorithm, Sha256, DEFAULT_BIT_WIDTH};
 
 /// Implementation of the HAMT data structure for IPLD.
 ///

--- a/ipld/hamt/src/hash.rs
+++ b/ipld/hamt/src/hash.rs
@@ -1,8 +1,7 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::hash::Hasher;
-use std::{mem, slice};
+use std::{hash::Hasher, mem, slice};
 
 /// Custom trait to avoid issues like https://github.com/rust-lang/rust/issues/27108.
 pub trait Hash {

--- a/ipld/hamt/src/hash_algorithm.rs
+++ b/ipld/hamt/src/hash_algorithm.rs
@@ -1,9 +1,11 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::{Hash, HashedKey};
-use sha2::{Digest, Sha256 as Sha256Hasher};
 use std::hash::Hasher;
+
+use sha2::{Digest, Sha256 as Sha256Hasher};
+
+use crate::{Hash, HashedKey};
 
 /// Algorithm used as the hasher for the Hamt.
 pub trait HashAlgorithm {

--- a/ipld/hamt/src/hash_bits.rs
+++ b/ipld/hamt/src/hash_bits.rs
@@ -1,8 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::{Error, HashedKey};
 use std::cmp::Ordering;
+
+use crate::{Error, HashedKey};
 
 /// Helper struct which indexes and allows returning bits from a hashed key
 #[derive(Debug, Clone, Copy)]

--- a/ipld/hamt/src/lib.rs
+++ b/ipld/hamt/src/lib.rs
@@ -18,13 +18,10 @@ mod hash_bits;
 mod node;
 mod pointer;
 
-pub use self::error::Error;
-pub use self::hamt::Hamt;
-pub use self::hash::*;
-pub use self::hash_algorithm::*;
-
 pub use forest_hash_utils::{BytesKey, Hash};
 use serde::{Deserialize, Serialize};
+
+pub use self::{error::Error, hamt::Hamt, hash::*, hash_algorithm::*};
 
 const MAX_ARRAY_WIDTH: usize = 3;
 

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -1,19 +1,18 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::bitfield::Bitfield;
-use super::hash_bits::HashBits;
-use super::pointer::Pointer;
-use super::{Error, Hash, HashAlgorithm, KeyValuePair, MAX_ARRAY_WIDTH};
+use std::{borrow::Borrow, fmt::Debug, marker::PhantomData};
+
 use blockstore::Blockstore;
 use cid::multihash::Code;
 use fvm_shared::encoding::CborStore;
 use once_cell::unsync::OnceCell;
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::borrow::Borrow;
-use std::fmt::Debug;
-use std::marker::PhantomData;
+use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
+
+use super::{
+    bitfield::Bitfield, hash_bits::HashBits, pointer::Pointer, Error, Hash, HashAlgorithm,
+    KeyValuePair, MAX_ARRAY_WIDTH,
+};
 
 /// Node in Hamt tree which contains bitfield of set indexes and pointers to nodes
 #[derive(Debug)]

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -1,15 +1,13 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::node::Node;
-use super::{Error, Hash, HashAlgorithm, KeyValuePair, MAX_ARRAY_WIDTH};
+use std::{cmp::Ordering, convert::TryFrom};
+
 use cid::Cid;
 use once_cell::unsync::OnceCell;
-use serde::de::DeserializeOwned;
-use serde::ser;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::cmp::Ordering;
-use std::convert::TryFrom;
+use serde::{de::DeserializeOwned, ser, Deserialize, Deserializer, Serialize, Serializer};
+
+use super::{node::Node, Error, Hash, HashAlgorithm, KeyValuePair, MAX_ARRAY_WIDTH};
 
 /// Pointer to index values or a link to another child node.
 #[derive(Debug)]

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -1,16 +1,18 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use blockstore::{tracking::BSStats, tracking::TrackingBlockstore, MemoryBlockstore};
-use cid::multihash::Code;
-use fvm_shared::encoding::CborStore;
-use ipld_hamt::BytesKey;
-use ipld_hamt::Hamt;
-use serde_bytes::ByteBuf;
 use std::fmt::Display;
 
+use blockstore::{
+    tracking::{BSStats, TrackingBlockstore},
+    MemoryBlockstore,
+};
+use cid::multihash::Code;
+use fvm_shared::encoding::CborStore;
 #[cfg(feature = "identity")]
 use ipld_hamt::Identity;
+use ipld_hamt::{BytesKey, Hamt};
+use serde_bytes::ByteBuf;
 
 // Redeclaring max array size of Hamt to avoid exposing value
 const BUCKET_SIZE: usize = 3;

--- a/lib/blockstore/src/buffered.rs
+++ b/lib/blockstore/src/buffered.rs
@@ -1,8 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::Blockstore;
 use cid::Cid;
+
+use super::Blockstore;
 
 // TODO: figure out where to put this.
 const DAG_CBOR: u64 = 0x71;
@@ -72,8 +73,7 @@ where
         .get(&root)
         .ok_or_else(|| format!("Invalid link ({}) in flushing buffered store", root))?;
 
-    use libipld::cbor::DagCborCodec;
-    use libipld::{codec::Codec, Ipld};
+    use libipld::{cbor::DagCborCodec, codec::Codec, Ipld};
     let mut references = Vec::new();
     DagCborCodec.references::<Ipld, _>(block, &mut references)?;
 
@@ -140,10 +140,11 @@ where
 #[cfg(test)]
 #[cfg(disabled)]
 mod tests {
-    use super::*;
     use cid::multihash::{Code, MultihashDigest};
     use forest_ipld::{ipld, Ipld};
     use fvm_shared::commcid::commitment_to_cid;
+
+    use super::*;
 
     const RAW: u64 = 0x55;
 

--- a/lib/blockstore/src/cgo.rs
+++ b/lib/blockstore/src/cgo.rs
@@ -12,11 +12,9 @@ extern "C" {
     pub fn cgobs_has(store: i32, k: *const u8, k_len: i32) -> i32;
 }
 
-use cid::Cid;
-use std::ptr;
+use std::{error, fmt, ptr};
 
-use std::error;
-use std::fmt;
+use cid::Cid;
 
 use super::Blockstore;
 

--- a/lib/blockstore/src/lib.rs
+++ b/lib/blockstore/src/lib.rs
@@ -1,7 +1,6 @@
 use std::rc::Rc;
 
-use cid::multihash;
-use cid::Cid;
+use cid::{multihash, Cid};
 
 pub mod buffered;
 mod memory;

--- a/lib/blockstore/src/memory.rs
+++ b/lib/blockstore/src/memory.rs
@@ -1,8 +1,7 @@
-use super::*;
-use std::cell::RefCell;
-use std::collections::HashMap;
 // TODO: move to ! someday. https://doc.rust-lang.org/std/convert/enum.Infallible.html#future-compatibility
-use std::convert::Infallible;
+use std::{cell::RefCell, collections::HashMap, convert::Infallible};
+
+use super::*;
 
 #[derive(Debug, Default, Clone)]
 pub struct MemoryBlockstore {

--- a/lib/blockstore/src/tracking.rs
+++ b/lib/blockstore/src/tracking.rs
@@ -1,10 +1,11 @@
 //#![cfg(feature = "tracking")]
 
+use std::cell::RefCell;
+
 use cid::{
     multihash::{self, Code},
     Cid,
 };
-use std::cell::RefCell;
 
 use crate::{Block, Blockstore};
 
@@ -111,10 +112,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::MemoryBlockstore;
-
     use super::*;
-    use crate::Block;
+    use crate::{Block, MemoryBlockstore};
 
     #[test]
     fn basic_tracking_store() {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+imports_granularity = "Crate"
+reorder_imports = true
+group_imports = "StdExternalCrate"

--- a/sdk/src/actor.rs
+++ b/sdk/src/actor.rs
@@ -1,11 +1,12 @@
+use core::option::Option; // no_std
+
+use cid::Cid;
+use fvm_shared::{address::Address, ActorID};
+
 use crate::{
     error::{IntoSyscallResult, SyscallResult},
     sys, MAX_ACTOR_ADDR_LEN, MAX_CID_LEN,
 };
-use cid::Cid;
-use core::option::Option; // no_std
-use fvm_shared::address::Address;
-use fvm_shared::ActorID;
 
 /// Resolves the ID address of an actor.
 pub fn resolve_address(addr: Address) -> SyscallResult<Option<ActorID>> {

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -1,15 +1,20 @@
-use crate::error::{IntoSyscallResult, SyscallResult};
-use crate::{ipld, status_code_to_bool, sys, MAX_CID_LEN};
 use cid::Cid;
-use fvm_shared::address::Address;
-use fvm_shared::consensus::ConsensusFault;
-use fvm_shared::crypto::signature::Signature;
-use fvm_shared::encoding::{from_slice, to_vec, Cbor};
-use fvm_shared::error::ExitCode;
-use fvm_shared::piece::PieceInfo;
-use fvm_shared::randomness::{Randomness, RANDOMNESS_LENGTH};
-use fvm_shared::sector::{
-    AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
+use fvm_shared::{
+    address::Address,
+    consensus::ConsensusFault,
+    crypto::signature::Signature,
+    encoding::{from_slice, to_vec, Cbor},
+    error::ExitCode,
+    piece::PieceInfo,
+    randomness::{Randomness, RANDOMNESS_LENGTH},
+    sector::{
+        AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
+    },
+};
+
+use crate::{
+    error::{IntoSyscallResult, SyscallResult},
+    ipld, status_code_to_bool, sys, MAX_CID_LEN,
 };
 
 /// Verifies that a signature is valid for an address and plaintext.

--- a/sdk/src/gas.rs
+++ b/sdk/src/gas.rs
@@ -1,5 +1,7 @@
-use crate::error::{IntoSyscallResult, SyscallResult};
-use crate::sys;
+use crate::{
+    error::{IntoSyscallResult, SyscallResult},
+    sys,
+};
 
 /// Charge gas for the operation identified by name.
 pub fn charge(name: &str, compute: u64) -> SyscallResult<()> {

--- a/sdk/src/ipld.rs
+++ b/sdk/src/ipld.rs
@@ -1,6 +1,9 @@
-use crate::error::{IntoSyscallResult, SyscallResult};
-use crate::{sself, sys, MAX_CID_LEN};
 use cid::Cid;
+
+use crate::{
+    error::{IntoSyscallResult, SyscallResult},
+    sself, sys, MAX_CID_LEN,
+};
 
 /// The unit/void object.
 pub const UNIT: u32 = sys::ipld::UNIT;

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -1,11 +1,16 @@
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{Cbor, DAG_CBOR};
-use fvm_shared::error::ExitCode;
-use fvm_shared::{ActorID, MethodNum};
+use fvm_shared::{
+    econ::TokenAmount,
+    encoding::{Cbor, DAG_CBOR},
+    error::ExitCode,
+    ActorID, MethodNum,
+};
 
-use crate::error::{IntoSyscallResult, SyscallResult};
-use crate::ipld::{BlockId, Codec};
-use crate::{abort, sys};
+use crate::{
+    abort,
+    error::{IntoSyscallResult, SyscallResult},
+    ipld::{BlockId, Codec},
+    sys,
+};
 
 /// Returns the ID address of the caller.
 #[inline(always)]

--- a/sdk/src/network.rs
+++ b/sdk/src/network.rs
@@ -1,10 +1,11 @@
 use std::convert::TryInto;
 
-use crate::error::{IntoSyscallResult, SyscallResult};
-use crate::sys;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::version::NetworkVersion;
+use fvm_shared::{clock::ChainEpoch, econ::TokenAmount, version::NetworkVersion};
+
+use crate::{
+    error::{IntoSyscallResult, SyscallResult},
+    sys,
+};
 
 pub fn curr_epoch() -> SyscallResult<ChainEpoch> {
     unsafe { Ok(sys::network::curr_epoch().into_syscall_result()? as ChainEpoch) }

--- a/sdk/src/rand.rs
+++ b/sdk/src/rand.rs
@@ -1,8 +1,13 @@
-use crate::error::{IntoSyscallResult, SyscallResult};
-use crate::sys;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::crypto::randomness::DomainSeparationTag;
-use fvm_shared::randomness::{Randomness, RANDOMNESS_LENGTH};
+use fvm_shared::{
+    clock::ChainEpoch,
+    crypto::randomness::DomainSeparationTag,
+    randomness::{Randomness, RANDOMNESS_LENGTH},
+};
+
+use crate::{
+    error::{IntoSyscallResult, SyscallResult},
+    sys,
+};
 
 /// Gets 32 bytes of randomness from the ticket chain.
 /// The supplied output buffer must have at least 32 bytes of capacity.

--- a/sdk/src/send.rs
+++ b/sdk/src/send.rs
@@ -1,9 +1,14 @@
-use crate::sys;
+use fvm_shared::{
+    encoding::{from_slice, to_vec},
+    message::Message,
+    receipt::Receipt,
+};
+
 // no_std
-use crate::error::{IntoSyscallResult, SyscallResult};
-use fvm_shared::encoding::{from_slice, to_vec};
-use fvm_shared::message::Message;
-use fvm_shared::receipt::Receipt;
+use crate::{
+    error::{IntoSyscallResult, SyscallResult},
+    sys,
+};
 
 /// Sends a message to another actor.
 /// TODO https://github.com/filecoin-project/fvm/issues/178

--- a/sdk/src/sself.rs
+++ b/sdk/src/sself.rs
@@ -1,8 +1,10 @@
-use crate::error::{IntoSyscallResult, SyscallResult};
-use crate::{sys, MAX_CID_LEN};
 use cid::Cid;
-use fvm_shared::address::Address;
-use fvm_shared::econ::TokenAmount;
+use fvm_shared::{address::Address, econ::TokenAmount};
+
+use crate::{
+    error::{IntoSyscallResult, SyscallResult},
+    sys, MAX_CID_LEN,
+};
 
 /// Get the IPLD root CID.
 pub fn get_root() -> SyscallResult<Cid> {

--- a/sdk/src/validation.rs
+++ b/sdk/src/validation.rs
@@ -1,7 +1,10 @@
-use crate::error::SyscallResult;
-use crate::{error::IntoSyscallResult, sys};
 use cid::Cid;
 use fvm_shared::address::Address;
+
+use crate::{
+    error::{IntoSyscallResult, SyscallResult},
+    sys,
+};
 
 /// Signals that this actor accepts calls from any other actor.
 pub fn validate_immediate_caller_accept_any() -> SyscallResult<()> {

--- a/shared/src/address/errors.rs
+++ b/shared/src/address/errors.rs
@@ -1,11 +1,13 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::{BLS_PUB_LEN, PAYLOAD_HASH_LEN, SECP_PUB_LEN};
-use data_encoding::DecodeError;
 use std::{io, num};
+
+use data_encoding::DecodeError;
 use thiserror::Error;
 use unsigned_varint::decode::Error as VarintError;
+
+use super::{BLS_PUB_LEN, PAYLOAD_HASH_LEN, SECP_PUB_LEN};
 
 /// Address error
 #[derive(Debug, PartialEq, Error)]

--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -5,20 +5,23 @@ mod errors;
 mod network;
 mod payload;
 mod protocol;
-pub use self::errors::Error;
-pub use self::network::Network;
-pub use self::payload::{BLSPublicKey, Payload};
-pub use self::protocol::Protocol;
+use std::{borrow::Cow, fmt, hash::Hash, str::FromStr};
 
-use crate::encoding::{blake2b_variable, serde_bytes, Cbor};
-use crate::ActorID;
 use data_encoding::Encoding;
 #[allow(unused_imports)]
 use data_encoding_macro::{internal_new_encoding, new_encoding};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-use std::hash::Hash;
-use std::str::FromStr;
-use std::{borrow::Cow, fmt};
+
+pub use self::{
+    errors::Error,
+    network::Network,
+    payload::{BLSPublicKey, Payload},
+    protocol::Protocol,
+};
+use crate::{
+    encoding::{blake2b_variable, serde_bytes, Cbor},
+    ActorID,
+};
 
 /// defines the encoder for base32 encoding with the provided string with no padding
 const ADDRESS_ENCODER: Encoding = new_encoding! {
@@ -321,8 +324,7 @@ pub(crate) fn from_leb_bytes(bz: &[u8]) -> Result<u64, Error> {
 #[cfg(test)]
 mod tests {
     // Test cases for FOR-02: https://github.com/ChainSafe/forest/issues/1134
-    use crate::address::errors::Error;
-    use crate::address::{from_leb_bytes, to_leb_bytes};
+    use crate::address::{errors::Error, from_leb_bytes, to_leb_bytes};
 
     #[test]
     fn test_from_leb_bytes_passing() {

--- a/shared/src/address/payload.rs
+++ b/shared/src/address/payload.rs
@@ -1,12 +1,15 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::{
+    convert::TryInto,
+    fmt,
+    hash::{Hash, Hasher},
+    ops::Deref,
+    u64,
+};
+
 use super::{from_leb_bytes, to_leb_bytes, Error, Protocol, BLS_PUB_LEN, PAYLOAD_HASH_LEN};
-use std::convert::TryInto;
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
-use std::u64;
 
 /// Public key struct used as BLS Address data.
 /// This type is only needed to be able to implement traits on it due to limitations on

--- a/shared/src/address/protocol.rs
+++ b/shared/src/address/protocol.rs
@@ -1,11 +1,10 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::{fmt, hash::Hash, u64};
+
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use std::fmt;
-use std::hash::Hash;
-use std::u64;
 
 /// Protocol defines the addressing protocol used to derive data to an address
 #[derive(PartialEq, Eq, Copy, Clone, FromPrimitive, Debug, Hash)]

--- a/shared/src/bigint/bigint_ser.rs
+++ b/shared/src/bigint/bigint_ser.rs
@@ -1,9 +1,10 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::borrow::Cow;
+
 use num_bigint::{BigInt, Sign};
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 
 /// Wrapper for serializing big ints to match filecoin spec. Serializes as bytes.
 #[derive(Serialize)]

--- a/shared/src/bigint/biguint_ser.rs
+++ b/shared/src/bigint/biguint_ser.rs
@@ -1,9 +1,10 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::borrow::Cow;
+
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 
 /// Wrapper for serializing big ints to match filecoin spec. Serializes as bytes.
 #[derive(Serialize)]

--- a/shared/src/crypto/signature.rs
+++ b/shared/src/crypto/signature.rs
@@ -1,13 +1,16 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::address::Error as AddressError;
-use crate::encoding::{de, repr::*, ser, serde_bytes, Cbor, Error as EncodingError};
+use std::{borrow::Cow, error};
+
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use std::borrow::Cow;
-use std::error;
 use thiserror::Error;
+
+use crate::{
+    address::Error as AddressError,
+    encoding::{de, repr::*, ser, serde_bytes, Cbor, Error as EncodingError},
+};
 
 /// BLS signature length in bytes.
 pub const BLS_SIG_LEN: usize = 96;
@@ -117,15 +120,15 @@ impl Signature {
 
 #[cfg(feature = "crypto")]
 pub mod ops {
-    use super::{Error, SECP_SIG_LEN};
-    use crate::address::Address;
-    use crate::crypto::signature::Signature;
-    use crate::encoding::blake2b_256;
     use bls_signatures::{
         verify_messages, PublicKey as BlsPubKey, Serialize, Signature as BlsSignature,
     };
-    use libsecp256k1::Error as SecpError;
-    use libsecp256k1::{recover, Message, RecoveryId, Signature as EcsdaSignature};
+    use libsecp256k1::{
+        recover, Error as SecpError, Message, RecoveryId, Signature as EcsdaSignature,
+    };
+
+    use super::{Error, SECP_SIG_LEN};
+    use crate::{address::Address, crypto::signature::Signature, encoding::blake2b_256};
 
     /// Returns `String` error if a bls signature is invalid.
     pub fn verify_bls_sig(signature: &[u8], data: &[u8], addr: &Address) -> Result<(), String> {
@@ -237,14 +240,17 @@ pub mod ops {
 
 #[cfg(all(test, feature = "crypto"))]
 mod tests {
-    use super::*;
-    use crate::crypto::signature::ops::{ecrecover, verify_bls_aggregate};
-    use crate::encoding::blake2b_256;
-    use crate::Address;
     use bls_signatures::{PrivateKey, Serialize, Signature as BlsSignature};
     use libsecp256k1::{sign, Message, PublicKey, SecretKey};
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
+
+    use super::*;
+    use crate::{
+        crypto::signature::ops::{ecrecover, verify_bls_aggregate},
+        encoding::blake2b_256,
+        Address,
+    };
 
     #[test]
     fn bls_agg_verify() {

--- a/shared/src/encoding/cbor.rs
+++ b/shared/src/encoding/cbor.rs
@@ -3,14 +3,15 @@
 
 use std::{ops::Deref, rc::Rc};
 
-use super::errors::Error;
-use crate::encoding::{de, from_slice, ser, to_vec, CodecProtocol};
 use blockstore::{Block, Blockstore};
 use cid::{
     multihash::{self, Code},
     Cid,
 };
 use serde::{Deserialize, Serialize};
+
+use super::errors::Error;
+use crate::encoding::{de, from_slice, ser, to_vec, CodecProtocol};
 
 // TODO find something to reference.
 pub const DAG_CBOR: u64 = 0x71;

--- a/shared/src/encoding/errors.rs
+++ b/shared/src/encoding/errors.rs
@@ -1,10 +1,10 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::{fmt, io};
+
 use cid::Error as CidError;
 use serde_cbor::error::Error as CborError;
-use std::fmt;
-use std::io;
 use thiserror::Error;
 
 /// Error type for encoding and decoding data through any Forest supported protocol.

--- a/shared/src/encoding/mod.rs
+++ b/shared/src/encoding/mod.rs
@@ -11,11 +11,7 @@ pub use serde::{de, ser};
 pub use serde_bytes;
 pub use serde_cbor::{error, from_reader, from_slice, tags, to_vec, to_writer};
 
-pub use self::bytes::*;
-pub use self::cbor::*;
-pub use self::errors::*;
-pub use self::hash::*;
-pub use self::vec::*;
+pub use self::{bytes::*, cbor::*, errors::*, hash::*, vec::*};
 
 // TODO: these really don't work all that well in a shared context like this as anyone importing
 // them also need to _explicitly_ import the serde_tuple & serde_repr crates. These are _macros_,

--- a/shared/src/encoding/vec.rs
+++ b/shared/src/encoding/vec.rs
@@ -1,10 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use serde::de::{self, SeqAccess, Visitor};
-use serde::Deserialize;
-use std::fmt;
-use std::marker::PhantomData;
+use std::{fmt, marker::PhantomData};
+
+use serde::{
+    de::{self, SeqAccess, Visitor},
+    Deserialize,
+};
 
 /// Helper visitor to match Go's default behaviour of serializing uninitialized slices as null.
 /// This will be able to deserialize null as empty Vectors of the type.
@@ -61,9 +63,12 @@ where
 }
 
 pub mod go_vec_visitor {
+    use serde::{
+        de::{Deserialize, Deserializer},
+        ser::{Serialize, SerializeSeq, Serializer},
+    };
+
     use super::*;
-    use serde::de::{Deserialize, Deserializer};
-    use serde::ser::{Serialize, SerializeSeq, Serializer};
 
     pub fn serialize<S, T>(m: &[T], serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -88,10 +93,10 @@ pub mod go_vec_visitor {
 
 #[cfg(test)]
 mod tests {
-    use super::go_vec_visitor;
-    use super::*;
     use serde::{Deserialize, Deserializer};
     use serde_json::from_str;
+
+    use super::{go_vec_visitor, *};
 
     #[test]
     fn test_json_basic() {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -4,10 +4,9 @@
 #[macro_use]
 extern crate lazy_static;
 
-use num_bigint::BigInt;
-
 use address::Address;
 use clock::ChainEpoch;
+use num_bigint::BigInt;
 
 pub mod address;
 pub mod bigint;

--- a/shared/src/message.rs
+++ b/shared/src/message.rs
@@ -3,15 +3,17 @@
 
 use anyhow::anyhow;
 
-use crate::address::Address;
-use crate::bigint::bigint_ser::{BigIntDe, BigIntSer};
-use crate::econ::TokenAmount;
-use crate::encoding::{
-    de::{Deserialize, Deserializer},
-    ser::{Serialize, Serializer},
-    Cbor, RawBytes,
+use crate::{
+    address::Address,
+    bigint::bigint_ser::{BigIntDe, BigIntSer},
+    econ::TokenAmount,
+    encoding::{
+        de::{Deserialize, Deserializer},
+        ser::{Serialize, Serializer},
+        Cbor, RawBytes,
+    },
+    MethodNum,
 };
-use crate::MethodNum;
 
 /// Default Unsigned VM message type which includes all data needed for a state transition
 #[derive(PartialEq, Clone, Debug, Hash, Eq)]

--- a/shared/src/piece/mod.rs
+++ b/shared/src/piece/mod.rs
@@ -5,12 +5,11 @@ use crate::encoding::Cbor;
 #[cfg(feature = "proofs")]
 pub mod zero;
 
-#[cfg(feature = "proofs")]
-pub use zero::zero_piece_commitment;
-
 use cid::Cid;
 use serde::{Deserialize, Serialize};
 use serde_tuple::*;
+#[cfg(feature = "proofs")]
+pub use zero::zero_piece_commitment;
 
 /// Size of a piece in bytes.
 #[derive(PartialEq, Debug, Eq, Clone, Copy)]

--- a/shared/src/randomness/mod.rs
+++ b/shared/src/randomness/mod.rs
@@ -1,8 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::encoding::{BytesDe, BytesSer};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::encoding::{BytesDe, BytesSer};
 
 /// String of random bytes usually generated from a randomness beacon or from tickets on chain.
 #[derive(PartialEq, Eq, Default, Clone, Debug)]

--- a/shared/src/receipt.rs
+++ b/shared/src/receipt.rs
@@ -1,11 +1,13 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::encoding::{
-    tuple::{Deserialize_tuple, Serialize_tuple},
-    {Cbor, RawBytes},
+use crate::{
+    encoding::{
+        tuple::{Deserialize_tuple, Serialize_tuple},
+        Cbor, RawBytes,
+    },
+    error::ExitCode,
 };
-use crate::error::ExitCode;
 
 /// Result of a state transition from a message
 #[derive(Debug, PartialEq, Clone, Serialize_tuple, Deserialize_tuple)]

--- a/shared/src/reward.rs
+++ b/shared/src/reward.rs
@@ -1,8 +1,6 @@
 use serde_tuple::*;
 
-use crate::bigint::bigint_ser;
-use crate::sector::StoragePower;
-use crate::smooth::FilterEstimate;
+use crate::{bigint::bigint_ser, sector::StoragePower, smooth::FilterEstimate};
 
 #[derive(Clone, Debug, PartialEq, Serialize_tuple, Deserialize_tuple)]
 pub struct ThisEpochRewardReturn {

--- a/shared/src/sector/mod.rs
+++ b/shared/src/sector/mod.rs
@@ -5,15 +5,16 @@ pub mod post;
 mod registered_proof;
 mod seal;
 
-pub use self::post::*;
-pub use self::registered_proof::*;
-pub use self::seal::*;
+use std::fmt;
 
-use crate::encoding::{repr::*, tuple::*};
-use crate::ActorID;
 use num_bigint::BigInt;
 use num_derive::FromPrimitive;
-use std::fmt;
+
+pub use self::{post::*, registered_proof::*, seal::*};
+use crate::{
+    encoding::{repr::*, tuple::*},
+    ActorID,
+};
 
 /// SectorNumber is a numeric identifier for a sector. It is usually relative to a miner.
 pub type SectorNumber = u64;

--- a/shared/src/sector/post.rs
+++ b/shared/src/sector/post.rs
@@ -5,9 +5,7 @@ use cid::Cid;
 use serde_tuple::*;
 
 use super::*;
-use crate::encoding::Cbor;
-use crate::randomness::Randomness;
-use crate::ActorID;
+use crate::{encoding::Cbor, randomness::Randomness, ActorID};
 
 /// Randomness type used for generating PoSt proof randomness.
 pub type PoStRandomness = Randomness;

--- a/shared/src/sector/registered_proof.rs
+++ b/shared/src/sector/registered_proof.rs
@@ -1,13 +1,13 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::SectorSize;
-use crate::clock;
-use crate::version::NetworkVersion;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
 #[cfg(feature = "proofs")]
 use std::convert::TryFrom;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::SectorSize;
+use crate::{clock, version::NetworkVersion};
 
 /// Seal proof type which defines the version and sector size.
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]

--- a/shared/src/sector/seal.rs
+++ b/shared/src/sector/seal.rs
@@ -1,15 +1,16 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::clock;
-use crate::deal;
-use crate::randomness::Randomness;
-use crate::sector::{RegisteredAggregateProof, RegisteredSealProof, SectorID, SectorNumber};
-use crate::ActorID;
-
-use crate::encoding::{serde_bytes, tuple::*, Cbor};
 use cid::Cid;
 use clock::ChainEpoch;
+
+use crate::{
+    clock, deal,
+    encoding::{serde_bytes, tuple::*, Cbor},
+    randomness::Randomness,
+    sector::{RegisteredAggregateProof, RegisteredSealProof, SectorID, SectorNumber},
+    ActorID,
+};
 
 /// Randomness used for Seal proofs.
 pub type SealRandomness = Randomness;

--- a/shared/src/smooth/alpha_beta_filter.rs
+++ b/shared/src/smooth/alpha_beta_filter.rs
@@ -1,12 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::bigint::{bigint_ser, BigInt, Integer};
-use crate::clock::ChainEpoch;
-use crate::encoding::tuple::*;
-use crate::encoding::Cbor;
-
-use crate::math::PRECISION;
+use crate::{
+    bigint::{bigint_ser, BigInt, Integer},
+    clock::ChainEpoch,
+    encoding::{tuple::*, Cbor},
+    math::PRECISION,
+};
 
 #[derive(Default, Serialize_tuple, Deserialize_tuple, Clone, Debug, PartialEq)]
 pub struct FilterEstimate {
@@ -74,8 +74,10 @@ impl<'a, 'b, 'f> AlphaBetaFilter<'a, 'b, 'f> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{DEFAULT_ALPHA, DEFAULT_BETA};
-    use super::*;
+    use super::{
+        super::{DEFAULT_ALPHA, DEFAULT_BETA},
+        *,
+    };
 
     #[test]
     fn rounding() {

--- a/shared/src/smooth/smooth_func.rs
+++ b/shared/src/smooth/smooth_func.rs
@@ -1,12 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::bigint::{BigInt, Integer};
-use crate::clock::ChainEpoch;
-
-use crate::math::{poly_parse, poly_val, PRECISION};
-
 use super::alpha_beta_filter::*;
+use crate::{
+    bigint::{BigInt, Integer},
+    clock::ChainEpoch,
+    math::{poly_parse, poly_val, PRECISION},
+};
 
 lazy_static! {
     pub static ref NUM: Vec<BigInt> = poly_parse(&[

--- a/shared/src/state/mod.rs
+++ b/shared/src/state/mod.rs
@@ -1,11 +1,10 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::encoding::repr::*;
-use crate::encoding::tuple::*;
-use crate::encoding::Cbor;
 use cid::Cid;
 use serde::{Deserialize, Serialize};
+
+use crate::encoding::{repr::*, tuple::*, Cbor};
 
 /// Specifies the version of the state tree
 #[derive(Debug, PartialEq, Clone, Copy, PartialOrd, Serialize_repr, Deserialize_repr)]

--- a/shared/tests/address_test.rs
+++ b/shared/tests/address_test.rs
@@ -1,13 +1,16 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use data_encoding::{DecodeError, DecodeKind};
-use fvm_shared::address::{
-    checksum, validate_checksum, Address, Error, Network, Protocol, BLS_PUB_LEN, PAYLOAD_HASH_LEN,
-    SECP_PUB_LEN,
-};
-use fvm_shared::encoding::{from_slice, Cbor};
 use std::str::FromStr;
+
+use data_encoding::{DecodeError, DecodeKind};
+use fvm_shared::{
+    address::{
+        checksum, validate_checksum, Address, Error, Network, Protocol, BLS_PUB_LEN,
+        PAYLOAD_HASH_LEN, SECP_PUB_LEN,
+    },
+    encoding::{from_slice, Cbor},
+};
 
 #[test]
 fn bytes() {

--- a/shared/tests/commcid_tests.rs
+++ b/shared/tests/commcid_tests.rs
@@ -1,10 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use cid::{multihash::Code, multihash::Multihash, multihash::MultihashDigest, Cid};
+use cid::{
+    multihash::{Code, Multihash, MultihashDigest},
+    Cid,
+};
 use fvm_shared::commcid::*;
-use rand::thread_rng;
-use rand::Rng;
+use rand::{thread_rng, Rng};
 
 fn rand_comm() -> Commitment {
     let mut rng = thread_rng();


### PR DESCRIPTION
# :no_entry: DO NOT MERGE :skull_and_crossbones: 

Using:

```toml
imports_granularity = "Crate"
reorder_imports = true
group_imports = "StdExternalCrate"
```

But I'm happy with anything as long as:

1. It's automatic.
2. It doesn't make our code look any different from normal rust code (no 3 space indent, thanks).

# :no_entry: DO NOT MERGE :skull_and_crossbones: 