### PR TITLE
ci: pin third-party action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2.4.0
-    - uses: actions-rs/toolchain@v1.0.7
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         profile: minimal
         override: true
@@ -19,17 +19,17 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2.4.0
-    - uses: actions-rs/toolchain@v1.0.7
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         profile: minimal
         target: wasm32-unknown-unknown
         override: true
         components: clippy
     # we don't check the lockfile in; this is needed for cache restoration/saving
-    - uses: actions-rs/cargo@v1.0.3
+    - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
         command: generate-lockfile
-    - uses: Swatinem/rust-cache@v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # v1.3.0
       with:
         # change this to invalidate cache for this job
         key: v0
@@ -46,20 +46,20 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.17.3
-    - uses: actions-rs/toolchain@v1.0.7
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         target: wasm32-unknown-unknown
         override: true
     # we don't check the lockfile in; this is needed for cache restoration/saving
-    - uses: actions-rs/cargo@v1.0.3
+    - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
         command: generate-lockfile
     - uses: protocol/cache-go-action@v1
-    - uses: Swatinem/rust-cache@v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # v1.3.0
       with:
         # change this to invalidate cache for this job
         key: v0
-    - uses: actions-rs/cargo@v1.0.3
+    - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
         command: install
         args: cbindgen


### PR DESCRIPTION
###### Description

I want to pin third-party action versions to ensure the underlying code doesn't change. We use the exact same approach in protocol/go actions. 

###### Testing

- [x] CI workflow

