### PR TITLE
create actors by ID

### DIFF
--- a/actors/init/src/state.rs
+++ b/actors/init/src/state.rs
@@ -39,7 +39,7 @@ impl State {
         &mut self,
         store: &BS,
         addr: &Address,
-    ) -> Result<Address, HamtError> {
+    ) -> Result<ActorID, HamtError> {
         let id = self.next_id;
         self.next_id += 1;
 
@@ -47,7 +47,7 @@ impl State {
         map.set(addr.to_bytes().into(), id)?;
         self.address_map = map.flush()?;
 
-        Ok(Address::new_id(id))
+        Ok(id)
     }
 
     /// ResolveAddress resolves an address to an ID-address, if possible.

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -61,8 +61,9 @@ fn create_2_payment_channels() {
         let unique_address = Address::new_actor(paych);
         rt.new_actor_addr = Some(Address::new_actor(paych));
 
-        let expected_id_addr = Address::new_id(100 + n);
-        rt.expect_create_actor(*PAYCH_ACTOR_CODE_ID, expected_id_addr);
+        let expected_id = 100 + n;
+        let expected_id_addr = Address::new_id(expected_id);
+        rt.expect_create_actor(*PAYCH_ACTOR_CODE_ID, expected_id);
 
         let fake_params = ConstructorParams {
             network_name: String::from("fake_param"),
@@ -112,8 +113,9 @@ fn create_storage_miner() {
     let unique_address = Address::new_actor(b"miner");
     rt.new_actor_addr = Some(unique_address);
 
-    let expected_id_addr = Address::new_id(100);
-    rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id_addr);
+    let expected_id = 100;
+    let expected_id_addr = Address::new_id(expected_id);
+    rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id);
 
     let fake_params = ConstructorParams {
         network_name: String::from("fake_param"),
@@ -166,8 +168,9 @@ fn create_multisig_actor() {
     rt.new_actor_addr = Some(unique_address);
 
     // Next id
-    let expected_id_addr = Address::new_id(100);
-    rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id_addr);
+    let expected_id = 100;
+    let expected_id_addr = Address::new_id(expected_id);
+    rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id);
 
     let fake_params = ConstructorParams {
         network_name: String::from("fake_param"),
@@ -208,8 +211,9 @@ fn sending_constructor_failure() {
     rt.new_actor_addr = Some(unique_address);
 
     // Create the next id address
-    let expected_id_addr = Address::new_id(100);
-    rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id_addr);
+    let expected_id = 100;
+    let expected_id_addr = Address::new_id(expected_id);
+    rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id);
 
     let fake_params = ConstructorParams {
         network_name: String::from("fake_param"),

--- a/actors/runtime/src/runtime/fvm.rs
+++ b/actors/runtime/src/runtime/fvm.rs
@@ -11,7 +11,6 @@ use crate::Runtime;
 use crate::{actor_error, ActorError};
 use blockstore::Blockstore;
 use fvm_sdk as fvm;
-use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::randomness::DomainSeparationTag;
 use fvm_shared::crypto::signature::Signature;
@@ -24,6 +23,7 @@ use fvm_shared::sector::{
 };
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::MethodNum;
+use fvm_shared::{address::Address, ActorID};
 
 lazy_static! {
     /// Cid of the empty array Cbor bytes (`EMPTY_ARR_BYTES`).
@@ -213,8 +213,8 @@ where
         Ok(fvm::actor::new_actor_address()?)
     }
 
-    fn create_actor(&mut self, code_id: Cid, address: &Address) -> Result<(), ActorError> {
-        Ok(fvm::actor::create_actor(*address, code_id)?)
+    fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {
+        Ok(fvm::actor::create_actor(actor_id, code_id)?)
     }
 
     fn delete_actor(&mut self, beneficiary: &Address) -> Result<(), ActorError> {

--- a/actors/runtime/src/runtime/mod.rs
+++ b/actors/runtime/src/runtime/mod.rs
@@ -20,7 +20,7 @@ use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
 };
 use fvm_shared::version::NetworkVersion;
-use fvm_shared::MethodNum;
+use fvm_shared::{ActorID, MethodNum};
 
 use crate::ActorError;
 
@@ -131,7 +131,7 @@ pub trait Runtime<BS: Blockstore>: Syscalls {
 
     /// Creates an actor with code `codeID` and address `address`, with empty state.
     /// May only be called by Init actor.
-    fn create_actor(&mut self, code_id: Cid, address: &Address) -> Result<(), ActorError>;
+    fn create_actor(&mut self, code_id: Cid, address: ActorID) -> Result<(), ActorError>;
 
     /// Deletes the executing actor from the state tree, transferring any balance to beneficiary.
     /// Aborts if the beneficiary does not exist.

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -25,7 +25,7 @@ use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
 };
 use fvm_shared::version::NetworkVersion;
-use fvm_shared::MethodNum;
+use fvm_shared::{ActorID, MethodNum};
 
 pub struct MockRuntime {
     pub epoch: ChainEpoch,
@@ -153,7 +153,7 @@ impl Default for MockRuntime {
 #[derive(Clone, Debug)]
 pub struct ExpectCreateActor {
     pub code_id: Cid,
-    pub address: Address,
+    pub actor_id: ActorID,
 }
 #[derive(Clone, Debug)]
 pub struct ExpectedMessage {
@@ -345,8 +345,8 @@ impl MockRuntime {
     }
 
     #[allow(dead_code)]
-    pub fn expect_create_actor(&mut self, code_id: Cid, address: Address) {
-        let a = ExpectCreateActor { code_id, address };
+    pub fn expect_create_actor(&mut self, code_id: Cid, actor_id: ActorID) {
+        let a = ExpectCreateActor { code_id, actor_id };
         self.expectations.borrow_mut().expect_create_actor = Some(a);
     }
 
@@ -634,7 +634,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
         Ok(ret)
     }
 
-    fn create_actor(&mut self, code_id: Cid, address: &Address) -> Result<(), ActorError> {
+    fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {
         self.require_in_call();
         if self.in_transaction {
             return Err(actor_error!(SysErrIllegalActor; "side-effect within transaction"));
@@ -646,7 +646,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
             .take()
             .expect("unexpected call to create actor");
 
-        assert!(expect_create_actor.code_id == code_id && &expect_create_actor.address == address, "unexpected actor being created, expected code: {:?} address: {:?}, actual code: {:?} address: {:?}", expect_create_actor.code_id, expect_create_actor.address, code_id, address);
+        assert!(expect_create_actor.code_id == code_id && expect_create_actor.actor_id == actor_id, "unexpected actor being created, expected code: {:?} address: {:?}, actual code: {:?} address: {:?}", expect_create_actor.code_id, expect_create_actor.actor_id, code_id, actor_id);
         Ok(())
     }
 

--- a/actors/runtime/src/util/chaos/mod.rs
+++ b/actors/runtime/src/util/chaos/mod.rs
@@ -125,9 +125,9 @@ impl Actor {
             arg.cid
         };
 
-        let actor_address = arg.address;
+        let actor_address = arg.actor_id;
 
-        rt.create_actor(actor_cid, &actor_address)
+        rt.create_actor(actor_cid, actor_address)
     }
 
     /// Resolves address, and returns the resolved address (defaulting to 0 ID) and success boolean.

--- a/actors/runtime/src/util/chaos/types.rs
+++ b/actors/runtime/src/util/chaos/types.rs
@@ -10,6 +10,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::tuple::*;
 use fvm_shared::encoding::RawBytes;
 use fvm_shared::error::ExitCode;
+use fvm_shared::ActorID;
 
 use super::state::State;
 
@@ -19,7 +20,7 @@ pub struct CreateActorArgs {
     pub undef_cid: bool,
     pub cid: Cid,
     pub undef_address: bool,
-    pub address: Address,
+    pub actor_id: ActorID,
 }
 
 /// Holds the response of a call to runtime.ResolveAddress

--- a/fvm/src/intercept/kernel.rs
+++ b/fvm/src/intercept/kernel.rs
@@ -1,3 +1,5 @@
+use fvm_shared::ActorID;
+
 use crate::{call_manager::CallManager, kernel::*, machine::Machine};
 
 use super::{InterceptCallManager, InterceptMachine};
@@ -65,12 +67,8 @@ where
         self.0.new_actor_address()
     }
 
-    fn create_actor(
-        &mut self,
-        code_id: cid::Cid,
-        address: &fvm_shared::address::Address,
-    ) -> Result<()> {
-        self.0.create_actor(code_id, address)
+    fn create_actor(&mut self, code_id: cid::Cid, actor_id: ActorID) -> Result<()> {
+        self.0.create_actor(code_id, actor_id)
     }
 }
 impl<M, C, K, D> BlockOps for InterceptKernel<K>

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -786,7 +786,7 @@ where
     }
 
     // TODO merge new_actor_address and create_actor into a single syscall.
-    fn create_actor(&mut self, code_id: Cid, address: &Address) -> Result<()> {
+    fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<()> {
         if !is_builtin_actor(&code_id) {
             return Err(
                 syscall_error!(SysErrIllegalArgument; "Can only create built-in actors").into(),
@@ -799,7 +799,7 @@ where
         }
 
         let state_tree = self.call_manager.state_tree();
-        if let Ok(Some(_)) = state_tree.get_actor(address) {
+        if let Ok(Some(_)) = state_tree.get_actor_id(actor_id) {
             return Err(
                 syscall_error!(SysErrIllegalArgument; "Actor address already exists").into(),
             );
@@ -809,8 +809,8 @@ where
             .charge_gas(self.call_manager.price_list().on_create_actor())?;
 
         let state_tree = self.call_manager.state_tree_mut();
-        state_tree.set_actor(
-            address,
+        state_tree.set_actor_id(
+            actor_id,
             ActorState::new(code_id, *EMPTY_ARR_CID, 0.into(), 0),
         )
     }

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -169,9 +169,9 @@ pub trait ActorOps {
     /// Always an ActorExec address.
     fn new_actor_address(&mut self) -> Result<Address>;
 
-    /// Creates an actor with code `codeID` and address `address`, with empty state.
+    /// Creates an actor with code `codeID` and id `actor_id`, with empty state.
     /// May only be called by Init actor.
-    fn create_actor(&mut self, code_id: Cid, address: &Address) -> Result<()>;
+    fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<()>;
 }
 
 /// Operations to send messages to other actors.

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -74,12 +74,10 @@ pub fn new_actor_address(
 
 pub fn create_actor(
     caller: &mut Caller<'_, impl Kernel>,
-    addr_off: u32, // Address
-    addr_len: u32,
-    typ_off: u32, // Cid
+    actor_id: u64, // Address
+    typ_off: u32,  // Cid
 ) -> Result<()> {
     let (k, mem) = caller.kernel_and_memory()?;
-    let addr = mem.read_address(addr_off, addr_len)?;
     let typ = mem.read_cid(typ_off)?;
-    k.create_actor(typ, &addr)
+    k.create_actor(typ, actor_id)
 }

--- a/sdk/src/actor.rs
+++ b/sdk/src/actor.rs
@@ -57,11 +57,7 @@ pub fn new_actor_address() -> SyscallResult<Address> {
 /// Creates a new actor of the specified type in the state tree, under
 /// the provided address.
 /// TODO this syscall will change to calculate the address internally.
-pub fn create_actor(address: Address, code_cid: Cid) -> SyscallResult<()> {
-    let addr = address.to_bytes();
+pub fn create_actor(actor_id: ActorID, code_cid: Cid) -> SyscallResult<()> {
     let cid = code_cid.to_bytes();
-    unsafe {
-        sys::actor::create_actor(addr.as_ptr(), addr.len() as u32, cid.as_ptr())
-            .into_syscall_result()
-    }
+    unsafe { sys::actor::create_actor(actor_id, cid.as_ptr()).into_syscall_result() }
 }

--- a/sdk/src/sys/actor.rs
+++ b/sdk/src/sys/actor.rs
@@ -19,9 +19,5 @@ extern "C" {
     /// Creates a new actor of the specified type in the state tree, under
     /// the provided address.
     /// TODO this syscall will change to calculate the address internally.
-    pub fn create_actor(
-        addr_off: *const u8,
-        addr_len: u32,
-        typ_off: *const u8,
-    ) -> super::SyscallStatus;
+    pub fn create_actor(actor_id: u64, typ_off: *const u8) -> super::SyscallStatus;
 }


### PR DESCRIPTION
This only ever worked by ID anyways, but this signature change makes that obvious and reduces the chances that we'll make a mistake somewhere.

It turns out this change wasn't strictly necessary (I thought we a bug that wasn't actually a bug), but this should be more efficient and is definitely easier to reason about.