### PR TITLE
various cleanups

### DIFF
--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -65,7 +65,7 @@ pub trait CallManager: 'static {
 
     /// Returns the current price list.
     fn price_list(&self) -> &PriceList {
-        self.machine().context().price_list()
+        &self.machine().context().price_list
     }
 
     /// Returns the machine context.
@@ -97,15 +97,5 @@ pub trait CallManager: 'static {
     fn charge_gas(&mut self, charge: GasCharge) -> Result<()> {
         self.gas_tracker_mut().charge_gas(charge)?;
         Ok(())
-    }
-
-    /// Returns the available gas.
-    fn gas_available(&self) -> i64 {
-        self.gas_tracker().gas_available()
-    }
-
-    /// Getter for gas used.
-    fn gas_used(&self) -> i64 {
-        self.gas_tracker().gas_used()
     }
 }

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -77,7 +77,7 @@ where
                 // Charge for including the result (before we end the transaction).
                 cm.charge_gas(
                     cm.context()
-                        .price_list()
+                        .price_list
                         .on_chain_return_value(ret.return_data.len()),
                 )?;
 
@@ -118,7 +118,7 @@ where
                     msg.to,
                     msg.sequence,
                     msg.method_num,
-                    self.context().epoch()
+                    self.context().epoch
                 )))
             }
         };
@@ -148,7 +148,7 @@ where
 
         // TODO I don't like having price lists _inside_ the FVM, but passing
         //  these across the boundary is also a no-go.
-        let pl = &self.context().price_list();
+        let pl = &self.context().price_list;
         let ser_msg = msg
             .marshal_cbor()
             .context("failed to re-marshal message")
@@ -160,12 +160,12 @@ where
         if inclusion_total > msg.gas_limit {
             return Ok(Err(ApplyRet::prevalidation_fail(
                 syscall_error!(SysErrOutOfGas; "Out of gas ({} > {})", inclusion_total, msg.gas_limit),
-                self.context().base_fee() * inclusion_total,
+                &self.context().base_fee * inclusion_total,
             )));
         }
 
         // Load sender actor state.
-        let miner_penalty_amount = self.context().base_fee() * msg.gas_limit;
+        let miner_penalty_amount = &self.context().base_fee * msg.gas_limit;
 
         let sender_id = match self
             .state_tree()
@@ -250,7 +250,7 @@ where
         } = GasOutputs::compute(
             receipt.gas_used,
             msg.gas_limit,
-            &self.context().base_fee(),
+            &self.context().base_fee,
             &msg.gas_fee_cap,
             &msg.gas_premium,
         );

--- a/fvm/src/intercept/machine.rs
+++ b/fvm/src/intercept/machine.rs
@@ -16,7 +16,7 @@ where
         self.machine.engine()
     }
 
