### PR TITLE
return hash digest & randomness as return value

### DIFF
--- a/actors/runtime/src/runtime/fvm.rs
+++ b/actors/runtime/src/runtime/fvm.rs
@@ -286,9 +286,7 @@ where
 
     fn hash_blake2b(&self, data: &[u8]) -> Result<[u8; 32], Error> {
         fvm::crypto::hash_blake2b(data)
-            .map_err(|e| anyhow!("failed to compute blake2b hash; exit code: {}", e))?
-            .try_into()
-            .map_err(|v: Vec<u8>| anyhow!("unexpected hash length; expected 32, got: {}", v.len()))
+            .map_err(|e| anyhow!("failed to compute blake2b hash; exit code: {}", e))
     }
 
     fn compute_unsealed_sector_cid(

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -677,12 +677,11 @@ where
         personalization: DomainSeparationTag,
         rand_epoch: ChainEpoch,
         entropy: &[u8],
-    ) -> Result<Randomness> {
+    ) -> Result<[u8; RANDOMNESS_LENGTH]> {
         // TODO: Check error code
         self.call_manager
             .externs()
             .get_chain_randomness_looking_forward(personalization, rand_epoch, entropy)
-            .map(|r| Randomness(r.to_vec()))
             .or_illegal_argument()
     }
 
@@ -692,13 +691,12 @@ where
         personalization: DomainSeparationTag,
         rand_epoch: ChainEpoch,
         entropy: &[u8],
-    ) -> Result<Randomness> {
+    ) -> Result<[u8; RANDOMNESS_LENGTH]> {
         // TODO: Check error code
         // Hyperdrive and above only.
         self.call_manager
             .externs()
             .get_beacon_randomness_looking_forward(personalization, rand_epoch, entropy)
-            .map(|r| Randomness(r.to_vec()))
             .or_illegal_argument()
     }
 }

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -9,7 +9,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::RawBytes;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PieceInfo;
-use fvm_shared::randomness::Randomness;
+use fvm_shared::randomness::{Randomness, RANDOMNESS_LENGTH};
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
 };
@@ -256,7 +256,7 @@ pub trait RandomnessOps {
         personalization: DomainSeparationTag,
         rand_epoch: ChainEpoch,
         entropy: &[u8],
-    ) -> Result<Randomness>;
+    ) -> Result<[u8; RANDOMNESS_LENGTH]>;
 
     /// Randomness returns a (pseudo)random byte array drawing from the latest
     /// beacon from a given epoch and incorporating requisite entropy.
@@ -266,7 +266,7 @@ pub trait RandomnessOps {
         personalization: DomainSeparationTag,
         rand_epoch: ChainEpoch,
         entropy: &[u8],
-    ) -> Result<Randomness>;
+    ) -> Result<[u8; RANDOMNESS_LENGTH]>;
 }
 
 /// Debugging APIs.

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -54,18 +54,9 @@ pub fn hash_blake2b(
     mut context: Context<'_, impl Kernel>,
     data_off: u32,
     data_len: u32,
-    obuf_off: u32,
-) -> Result<()> {
-    const HASH_LEN: usize = 32;
-
-    let hash = {
-        let data = context.memory.try_slice(data_len, data_off)?;
-        context.kernel.hash_blake2b(data)?
-    };
-    assert_eq!(hash.len(), 32);
-    let obuf = context.memory.try_slice_mut(obuf_off, HASH_LEN as u32)?;
-    obuf.copy_from_slice(&hash[..HASH_LEN]);
-    Ok(())
+) -> Result<[u8; 32]> {
+    let data = context.memory.try_slice(data_len, data_off)?;
+    context.kernel.hash_blake2b(data)
 }
 
 /// Computes an unsealed sector CID (CommD) from its constituent piece CIDs

--- a/fvm/src/syscalls/rand.rs
+++ b/fvm/src/syscalls/rand.rs
@@ -1,12 +1,11 @@
 use anyhow::Context as _;
 use fvm_shared::crypto::randomness::DomainSeparationTag;
