### PR TITLE
feat: switch from receipts to invocation results

### DIFF
--- a/fvm/src/intercept/call_manager.rs
+++ b/fvm/src/intercept/call_manager.rs
@@ -35,7 +35,7 @@ where
         method: fvm_shared::MethodNum,
         params: &fvm_shared::encoding::RawBytes,
         value: &fvm_shared::econ::TokenAmount,
-    ) -> Result<fvm_shared::receipt::Receipt> {
+    ) -> Result<crate::call_manager::InvocationResult> {
         // K is the kernel specified by the non intercepted kernel.
         // We wrap that here.
         self.0
@@ -44,8 +44,8 @@ where
 
     fn with_transaction(
         &mut self,
-        f: impl FnOnce(&mut Self) -> Result<fvm_shared::receipt::Receipt>,
-    ) -> Result<fvm_shared::receipt::Receipt> {
+        f: impl FnOnce(&mut Self) -> Result<crate::call_manager::InvocationResult>,
+    ) -> Result<crate::call_manager::InvocationResult> {
         // This transmute is _safe_ because this type is "repr transparent".
         let inner_ptr = &mut self.0 as *mut C;
         self.0.with_transaction(|inner: &mut C| unsafe {

--- a/fvm/src/intercept/kernel.rs
+++ b/fvm/src/intercept/kernel.rs
@@ -301,7 +301,7 @@ where
         method: u64,
         params: &fvm_shared::encoding::RawBytes,
         value: &fvm_shared::econ::TokenAmount,
-    ) -> Result<fvm_shared::receipt::Receipt> {
+    ) -> Result<crate::call_manager::InvocationResult> {
         self.0.send(recipient, method, params, value)
     }
 }

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -12,13 +12,12 @@ use fvm_shared::commcid::{
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::{blake2b_256, bytes_32, to_vec, CborStore, RawBytes};
 use fvm_shared::error::ExitCode;
-use fvm_shared::receipt::Receipt;
 use fvm_shared::{ActorID, FILECOIN_PRECISION};
 
 use blockstore::Blockstore;
 
 use crate::builtin::{is_builtin_actor, is_singleton_actor, EMPTY_ARR_CID};
-use crate::call_manager::CallManager;
+use crate::call_manager::{CallManager, InvocationResult};
 use crate::externs::{Consensus, Rand};
 use crate::machine::CallError;
 use crate::state_tree::ActorState;
@@ -357,7 +356,7 @@ where
         method: MethodNum,
         params: &RawBytes,
         value: &TokenAmount,
-    ) -> Result<Receipt> {
+    ) -> Result<InvocationResult> {
         let from = self.from;
         self.call_manager
             .with_transaction(|cm| cm.send::<Self>(from, *recipient, method, params, value))

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -13,7 +13,6 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::RawBytes;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::Randomness;
-use fvm_shared::receipt::Receipt;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
 };
@@ -26,7 +25,7 @@ pub mod default;
 mod error;
 pub use error::{ClassifyResult, Context, ExecutionError, Result, SyscallError};
 
-use crate::call_manager::CallManager;
+use crate::call_manager::{CallManager, InvocationResult};
 use crate::machine::Machine;
 
 pub trait Kernel:
@@ -182,7 +181,7 @@ pub trait SendOps {
         method: u64,
         params: &RawBytes,
         value: &TokenAmount,
-    ) -> Result<Receipt>;
+    ) -> Result<InvocationResult>;
 }
 
 /// Operations to query the circulating supply.

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -8,7 +8,7 @@ use crate::ipld::{BlockId, Codec};
 use crate::{abort, sys};
 
 /// BlockID representing nil parameters or return data.
-const NO_DATA_BLOCK_ID: u32 = 0;
+pub const NO_DATA_BLOCK_ID: u32 = 0;
 
 /// Returns the ID address of the caller.
 #[inline(always)]

--- a/sdk/src/send.rs
+++ b/sdk/src/send.rs
@@ -1,14 +1,18 @@
+use crate::message::NO_DATA_BLOCK_ID;
 use crate::sys;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 // no_std
 use crate::error::{IntoSyscallResult, SyscallResult};
