### PR TITLE
Enforce a call stack depth of 4096

### DIFF
--- a/fvm/src/intercept/mod.rs
+++ b/fvm/src/intercept/mod.rs
@@ -27,11 +27,7 @@ mod test {
         bs = st.consume();
 
         let machine = DefaultMachine::new(
-            Config {
-                initial_pages: 0,
-                max_pages: 1024,
-                engine: Default::default(),
-            },
+            Config::default(),
             0,
             Zero::zero(),
             fvm_shared::version::NetworkVersion::V14,

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -16,6 +16,8 @@ mod state_tree;
 
 #[derive(Clone)]
 pub struct Config {
+    /// The maximum call depth.
+    pub max_call_depth: u32,
     /// Initial number of memory pages to allocate for the invocation container.
     pub initial_pages: usize,
     /// Maximum number of memory pages an invocation container's memory
@@ -23,6 +25,17 @@ pub struct Config {
     pub max_pages: usize,
     /// Wasmtime engine configuration.
     pub engine: wasmtime::Config,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            initial_pages: 0,
+            max_pages: 1024,
+            engine: Default::default(),
+            max_call_depth: 4096,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -44,11 +57,7 @@ mod test {
         bs = st.consume();
 
         let machine = DefaultMachine::new(
-            Config {
-                initial_pages: 0,
-                max_pages: 1024,
-                engine: Default::default(),
-            },
+            Config::default(),
             0,
             Zero::zero(),
             fvm_shared::version::NetworkVersion::V14,


### PR DESCRIPTION
Fixes #157 

Louts VM will allow you to have 4096 internal txs (excluding the original msg invocation) and fail on the 4097th, which is what this does.