+use fvm_shared::randomness::RANDOMNESS_LENGTH;
 use num_traits::FromPrimitive;
 
 use super::Context;
 use crate::kernel::{ClassifyResult, Result};
 use crate::Kernel;
-
-const RAND_LEN: usize = 32;
 
 /// Gets 32 bytes of randomness from the ticket chain.
 /// The supplied output buffer must have at least 32 bytes of capacity.
@@ -18,21 +17,15 @@ pub fn get_chain_randomness(
     round: i64, // ChainEpoch
     entropy_off: u32,
     entropy_len: u32,
-    obuf_off: u32,
-) -> Result<()> {
+) -> Result<[u8; RANDOMNESS_LENGTH]> {
     let entropy = context.memory.try_slice(entropy_off, entropy_len)?;
     // TODO determine if this error should lead to an abort.
     let pers = DomainSeparationTag::from_i64(pers)
         .context("invalid domain separation tag")
         .or_illegal_argument()?;
-    let randomness = context
+    context
         .kernel
-        .get_randomness_from_tickets(pers, round, entropy)?;
-    assert_eq!(randomness.0.len(), RAND_LEN);
-
-    let obuf = context.memory.try_slice_mut(obuf_off, RAND_LEN as u32)?;
-    obuf.copy_from_slice(randomness.0.as_slice());
-    Ok(())
+        .get_randomness_from_tickets(pers, round, entropy)
 }
 
 /// Gets 32 bytes of randomness from the beacon system (currently Drand).
@@ -45,19 +38,13 @@ pub fn get_beacon_randomness(
     round: i64, // ChainEpoch
     entropy_off: u32,
     entropy_len: u32,
-    obuf_off: u32,
-) -> Result<()> {
+) -> Result<[u8; RANDOMNESS_LENGTH]> {
     let entropy = context.memory.try_slice(entropy_off, entropy_len)?;
     // TODO determine if this error should lead to an abort.
     let pers = DomainSeparationTag::from_i64(pers)
         .context("invalid domain separation tag")
         .or_illegal_argument()?;
-    let randomness = context
+    context
         .kernel
-        .get_randomness_from_beacon(pers, round, entropy)?;
-    assert_eq!(randomness.0.len(), RAND_LEN);
-
-    let obuf = context.memory.try_slice_mut(obuf_off, RAND_LEN as u32)?;
-    obuf.copy_from_slice(randomness.0.as_slice());
-    Ok(())
+        .get_randomness_from_beacon(pers, round, entropy)
 }

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -38,10 +38,8 @@ pub fn verify_signature(
 
 /// Hashes input data using blake2b with 256 bit output.
 #[allow(unused)]
-pub fn hash_blake2b(data: &[u8]) -> SyscallResult<Vec<u8>> {
-    let mut ret = Vec::with_capacity(32);
-    unsafe { sys::crypto::hash_blake2b(data.as_ptr(), data.len() as u32, ret.as_mut_ptr())? }
-    Ok(ret)
+pub fn hash_blake2b(data: &[u8]) -> SyscallResult<[u8; 32]> {
+    unsafe { sys::crypto::hash_blake2b(data.as_ptr(), data.len() as u32) }
 }
 
 /// Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.

--- a/sdk/src/rand.rs
+++ b/sdk/src/rand.rs
@@ -1,6 +1,6 @@
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::randomness::DomainSeparationTag;
-use fvm_shared::randomness::{Randomness, RANDOMNESS_LENGTH};
+use fvm_shared::randomness::Randomness;
 
 use crate::{sys, SyscallResult};
 
@@ -13,16 +13,14 @@ pub fn get_chain_randomness(
     round: ChainEpoch,
     entropy: &[u8],
 ) -> SyscallResult<Randomness> {
-    let mut ret = [0u8; RANDOMNESS_LENGTH];
-    unsafe {
+    let ret = unsafe {
         sys::rand::get_chain_randomness(
             dst as i64,
             round as i64,
             entropy.as_ptr(),
             entropy.len() as u32,
-            ret.as_mut_ptr(),
         )?
-    }
+    };
     Ok(Randomness(ret.to_vec()))
 }
 
@@ -35,15 +33,13 @@ pub fn get_beacon_randomness(
     round: ChainEpoch,
     entropy: &[u8],
 ) -> SyscallResult<Randomness> {
-    let mut ret = [0u8; RANDOMNESS_LENGTH];
-    unsafe {
+    let ret = unsafe {
         sys::rand::get_beacon_randomness(
             dst as i64,
             round as i64,
             entropy.as_ptr(),
             entropy.len() as u32,
-            ret.as_mut_ptr(),
         )?
-    }
+    };
     Ok(Randomness(ret.to_vec()))
 }

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -17,8 +17,7 @@ super::fvm_syscalls! {
     pub fn hash_blake2b(
         data_off: *const u8,
         data_len: u32,
-        obuf_off: *mut u8,
-    ) -> Result<()>;
+    ) -> Result<[u8; 32]>;
 
     /// Computes an unsealed sector CID (CommD) from its constituent piece CIDs
     /// (CommPs) and sizes.

--- a/sdk/src/sys/rand.rs
+++ b/sdk/src/sys/rand.rs
@@ -1,3 +1,5 @@
+use fvm_shared::randomness::RANDOMNESS_LENGTH;
+
 super::fvm_syscalls! {
     module = "rand";
 
@@ -10,8 +12,7 @@ super::fvm_syscalls! {
         round: i64,
         entropy_offset: *const u8,
         entropy_len: u32,
-        obuf: *mut u8,
-    ) -> Result<()>;
+    ) -> Result<[u8; RANDOMNESS_LENGTH]>;
 
     /// Gets 32 bytes of randomness from the beacon system (currently Drand).
     /// The supplied output buffer must have at least 32 bytes of capacity.
@@ -22,6 +23,5 @@ super::fvm_syscalls! {
         round: i64,
         entropy_offset: *const u8,
         entropy_len: u32,
-        obuf: *mut u8,
-    ) -> Result<()>;
+    ) -> Result<[u8; RANDOMNESS_LENGTH]>;
 }