-    fn config(&self) -> crate::Config {
+    fn config(&self) -> &crate::Config {
         self.machine.config()
     }
 

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -157,7 +157,7 @@ where
 
     fn set_root(&mut self, new: Cid) -> Result<()> {
         let addr = Address::new_id(self.to);
-        let state_tree = self.call_manager.machine_mut().state_tree_mut();
+        let state_tree = self.call_manager.state_tree_mut();
 
         state_tree.mutate_actor(&addr, |actor_state| {
             actor_state.state = new;
@@ -212,10 +212,7 @@ where
 
         // Delete the executing actor
         // TODO errors here are FATAL errors
-        self.call_manager
-            .machine_mut()
-            .state_tree_mut()
-            .delete_actor_id(self.to)
+        self.call_manager.state_tree_mut().delete_actor_id(self.to)
     }
 }
 
@@ -607,15 +604,15 @@ where
     C: CallManager,
 {
     fn network_epoch(&self) -> ChainEpoch {
-        self.call_manager.context().epoch()
+        self.call_manager.context().epoch
     }
 
     fn network_version(&self) -> NetworkVersion {
-        self.call_manager.context().network_version()
+        self.call_manager.context().network_version
     }
 
     fn network_base_fee(&self) -> &TokenAmount {
-        self.call_manager.context().base_fee()
+        &self.call_manager.context().base_fee
     }
 }
 

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -20,7 +20,7 @@ impl<M: Machine> Machine for Box<M> {
     }
 
     #[inline(always)]
-    fn config(&self) -> Config {
+    fn config(&self) -> &Config {
         (&**self).config()
     }
 

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -56,13 +56,13 @@ where
         blockstore: B,
         externs: E,
     ) -> anyhow::Result<Self> {
-        let context = MachineContext::new(
+        let context = MachineContext {
             epoch,
             base_fee,
-            state_root,
-            price_list_by_epoch(epoch),
             network_version,
-        );
+            initial_state_root: state_root,
+            price_list: price_list_by_epoch(epoch),
+        };
 
         // Initialize the WASM engine.
         let engine = Engine::new(&config.engine)?;
@@ -93,8 +93,8 @@ where
         &self.engine
     }
 
-    fn config(&self) -> Config {
-        self.config.clone()
+    fn config(&self) -> &Config {
+        &self.config
     }
 
     fn blockstore(&self) -> &Self::Blockstore {

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -28,26 +28,40 @@ pub trait Machine: 'static {
     type Blockstore: Blockstore;
     type Externs: Externs;
 
+    /// Returns the underlying wasmtime engine. Cloning it will simply create a new handle
+    /// with a static lifetime.
     fn engine(&self) -> &Engine;
 
-    fn config(&self) -> Config;
+    /// Returns the FVM's configuration.
+    fn config(&self) -> &Config;
 
+    /// Returns a reference to the machine's blockstore.
     fn blockstore(&self) -> &Self::Blockstore;
 
+    /// Returns a reference to the machine context: static information about the current execution
+    /// context.
     fn context(&self) -> &MachineContext;
 
+    /// Returns a reference to all "node" supplied APIs.
     fn externs(&self) -> &Self::Externs;
 
+    /// Returns an immutable reference to the state tree.
     fn state_tree(&self) -> &StateTree<Self::Blockstore>;
 
+    /// Returns a mutable reference to the state tree.
     fn state_tree_mut(&mut self) -> &mut StateTree<Self::Blockstore>;
 
     /// Creates an uninitialized actor.
     // TODO: Remove
     fn create_actor(&mut self, addr: &Address, act: ActorState) -> Result<ActorID>;
 
+    /// Loads a wasm module by CID.
     fn load_module(&self, code: &Cid) -> Result<Module>;
 
+    /// Transfers tokens from one actor to another.
+    ///
+    /// If either the receiver or the sender do not exist, this method fails with a FATAL error.
+    /// Otherwise, if the amounts are invalid, etc., it fails with a syscall error.
     fn transfer(&mut self, from: ActorID, to: ActorID, value: &TokenAmount) -> Result<()>;
 }
 
@@ -62,56 +76,17 @@ pub struct CallError {
     pub message: String,
 }
 
-/// Execution context supplied to the machine. All fields are private.
-/// Epoch and base fee cannot be mutated. The state_root corresponds to the
-/// initial state root, and gets updated internally with every message execution.
+/// Execution context supplied to the machine.
+#[derive(Clone, Debug)]
 pub struct MachineContext {
     /// The epoch at which the Machine runs.
-    epoch: ChainEpoch,
+    pub epoch: ChainEpoch,
     /// The base fee that's in effect when the Machine runs.
-    base_fee: TokenAmount,
-    /// The initial state root.
-    initial_state_root: Cid,
+    pub base_fee: TokenAmount,
+    /// The initial state root on which this block is based.
+    pub initial_state_root: Cid,
     /// The price list.
-    price_list: PriceList,
+    pub price_list: PriceList,
     /// The network version at epoch
-    network_version: NetworkVersion,
-}
-
-impl MachineContext {
-    fn new(
-        epoch: ChainEpoch,
-        base_fee: TokenAmount,
-        state_root: Cid,
-        price_list: PriceList,
-        network_version: NetworkVersion,
-    ) -> MachineContext {
-        MachineContext {
-            epoch,
-            base_fee,
-            price_list,
-            network_version,
-            initial_state_root: state_root,
-        }
-    }
-
-    pub fn epoch(&self) -> ChainEpoch {
-        self.epoch
-    }
-
-    pub fn base_fee(&self) -> &TokenAmount {
-        &self.base_fee
-    }
-
-    pub fn state_root(&self) -> Cid {
-        self.initial_state_root
-    }
-
-    pub fn network_version(&self) -> NetworkVersion {
-        self.network_version
-    }
-
-    pub fn price_list(&self) -> &PriceList {
-        &self.price_list
-    }
+    pub network_version: NetworkVersion,
 }


### PR DESCRIPTION
1. Make the MachineContext plain-old-data. We only expose it by immutable reference, so we don't need to make the fields private (they're all immutable).
2. Remove unused methods on the CallManager trait.
3. Return the machine config by reference.
4. Replace `callmanager.machine_mut().state_tree_mut()` with `callmanager.state_tree_mut()`.
5. Document a bunch of methods.

There's nothing critical in here so we can wait to avoid conflicts.