### PR TITLE
Moving over ChainSafe/forest#1356

### DIFF
--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -426,7 +426,8 @@ impl Actor {
                     info!(
                         "invalid deal {}: failed to acquire datacap exitcode: {}",
                         di, e
-                    )
+                    );
+                    continue;
                 }
             }
 


### PR DESCRIPTION
Fixes logic in market actor to match go. Merged into forest already.