### PR TITLE
build: make compiling actors optional.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: build examples
 .PHONY: all
 
 build:
-	cargo build
+	cargo build --features builtin_actors
 .PHONY: build
 
 #examples: example-actor example-fvm example-blockstore-cgo

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -32,17 +32,32 @@ num_cpus = "1.13.0"
 log = "0.4.14"
 byteorder = "1.4.3"
 
-fvm_actor_account = { path = "../actors/account" }
-fvm_actor_cron = { path = "../actors/cron" }
-fvm_actor_init = { path = "../actors/init" }
-fvm_actor_market = { path = "../actors/market" }
-fvm_actor_miner = { path = "../actors/miner" }
-fvm_actor_multisig = { path = "../actors/multisig" }
-fvm_actor_paych = { path = "../actors/paych" }
-fvm_actor_power = { path = "../actors/power" }
-fvm_actor_reward = { path = "../actors/reward" }
-fvm_actor_system = { path = "../actors/system" }
-fvm_actor_verifreg = { path = "../actors/verifreg" }
+## These are the built-in actors that we ship with the FVM in Milestone 0.
+## Starting with Milestone 1, the bytecode will no longer be inlined within the
+## FVM library. Instead, it will be stored in the blockstore managed by the node.
+##
+## How does the WASM bytecode inlining work?
+##
+## Each crate has a build script that uses wasm-builder to produce the WASM
+## bytecode. Cargo runs build scripts _before_ the ordinary build. The ordinary
+## build then embeds the WASM output into a constant in the library. The fvm
+## crate then imports those constants.
+##
+## Why are they optional?
+##
+## In order to speed up development builds, these dependencies are only activated
+## when the `builtin_actors` feature is enabled.
+fvm_actor_account = { path = "../actors/account", optional = true }
+fvm_actor_cron = { path = "../actors/cron", optional = true }
+fvm_actor_init = { path = "../actors/init", optional = true }
+fvm_actor_market = { path = "../actors/market", optional = true }
+fvm_actor_miner = { path = "../actors/miner", optional = true }
+fvm_actor_multisig = { path = "../actors/multisig", optional = true }
+fvm_actor_paych = { path = "../actors/paych", optional = true }
+fvm_actor_power = { path = "../actors/power", optional = true }
+fvm_actor_reward = { path = "../actors/reward", optional = true }
+fvm_actor_system = { path = "../actors/system", optional = true }
+fvm_actor_verifreg = { path = "../actors/verifreg", optional = true }
 
 [dependencies.wasmtime]
 version = "0.32.0"
@@ -51,3 +66,16 @@ features = ["cranelift", "pooling-allocator", "cache", "parallel-compilation"]
 
 [features]
 default = []
+builtin_actors = [
+    "fvm_actor_account",
+    "fvm_actor_cron",
+    "fvm_actor_init",
+    "fvm_actor_market",
+    "fvm_actor_miner",
+    "fvm_actor_multisig",
+    "fvm_actor_paych",
+    "fvm_actor_power",
+    "fvm_actor_reward",
+    "fvm_actor_system",
+    "fvm_actor_verifreg"
+]


### PR DESCRIPTION
This places the compilation of builtin actors is now behind a non-default `builtin_actors` feature.

This speeds up local cargo builds of the `fvm` crate for development purposes.

`make` enables the feature, and consequently, it is also enabled in CI.

This PR does not attempt to speed up CI, as that's a different problem because we _do_ want CI to build the entire tree, and it will be harder to solve.