### PR TITLE
feat: disable opencl in conformance tests

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.4.0"
 derive-getters = "0.2.0"
 derive_more = "0.99.17"
 replace_with = "0.1.7"
-filecoin-proofs-api = { version = "10", features = ["opencl"], default_features = false }
+filecoin-proofs-api = { version = "10", default-features = false }
 rayon = "1"
 num_cpus = "1.13.0"
 log = "0.4.14"
@@ -64,7 +64,9 @@ default-features = false
 features = ["cranelift", "pooling-allocator", "cache", "parallel-compilation"]
 
 [features]
-default = []
+default = ["opencl"]
+opencl = ["filecoin-proofs-api/opencl"]
+cuda = ["filecoin-proofs-api/cuda"]
 builtin_actors = [
     "fvm_actor_account",
     "fvm_actor_cron",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = "1.0.51"
 ## non-wasm dependencies; these dependencies and the respective code is
 ## only activated through non-default features, which the Kernel enables, but
 ## not the actors.
-filecoin-proofs-api = { version = "10", features = ["opencl"], default_features = false, optional = true }
+filecoin-proofs-api = { version = "10", default_features = false, optional = true }
 libsecp256k1 = { version = "0.7", optional = true }
 bls-signatures = { version = "0.11", default-features = false, optional = true }
 byteorder = "1.4.3"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -14,10 +14,10 @@ num-traits = "0.2"
 derive_builder = "0.10"
 ahash = "0.7"
 num-derive = "0.3.3"
-cid = { version = "0.7", default-features = false, features = ["serde-codec"] }
-multihash = { version = "0.15", default-features = false, features = ["identity"] }
-fvm = { path = "../../fvm", features = ["builtin_actors"] }
-fvm_shared = { path = "../../shared", features = ["crypto"] }
+cid = { version = "0.7", default-features = false }
+multihash = { version = "0.15", default-features = false }
+fvm = { path = "../../fvm", features = ["builtin_actors"], default-features = false}
+fvm_shared = { path = "../../shared" }
 ipld_hamt = { path = "../../ipld/hamt"}
 ipld_amt = { path = "../../ipld/amt"}
 serde = { version = "1.0", features = ["derive"] }
@@ -47,5 +47,3 @@ serde_json = "1.0"
 flate2 = "1.0"
 lazy_static = "1.4"
 pretty_env_logger = "0.4.0"
-log = "0.4"
-


### PR DESCRIPTION
1. Make opencl/cuda configurable as FVM features.
2. Enable opencl by default.
3. Disable opencl for conformance tests.

This will let us run conformance tests in CI.