### PR TITLE
fix: avoid "ignore" in doc comments

### DIFF
--- a/ipld/bitfield/src/iter/combine.rs
+++ b/ipld/bitfield/src/iter/combine.rs
@@ -15,7 +15,7 @@
 //!
 //! For example, given the iterators over the following ranges:
 //!
-//! ```ignore
+//! ```txt
 //! lhs: -xx-xx
 //! rhs: xxxxx-
 //! ```
@@ -23,7 +23,7 @@
 //! First `-xx---` and `xxxxx-` are passed to the combinator. Then `-xx---` is
 //! discarded because it has the lowest upper bound, after which we are left with
 //!
-//! ```ignore
+//! ```txt
 //! lhs: ----xx
 //! rhs: xxxxx-
 //! ```
@@ -36,7 +36,7 @@
 //! example, the `Intersection` combinator would produce the following outputs
 //! given the inputs from above:
 //!
-//! ```ignore
+//! ```txt
 //! xxx---
 //! xxxxx-
 //! ----xx
@@ -395,7 +395,7 @@ where
 ///
 /// For example, given the ranges:
 ///
-/// ```ignore
+/// ```txt
 /// xx--------
 /// xxx-------
 /// ---xx-----
@@ -406,7 +406,7 @@ where
 ///
 /// `Merge` will produce
 ///
-/// ```ignore
+/// ```txt
 /// xxxxx--xxx
 /// ```
 ///

--- a/ipld/bitfield/src/iter/mod.rs
+++ b/ipld/bitfield/src/iter/mod.rs
@@ -41,7 +41,7 @@ pub trait RangeIterator: Iterator<Item = Range<usize>> + Sized {
     /// Returns a new `RangeIterator` over the bits in `self` that remain after "cutting" out the
     /// bits in `other`, and shifting remaining bits to the left if necessary. For example:
     ///
-    /// ```ignore
+    /// ```txt
     /// lhs:     xx-xxx--x
     /// rhs:     -xx-x----
     ///

--- a/ipld/bitfield/src/lib.rs
+++ b/ipld/bitfield/src/lib.rs
@@ -211,7 +211,7 @@ impl BitField {
     /// after "cutting" out the bits in `other`, and shifting remaining
     /// bits to the left if necessary. For example:
     ///
-    /// ```ignore
+    /// ```txt
     /// lhs:     xx-xxx--x
     /// rhs:     -xx-x----
     ///


### PR DESCRIPTION
"ignore" means "this is rust, but don't run it". "txt" means "this is text".

This change just cleans up the output of `cargo test`.