-use fvm_shared::encoding::{from_slice, RawBytes, DAG_CBOR};
-use fvm_shared::error::ExitCode::ErrIllegalArgument;
+use fvm_shared::encoding::{RawBytes, DAG_CBOR};
+use fvm_shared::error::ExitCode::{self, ErrIllegalArgument};
 use fvm_shared::receipt::Receipt;
 use fvm_shared::MethodNum;
+use num_traits::FromPrimitive;
 
 /// Sends a message to another actor.
+// TODO: Drop the use of receipts here as we don't return the gas used. Alternatively, we _could_
+// return gas used?
 pub fn send(
     to: &Address,
     method: MethodNum,
@@ -24,9 +28,13 @@ pub fn send(
     };
     unsafe {
         // Send the message.
-        let params_id = sys::ipld::create(DAG_CBOR, params.as_ptr(), params.len() as u32)
-            .into_syscall_result()?;
-        let id = sys::send::send(
+        let params_id = if params.len() == 0 {
+            NO_DATA_BLOCK_ID
+        } else {
+            sys::ipld::create(DAG_CBOR, params.as_ptr(), params.len() as u32)
+                .into_syscall_result()?
+        };
+        let (exit_code, return_id) = sys::send::send(
             recipient.as_ptr(),
             recipient.len() as u32,
             method,
@@ -35,14 +43,30 @@ pub fn send(
             value_lo,
         )
         .into_syscall_result()?;
-        // Allocate a buffer to read the result.
-        let (_, length) = sys::ipld::stat(id).into_syscall_result()?;
-        let mut bytes = Vec::with_capacity(length as usize);
-        // Now read the result.
-        let read = sys::ipld::read(id, 0, bytes.as_mut_ptr(), length).into_syscall_result()?;
-        assert_eq!(read, length);
+        if exit_code != ExitCode::Ok as u32 {
+            return Ok(Receipt {
+                exit_code: ExitCode::from_u32(exit_code).unwrap_or(ExitCode::ErrIllegalState),
+                return_data: Default::default(),
+                gas_used: 0,
+            });
+        }
+        let return_data = if return_id == NO_DATA_BLOCK_ID {
+            RawBytes::default()
+        } else {
+            // Allocate a buffer to read the result.
+            let (_, length) = sys::ipld::stat(return_id).into_syscall_result()?;
+            let mut bytes = Vec::with_capacity(length as usize);
+            // Now read the result.
+            let read =
+                sys::ipld::read(return_id, 0, bytes.as_mut_ptr(), length).into_syscall_result()?;
+            assert_eq!(read, length);
+            RawBytes::from(bytes)
+        };
         // Deserialize the receipt.
-        let ret = from_slice::<Receipt>(bytes.as_slice()).expect("invalid receipt returned");
-        Ok(ret)
+        Ok(Receipt {
+            exit_code: ExitCode::Ok,
+            return_data,
+            gas_used: 0,
+        })
     }
 }

--- a/sdk/src/sys/send.rs
+++ b/sdk/src/sys/send.rs
@@ -1,8 +1,10 @@
+use crate::ipld::BlockId;
+
 #[link(wasm_import_module = "send")]
 #[allow(improper_ctypes)]
 extern "C" {
-    /// Sends a message to another actor, and returns the BlockID where
-    /// the invocation result (currently a Receipt object) has been placed.
+    /// Sends a message to another actor, and returns the exit code and block ID of the return
+    /// result.
     pub fn send(
         recipient_off: *const u8,
         recipient_len: u32,
@@ -10,5 +12,5 @@ extern "C" {
         params: u32,
         value_hi: u64,
         value_lo: u64,
-    ) -> (super::SyscallStatus, u32);
+    ) -> (super::SyscallStatus, u32, BlockId);
 }


### PR DESCRIPTION
part of #168

InvocationResult doesn't include "gas used", so there's no chance we'll assume it was set correctly. It turns out we were doing exactly that.

Additionally:

1. I'm now passing the send _result_ back into the actor as a tuple of `(exit_code, return_block_id)`. This saves us a CBOR serialization, and will eventually allow us to return blocks without copying them.
2. Both send parameters and return results use the "0" block to pass/return "empty" values.