### PR TITLE
ci: Split build job and introduce sccache

### DIFF
--- a/.github/actions/rust-sccache/action.yml
+++ b/.github/actions/rust-sccache/action.yml
@@ -1,0 +1,62 @@
+name: rust sccache
+description: Shared Compilation Cache for Rust
+inputs:
+  version:
+    description: The version of sccache to use
+    required: true
+  key:
+    description: An additional key for the cache
+    required: false
+  shared-key:
+    description: An additional key that is stable over multiple jobs
+    required: false
+runs:
+  using: composite
+  steps:
+    - id: rust
+      run: |
+        version="$(rustc -vV)"
+        echo "::set-output name=release::$(grep -oP 'release: \K.+' <<< "$version")"
+        echo "::set-output name=host::$(grep -oP 'host: \K.+' <<< "$version")"
+        echo "::set-output name=commit-hash::$(grep -oP 'commit-hash: \K.{0,12}' <<< "$version")"
+      shell: bash
+    - id: cache
+      run: |
+        key='v0-sccache'
+        if [[ ! -z '${{ inputs.shared-key }}' ]]; then
+          key="$key-${{ inputs.shared-key }}"
+        else
+          if [[ ! -z '${{ inputs.key }}' ]]; then
+            key="$key-${{ inputs.key }}"
+          fi
+          key="$key-${{ github.job }}"
+        fi
+        key="$key-${{ steps.rust.outputs.release }}-${{ steps.rust.outputs.host }}-${{ steps.rust.outputs.commit-hash }}"
+        hash='${{ hashFiles('**/Cargo.toml', '**/Cargo.lock', 'rust-toolchain', 'rust-toolchain.toml') }}'
+        echo "::set-output name=key::$key-${hash:0:20}"
+        echo "::set-output name=restore-key::$key-"
+      shell: bash
+    - run: |
+        asset_name='sccache-${{ inputs.version }}-x86_64-unknown-linux-musl'
+        gh release download --repo 'mozilla/sccache' --dir '.' --pattern "$asset_name.tar.gz" '${{ inputs.version }}'
+        tar -zxf "$asset_name.tar.gz"
+        cp "$asset_name/sccache" '/usr/local/bin/sccache'
+        chmod +x '/usr/local/bin/sccache'
+        rm -r "$asset_name"
+        rm "$asset_name.tar.gz"
+      shell: bash
+    - run: |
+        if [ -z '${{ env.RUSTC_WRAPPER }}' ]; then
+          echo 'RUSTC_WRAPPER=sccache' >> $GITHUB_ENV
+        fi
+        if [ -z '${{ env.SCCACHE_DIR }}' ]; then
+          echo "SCCACHE_DIR=$(realpath ~/.cache/sccache)" >> $GITHUB_ENV
+        fi
+      shell: bash
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ${{ env.SCCACHE_DIR }}
+        key: ${{ steps.cache.outputs.key }}
+        restore-keys: |
+          ${{ steps.cache.outputs.restore-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
     - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
         command: generate-lockfile
+    # right now all jobs use separate caches
+    # because of this we hit 10G limit quickly and entries are often evicted
+    # once https://github.com/actions/cache/pull/489 is merged:
+    #   - use sharedKey instead of key in all jobs in this workflow
+    #   - set CACHE_SKIP_SAVE in all jobs in this workflow but build
     - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # v1.3.0
       with:
         # change this to invalidate cache for this job
@@ -48,10 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
-      RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 2G
-      SCCACHE_VERSION: v0.2.15
-      SCCACHE_ASSET_NAME: sccache-v0.2.15-x86_64-unknown-linux-musl
       SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -68,32 +70,11 @@ jobs:
       with:
         # change this to invalidate cache for this job
         key: v0
-    - name: Install sccache
-      run: |
-        gh release download --repo 'mozilla/sccache' --dir '.' --pattern '${{ env.SCCACHE_ASSET_NAME }}.tar.gz' '${{ env.SCCACHE_VERSION }}'
-        tar -zxf '${{ env.SCCACHE_ASSET_NAME }}.tar.gz'
-        cp '${{ env.SCCACHE_ASSET_NAME }}/sccache' '/usr/local/bin/sccache'
-        chmod +x '/usr/local/bin/sccache'
-        mkdir -p '${{ env.SCCACHE_DIR }}'
-        rm -r '${{ env.SCCACHE_ASSET_NAME }}'
-        rm '${{ env.SCCACHE_ASSET_NAME }}.tar.gz'
-        rust_version="$(rustc -vV)"
-        rust_release="$(grep -oP 'release: \K.+' <<< "$rust_version")"
-        rust_host="$(grep -oP 'host: \K.+' <<< "$rust_version")"
-        rust_commit_hash="$(grep -oP 'commit-hash: \K.{0,12}' <<< "$rust_version")"
-        restore_key="v0-sccache-v0-build-$rust_release-$rust_host-$rust_commit_hash"
-        key="$restore_key-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock', 'rust-toolchain', 'rust-toolchain.toml') }}"
-        echo "SCCACHE_KEY=$key" >> $GITHUB_ENV
-        echo "SCCACHE_RESTORE_KEY=$restore_key" >> $GITHUB_ENV
-      shell: bash
-    - name: Cache sccache
-      uses: actions/cache@v2
+    - uses: ./.github/actions/rust-sccache
       with:
-        path: |
-          ${{ env.SCCACHE_DIR }}
-        key: ${{ env.SCCACHE_KEY }}
-        restore-keys: |
-          ${{ env.SCCACHE_RESTORE_KEY }}
+        version: v0.2.15
+        # change this to invalidate sccache for this job
+        key: v0
     - name: Build on wasm32-unknown-unknown
       uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:


### PR DESCRIPTION
In this PR I propose to split the `build` job into two: `build` which performs `cargo build` and `examples` which performs `make examples`. I also propose to add [sccache](https://github.com/mozilla/sccache) to the `build` job.

###### Split `build` into `build` and `examples`

I hope that by taking building of the examples out of the `build` job we decrease its' runtime. 

###### Add `sccache` to `build`

For now, I want to add `sccache` to `build` job only because it is the longest running job. Testing in this PR shows that it has the potential to improve build times:
- `cargo build` when the local sccache was empty https://github.com/filecoin-project/fvm/runs/4789414608?check_suite_focus=true `5m 40s`
- `cargo build` with local sccache from a previous run https://github.com/filecoin-project/fvm/runs/4789526853?check_suite_focus=true `2m 50s`