--- a/shared/src/randomness/mod.rs
+++ b/shared/src/randomness/mod.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::encoding::{BytesDe, BytesSer};
 
+// TODO: turn this back into a 32byte array once we no longer need go compat. It's a vec so that the
+// errors match.
 /// String of random bytes usually generated from a randomness beacon or from tickets on chain.
 #[derive(PartialEq, Eq, Default, Clone, Debug)]
 pub struct Randomness(pub Vec<u8>);

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -17,7 +17,7 @@ use fvm_shared::crypto::signature::Signature;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PieceInfo;
-use fvm_shared::randomness::Randomness;
+use fvm_shared::randomness::RANDOMNESS_LENGTH;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
 };
@@ -514,7 +514,7 @@ where
         personalization: DomainSeparationTag,
         rand_epoch: ChainEpoch,
         entropy: &[u8],
-    ) -> Result<Randomness> {
+    ) -> Result<[u8; RANDOMNESS_LENGTH]> {
         self.0
             .get_randomness_from_tickets(personalization, rand_epoch, entropy)
     }
@@ -524,7 +524,7 @@ where
         personalization: DomainSeparationTag,
         rand_epoch: ChainEpoch,
         entropy: &[u8],
-    ) -> Result<Randomness> {
+    ) -> Result<[u8; RANDOMNESS_LENGTH]> {
         self.0
             .get_randomness_from_beacon(personalization, rand_epoch, entropy)
     }


### PR DESCRIPTION
This is functionally equivalent to writing it to an out parameter, but more consistent with the rest of the code.

Unfortunately, we can't just make `Randomness` a `[u8; 32]` because decoding inconsistencies with the go specs-actors (for now).