### PR TITLE
remove Blockstore child trait from Externs (+ more)

### DIFF
--- a/fvm/src/externs/cgo.rs
+++ b/fvm/src/externs/cgo.rs
@@ -2,7 +2,6 @@
 use cid::Cid;
 
 use anyhow::Result;
-use blockstore::cgo::CgoBlockstore;
 use fvm_shared::{
     address::Address,
     clock::ChainEpoch,
@@ -10,7 +9,7 @@ use fvm_shared::{
     crypto::randomness::DomainSeparationTag,
 };
 
-use crate::externs::{Blockstore, Consensus, Externs, Rand};
+use crate::externs::{Consensus, Externs, Rand};
 
 /// TODO this will be the externs implementation that delegates to a Go node
 /// (e.g. Lotus) via Cgo to resolve externs.
@@ -79,22 +78,6 @@ impl Consensus for CgoExterns {
             epoch: 0,
             fault_type: ConsensusFaultType::DoubleForkMining,
         }))
-    }
-}
-
-impl Blockstore for CgoExterns {
-    type Error = blockstore::cgo::Error;
-    fn has(&self, k: &Cid) -> Result<bool, Self::Error> {
-        let bs = CgoBlockstore::new(self.handle);
-        bs.has(k)
-    }
-    fn get(&self, k: &Cid) -> Result<Option<Vec<u8>>, Self::Error> {
-        let bs = CgoBlockstore::new(self.handle);
-        bs.get(k)
-    }
-    fn put_keyed(&self, k: &Cid, block: &[u8]) -> Result<(), Self::Error> {
-        let bs = CgoBlockstore::new(self.handle);
-        bs.put_keyed(k, block)
     }
 }
 

--- a/fvm/src/externs/mod.rs
+++ b/fvm/src/externs/mod.rs
@@ -1,13 +1,12 @@
 //! This module contains the logic to invoke the node by traversing Boundary A.
 
-use blockstore::Blockstore;
 use fvm_shared::{
     clock::ChainEpoch, consensus::ConsensusFault, crypto::randomness::DomainSeparationTag,
 };
 
 pub mod cgo;
 
-pub trait Externs: Rand + Consensus + Blockstore {}
+pub trait Externs: Rand + Consensus {}
 
 /// Consensus related methods.
 pub trait Consensus {

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -452,6 +452,11 @@ where
         }
     }
 
+    /// Consumes this StateTree and returns the Blockstore it owns via the HAMT.
+    pub fn consume(self) -> S {
+        self.hamt.consume()
+    }
+
     pub fn for_each<F>(&self, mut f: F) -> anyhow::Result<()>
     where
         F: FnMut(Address, &ActorState) -> anyhow::Result<()>,

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -29,10 +29,10 @@ pub(super) trait BindSyscall<Args, Ret, Func> {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```ignore
     /// mod my_module {
-    ///     fn zero(caller: wasmtime::Caller<'a, ()>, arg: i32) -> crate::kernel::Result<i32> {
-    ///         0
+    ///     pub fn zero(caller: wasmtime::Caller<()>, arg: i32) -> crate::fvm::kernel::Result<i32> {
+    ///         Ok(0)
     ///     }
     /// }
     /// let engine = wasmtime::Engine::default();

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -309,4 +309,9 @@ where
     {
         self.root.for_each(self.store.borrow(), &mut f)
     }
+
+    /// Consumes this HAMT and returns the Blockstore it owns.
+    pub fn consume(self) -> BS {
+        self.store
+    }
 }


### PR DESCRIPTION
The Blockstore will always be passed separately.

Also:
- Drop the blockstore/cgo requirement for the fvm crate, which does not belong here. (Moreover, the CgoExterns should live in their own crate).
- Ignore the BindSyscall rust doc example, since it doesn't compile due to visibility issues.
- Add consume() methods to StateTree and HAMT to consume the instances and return the owned Blockstore. We need
to instantiate a working state tree because the Machine loads it.

With these changes, we are now able to run cargo test on the fvm crate.