### PR TITLE
make the consensus fault API return a tuple instead of an IPLD block

### DIFF
--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -51,7 +51,12 @@ extern "C" {
         h2_len: u32,
         extra_off: *const u8,
         extra_len: u32,
-    ) -> (super::SyscallStatus, i32, u32);
+    ) -> (
+        super::SyscallStatus,
+        u32,
+        fvm_shared::clock::ChainEpoch,
+        fvm_shared::ActorID,
+    );
 
     /// Verifies an aggregated batch of sector seal proofs.
     pub fn verify_aggregate_seals(agg_off: *const u8, agg_len: u32) -> (super::SyscallStatus, i32);

--- a/shared/src/consensus/mod.rs
+++ b/shared/src/consensus/mod.rs
@@ -1,8 +1,9 @@
+use num_derive::FromPrimitive;
+
 use super::{Address, ChainEpoch};
-use crate::encoding::{repr::*, tuple::*, Cbor};
 
 /// Result of checking two headers for a consensus fault.
-#[derive(Clone, Serialize_tuple, Deserialize_tuple)]
+#[derive(Clone, Debug)]
 pub struct ConsensusFault {
     /// Address of the miner at fault (always an ID address).
     pub target: Address,
@@ -13,13 +14,10 @@ pub struct ConsensusFault {
 }
 
 /// Consensus fault types in VM.
-#[derive(Clone, Copy, Serialize_repr, Deserialize_repr)]
+#[derive(FromPrimitive, Clone, Copy, Debug)]
 #[repr(u8)]
 pub enum ConsensusFaultType {
     DoubleForkMining = 1,
     ParentGrinding = 2,
     TimeOffsetMining = 3,
 }
-
-// For syscall marshalling.
-impl Cbor for ConsensusFault {}


### PR DESCRIPTION
The return values are:

1. The consensus fault type or 0 for none.
2. the epoch at which the consensus fault happened.
3. The ID of the actor that committed the fault.

fixes #165