### PR TITLE
feat: run conformance vectors in parallel

### DIFF
--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -38,6 +38,7 @@ flate2 = { version = "1.0" }
 colored = "2"
 either = "1.6.1"
 itertools = "0.10.3"
+num_cpus = "1.13.1"
 
 [dev-dependencies]
 regex = { version = "1.0" }

--- a/testing/conformance/tests/runner.rs
+++ b/testing/conformance/tests/runner.rs
@@ -35,6 +35,12 @@ lazy_static! {
     static ref SKIP_TESTS: Vec<Regex> = vec![
         // currently empty.
     ];
+    /// The maximum parallelism when processing test vectors.
+    static ref TEST_VECTOR_PARALLELISM: usize = std::env::var_os("TEST_VECTOR_PARALLELISM")
+        .map(|s| {
+            let s = s.to_str().unwrap();
+            s.parse().expect("parallelism must be an integer")
+        }).unwrap_or(num_cpus::get());
 }
 
 /// Checks if the file is a runnable vector.
@@ -200,7 +206,7 @@ async fn conformance_test_runner() -> anyhow::Result<()> {
                 .try_flatten_stream()
             })
             .flatten()
-            .try_buffer_unordered(100),
+            .try_buffer_unordered(*TEST_VECTOR_PARALLELISM),
     );
 
     let mut succeeded = 0;


### PR DESCRIPTION
We queue up 100 tasks, but the underlying scheduler will only schedule one per core. We could probably do something smarter, but eh.