### PR TITLE
Harden actor deletion (and some other errors)

### DIFF
--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -249,12 +249,11 @@ where
         }
 
         // Deduct message inclusion gas cost and increment sequence.
-        self.state_tree_mut()
-            .mutate_actor(&Address::new_id(sender_id), |act| {
-                act.deduct_funds(&gas_cost)?;
-                act.sequence += 1;
-                Ok(())
-            })?;
+        self.state_tree_mut().mutate_actor_id(sender_id, |act| {
+            act.deduct_funds(&gas_cost)?;
+            act.sequence += 1;
+            Ok(())
+        })?;
 
         Ok(Ok((sender_id, gas_cost, inclusion_cost)))
     }

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -121,7 +121,7 @@ pub trait BlockOps {
 /// Depends on BlockOps to read and write blocks in the state tree.
 pub trait SelfOps: BlockOps {
     /// Get the state root.
-    fn root(&self) -> Cid;
+    fn root(&self) -> Result<Cid>;
 
     /// Update the state-root.
     ///

--- a/fvm/src/syscalls/sself.rs
+++ b/fvm/src/syscalls/sself.rs
@@ -10,7 +10,7 @@ use crate::kernel::{ClassifyResult, Kernel, Result};
 /// buffer is smaller, no value will have been written. The caller must retry
 /// with a larger buffer.
 pub fn root(context: Context<'_, impl Kernel>, obuf_off: u32, obuf_len: u32) -> Result<u32> {
-    let root = context.kernel.root();
+    let root = context.kernel.root()?;
     let size = super::encoded_cid_size(&root);
 
     if size <= obuf_len {

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -19,8 +19,7 @@ pub enum ExitCode {
     /// Indicates failure to find an actor in the state tree.
     SysErrSenderInvalid = 1,
 
-    /// Indicates that the message sender was not in a valid state to send this message. This means
-    /// that the message shouldn't have been included on-chain.
+    /// Indicates that the message sender was not in a valid state to send this message.
     ///
     /// Either:
     /// - The sender's nonce nonce didn't match the message nonce.

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -19,13 +19,18 @@ pub enum ExitCode {
     /// Indicates failure to find an actor in the state tree.
     SysErrSenderInvalid = 1,
 
-    /// Indicates failure to find the code for an actor.
+    /// Indicates that the message sender was not in a valid state to send this message. This means
+    /// that the message shouldn't have been included on-chain.
+    ///
+    /// Either:
+    /// - The sender's nonce nonce didn't match the message nonce.
+    /// - The sender didn't have the funds to cover the message gas.
     SysErrSenderStateInvalid = 2,
 
     /// Indicates failure to find a method in an actor.
     SysErrInvalidMethod = 3,
 
-    /// Used for catching panics currently. (marked as unused/SysErrReserved1 in go impl though)
+    /// Used for catching panics currently.
     SysErrActorPanic = 4,
 
     /// Indicates that the receiver of a message is not valid (and cannot be implicitly created).

--- a/shared/src/sector/registered_proof.rs
+++ b/shared/src/sector/registered_proof.rs
@@ -24,6 +24,9 @@ pub enum RegisteredSealProof {
     StackedDRG8MiBV1P1,
     StackedDRG32GiBV1P1,
     StackedDRG64GiBV1P1,
+    // TODO: get rid of this option once we no longer need go compat.
+    // We use it to ensure that we can deserialize bad values here because go checks this value
+    // later.
     Invalid(i64),
 }
 

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -535,7 +535,7 @@ where
     C: CallManager<Machine = TestMachine<M>>,
     K: Kernel<CallManager = TestCallManager<C>>,
 {
-    fn root(&self) -> Cid {
+    fn root(&self) -> Result<Cid> {
         self.0.root()
     }
 


### PR DESCRIPTION
These cases should be unreachable in our current actors, but would not have been unreachable in user programmable actors.

Fixes #185 by _not_ returning fatal errors if the current actor doesn't exist in state.

After deletion:

1. Actors have "zero" balance.
2. Getting & setting the root fails with "illegal actor".
3. Sending still works, but sending with a value will fail because the balance is zero.
4. Sending _to_ this actor will fail.

Effectively, I'm treating "deletion" as "unlinking" the actor in the state-tree. It still _exists_ until it returns, it just can't be looked-up or linked back into the state.

NOTE: the exact error codes will change with https://github.com/filecoin-project/fvm-specs/pull/53.