### PR TITLE
feat: basic state tree comparison

### DIFF
--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -37,6 +37,7 @@ base64 = "0.13.0"
 flate2 = { version = "1.0" }
 colored = "2"
 either = "1.6.1"
+itertools = "0.10.3"
 
 [dev-dependencies]
 regex = { version = "1.0" }


### PR DESCRIPTION
Add basic state-diffing support. This won't diff actors states, but will display actor mismatches and help catch balance issues.

Depends on https://github.com/filecoin-project/specs-actors/pull/1559 and regenerated test vectors with the "post" state.