### PR TITLE
feat: remove errors from infallible sdk functions

### DIFF
--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -84,7 +84,7 @@ impl Actor {
         log::trace!("called exec; params.code_cid: {:?}", &params.code_cid);
 
         let caller_code = rt
-            .get_actor_code_cid(&rt.message().caller())?
+            .get_actor_code_cid(&rt.message().caller())
             .ok_or_else(|| {
                 actor_error!(
                     ErrIllegalState,

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -257,7 +257,7 @@ impl Actor {
 
         // All deals should have the same provider so get worker once
         let provider_raw = params.deals[0].proposal.provider;
-        let provider = rt.resolve_address(&provider_raw)?.ok_or_else(|| {
+        let provider = rt.resolve_address(&provider_raw).ok_or_else(|| {
             actor_error!(
                 ErrNotFound,
                 "failed to resolve provider address {}",
@@ -265,7 +265,7 @@ impl Actor {
             )
         })?;
 
-        let code_id = rt.get_actor_code_cid(&provider)?.ok_or_else(|| {
+        let code_id = rt.get_actor_code_cid(&provider).ok_or_else(|| {
             actor_error!(ErrIllegalArgument, "no code ID for address {}", provider)
         })?;
         if code_id != *MINER_ACTOR_CODE_ID {
@@ -329,7 +329,7 @@ impl Actor {
                 continue;
             }
             let client = match rt.resolve_address(&deal.proposal.client) {
-                Ok(Some(client)) => client,
+                Some(client) => client,
                 _ => {
                     info!(
                         "invalid deal {}: failed to resolve proposal.client address {} for deal",
@@ -1359,7 +1359,7 @@ where
         proposal.piece_size,
         network_raw_power,
         baseline_power,
-        &rt.total_fil_circ_supply()?,
+        &rt.total_fil_circ_supply(),
     );
     if proposal.provider_collateral < min_provider_collateral
         || proposal.provider_collateral > max_provider_collateral
@@ -1418,11 +1418,11 @@ where
 {
     // Resolve the provided address to the canonical form against which the balance is held.
     let nominal = rt
-        .resolve_address(addr)?
+        .resolve_address(addr)
         .ok_or_else(|| actor_error!(ErrIllegalArgument, "failed to resolve address {}", addr))?;
 
     let code_id = rt
-        .get_actor_code_cid(&nominal)?
+        .get_actor_code_cid(&nominal)
         .ok_or_else(|| actor_error!(ErrIllegalArgument, "no code for address {}", nominal))?;
 
     if code_id == *MINER_ACTOR_CODE_ID {

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -672,7 +672,7 @@ impl Actor {
 
         let state: State = rt.state()?;
         state
-            .check_balance_invariants(&rt.current_balance()?)
+            .check_balance_invariants(&rt.current_balance())
             .map_err(|e| {
                 ActorError::new(
                     ErrBalanceInvariantBroken,
@@ -859,7 +859,7 @@ impl Actor {
         let aggregate_fee =
             aggregate_prove_commit_network_fee(precommits_to_confirm.len() as i64, &rt.base_fee());
         let unlocked_balance = state
-            .get_unlocked_balance(&rt.current_balance()?)
+            .get_unlocked_balance(&rt.current_balance())
             .map_err(|_e| actor_error!(ErrIllegalState, "failed to determine unlocked balance"))?;
         if unlocked_balance < aggregate_fee {
             return Err(actor_error!(
@@ -871,7 +871,7 @@ impl Actor {
         }
         burn_funds(rt, aggregate_fee)?;
         state
-            .check_balance_invariants(&rt.current_balance()?)
+            .check_balance_invariants(&rt.current_balance())
             .map_err(|e| {
                 ActorError::new(
                     ErrBalanceInvariantBroken,
@@ -1059,7 +1059,7 @@ impl Actor {
                     .repay_partial_debt_in_priority_order(
                         rt.store(),
                         current_epoch,
-                        &rt.current_balance()?,
+                        &rt.current_balance(),
                     )
                     .map_err(|e| {
                         e.downcast_default(ExitCode::ErrIllegalState, "failed to pay debt")
@@ -1093,7 +1093,7 @@ impl Actor {
         notify_pledge_changed(rt, &pledge_delta)?;
 
         let st: State = rt.state()?;
-        st.check_balance_invariants(&rt.current_balance()?)
+        st.check_balance_invariants(&rt.current_balance())
             .map_err(|e| {
                 ActorError::new(
                     ErrBalanceInvariantBroken,
@@ -1268,7 +1268,7 @@ impl Actor {
             // this before RepayDebts. We would have to
             // subtract fee debt explicitly if we called this after.
             let available_balance = state
-                .get_available_balance(&rt.current_balance()?)
+                .get_available_balance(&rt.current_balance())
                 .map_err(|e| {
                     actor_error!(
                         ErrIllegalState,
@@ -1380,7 +1380,7 @@ impl Actor {
         burn_funds(rt, fee_to_burn)?;
         let state: State = rt.state()?;
         state
-            .check_balance_invariants(&rt.current_balance()?)
+            .check_balance_invariants(&rt.current_balance())
             .map_err(|e| {
                 ActorError::new(
                     ErrBalanceInvariantBroken,
@@ -2036,7 +2036,7 @@ impl Actor {
         }
         let state: State = rt.state()?;
         state
-            .check_balance_invariants(&rt.current_balance()?)
+            .check_balance_invariants(&rt.current_balance())
             .map_err(|e| {
                 ActorError::new(
                     ErrBalanceInvariantBroken,
@@ -2326,7 +2326,7 @@ impl Actor {
         burn_funds(rt, fee_to_burn)?;
         let state: State = rt.state()?;
         state
-            .check_balance_invariants(&rt.current_balance()?)
+            .check_balance_invariants(&rt.current_balance())
             .map_err(|e| {
                 ActorError::new(
                     ErrBalanceInvariantBroken,
@@ -2574,15 +2574,15 @@ impl Actor {
 
             // This ensures the miner has sufficient funds to lock up amountToLock.
             // This should always be true if reward actor sends reward funds with the message.
-            let unlocked_balance =
-                st.get_unlocked_balance(&rt.current_balance()?)
-                    .map_err(|e| {
-                        actor_error!(
-                            ErrIllegalState,
-                            "failed to calculate unlocked balance: {}",
-                            e
-                        )
-                    })?;
+            let unlocked_balance = st
+                .get_unlocked_balance(&rt.current_balance())
+                .map_err(|e| {
+                    actor_error!(
+                        ErrIllegalState,
+                        "failed to calculate unlocked balance: {}",
+                        e
+                    )
+                })?;
 
             if unlocked_balance < reward_to_lock {
                 return Err(actor_error!(
@@ -2620,7 +2620,7 @@ impl Actor {
                 .repay_partial_debt_in_priority_order(
                     rt.store(),
                     rt.curr_epoch(),
-                    &rt.current_balance()?,
+                    &rt.current_balance(),
                 )
                 .map_err(|e| {
                     e.downcast_default(ExitCode::ErrIllegalState, "failed to repay penalty")
@@ -2633,7 +2633,7 @@ impl Actor {
         notify_pledge_changed(rt, &pledge_delta_total)?;
         burn_funds(rt, to_burn)?;
         let st: State = rt.state()?;
-        st.check_balance_invariants(&rt.current_balance()?)
+        st.check_balance_invariants(&rt.current_balance())
             .map_err(|e| {
                 ActorError::new(
                     ErrBalanceInvariantBroken,
@@ -2714,7 +2714,7 @@ impl Actor {
                 .repay_partial_debt_in_priority_order(
                     rt.store(),
                     rt.curr_epoch(),
-                    &rt.current_balance()?,
+                    &rt.current_balance(),
                 )
                 .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "failed to pay fees"))?;
 
@@ -2743,7 +2743,7 @@ impl Actor {
 
         let state: State = rt.state()?;
         state
-            .check_balance_invariants(&rt.current_balance()?)
+            .check_balance_invariants(&rt.current_balance())
             .map_err(|e| {
                 ActorError::new(
                     ErrBalanceInvariantBroken,
@@ -2798,7 +2798,7 @@ impl Actor {
                 // this before RepayDebts. We would have to
                 // subtract fee debt explicitly if we called this after.
                 let available_balance = state
-                    .get_available_balance(&rt.current_balance()?)
+                    .get_available_balance(&rt.current_balance())
                     .map_err(|e| {
                         actor_error!(
                             ErrIllegalState,
@@ -2849,7 +2849,7 @@ impl Actor {
         notify_pledge_changed(rt, &newly_vested.neg())?;
 
         state
-            .check_balance_invariants(&rt.current_balance()?)
+            .check_balance_invariants(&rt.current_balance())
             .map_err(|e| {
                 ActorError::new(
                     ErrBalanceInvariantBroken,
@@ -2879,7 +2879,7 @@ impl Actor {
                 .repay_partial_debt_in_priority_order(
                     rt.store(),
                     rt.curr_epoch(),
-                    &rt.current_balance()?,
+                    &rt.current_balance(),
                 )
                 .map_err(|e| {
                     e.downcast_default(ExitCode::ErrIllegalState, "failed to unlock fee debt")
@@ -2893,7 +2893,7 @@ impl Actor {
         burn_funds(rt, burn_amount)?;
 
         state
-            .check_balance_invariants(&rt.current_balance()?)
+            .check_balance_invariants(&rt.current_balance())
             .map_err(|e| {
                 ActorError::new(
                     ErrBalanceInvariantBroken,
@@ -2947,7 +2947,7 @@ impl Actor {
         };
         let state: State = rt.state()?;
         state
-            .check_balance_invariants(&rt.current_balance()?)
+            .check_balance_invariants(&rt.current_balance())
             .map_err(|e| {
                 ActorError::new(
                     ErrBalanceInvariantBroken,
@@ -3054,7 +3054,7 @@ where
                 .repay_partial_debt_in_priority_order(
                     rt.store(),
                     rt.curr_epoch(),
-                    &rt.current_balance()?,
+                    &rt.current_balance(),
                 )
                 .map_err(|e| {
                     e.downcast_default(ExitCode::ErrIllegalState, "failed to repay penalty")
@@ -3179,7 +3179,7 @@ where
             .repay_partial_debt_in_priority_order(
                 rt.store(),
                 rt.curr_epoch(),
-                &rt.current_balance()?,
+                &rt.current_balance(),
             )
             .map_err(|e| {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to unlock penalty")
@@ -3739,11 +3739,11 @@ where
     RT: Runtime<BS>,
 {
     let resolved = rt
-        .resolve_address(&raw)?
+        .resolve_address(&raw)
         .ok_or_else(|| actor_error!(ErrIllegalArgument, "unable to resolve address: {}", raw))?;
 
     let owner_code = rt
-        .get_actor_code_cid(&resolved)?
+        .get_actor_code_cid(&resolved)
         .ok_or_else(|| actor_error!(ErrIllegalArgument, "no code for address: {}", resolved))?;
     if !is_principal(&owner_code) {
         return Err(actor_error!(
@@ -3764,11 +3764,11 @@ where
     RT: Runtime<BS>,
 {
     let resolved = rt
-        .resolve_address(&raw)?
+        .resolve_address(&raw)
         .ok_or_else(|| actor_error!(ErrIllegalArgument, "unable to resolve address: {}", raw))?;
 
     let worker_code = rt
-        .get_actor_code_cid(&resolved)?
+        .get_actor_code_cid(&resolved)
         .ok_or_else(|| actor_error!(ErrIllegalArgument, "no code for address: {}", resolved))?;
     if worker_code != *ACCOUNT_ACTOR_CODE_ID {
         return Err(actor_error!(
@@ -3842,12 +3842,12 @@ where
 fn assign_proving_period_offset(
     addr: Address,
     current_epoch: ChainEpoch,
-    blake2b: impl FnOnce(&[u8]) -> anyhow::Result<[u8; 32]>,
+    blake2b: impl FnOnce(&[u8]) -> [u8; 32],
 ) -> anyhow::Result<ChainEpoch> {
     let mut my_addr = addr.marshal_cbor()?;
     my_addr.write_i64::<BigEndian>(current_epoch)?;
 
-    let digest = blake2b(&my_addr)?;
+    let digest = blake2b(&my_addr);
 
     let mut offset: u64 = BigEndian::read_u64(&digest);
     offset %= WPOST_PROVING_PERIOD as u64;
@@ -4022,7 +4022,7 @@ where
     BS: Blockstore,
     RT: Runtime<BS>,
 {
-    let res = state.repay_debts(&rt.current_balance()?).map_err(|e| {
+    let res = state.repay_debts(&rt.current_balance()).map_err(|e| {
         e.downcast_default(
             ExitCode::ErrIllegalState,
             "unlocked balance can not repay fee debt",
@@ -4129,7 +4129,7 @@ where
     RT: Runtime<BS>,
 {
     // get network stats from other actors
-    let circulating_supply = rt.total_fil_circ_supply()?;
+    let circulating_supply = rt.total_fil_circ_supply();
 
     // Ideally, we'd combine some of these operations, but at least we have
     // a constant number of them.
@@ -4328,7 +4328,7 @@ where
             .map_err(|e| actor_error!(ErrIllegalState, "failed to add precommit deposit: {}", e))?;
 
         let unlocked_balance = state
-            .get_unlocked_balance(&rt.current_balance()?)
+            .get_unlocked_balance(&rt.current_balance())
             .map_err(|e| {
                 actor_error!(
                     ErrIllegalState,
@@ -4350,7 +4350,7 @@ where
             .map_err(|e| actor_error!(ErrIllegalState, "failed to add initial pledge: {}", e))?;
 
         state
-            .check_balance_invariants(&rt.current_balance()?)
+            .check_balance_invariants(&rt.current_balance())
             .map_err(|e| {
                 ActorError::new(
                     ErrBalanceInvariantBroken,

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -605,7 +605,7 @@ where
     let mut applied = false;
     let threshold_met = txn.approved.len() as u64 >= st.num_approvals_threshold;
     if threshold_met {
-        st.check_available(rt.current_balance()?, &txn.value, rt.curr_epoch())
+        st.check_available(rt.current_balance(), &txn.value, rt.curr_epoch())
             .map_err(|e| {
                 actor_error!(ErrInsufficientFunds, "insufficient funds unlocked: {}", e)
             })?;
@@ -703,7 +703,7 @@ fn compute_proposal_hash(txn: &Transaction, sys: &dyn Syscalls) -> anyhow::Resul
     let data = to_vec(&proposal_hash)
         .map_err(|e| ActorError::from(e).wrap("failed to construct multisig approval hash"))?;
 
-    sys.hash_blake2b(&data)
+    Ok(sys.hash_blake2b(&data))
 }
 
 impl ActorCode for Actor {

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -97,7 +97,7 @@ impl Actor {
         })?;
 
         let code_cid = rt
-            .get_actor_code_cid(&resolved)?
+            .get_actor_code_cid(&resolved)
             .ok_or_else(|| actor_error!(ErrIllegalArgument, "no code for address {}", resolved))?;
 
         if code_cid != *ACCOUNT_ACTOR_CODE_ID {
@@ -162,7 +162,7 @@ impl Actor {
         })?;
 
         let pch_addr = rt.message().receiver();
-        let svpch_id_addr = rt.resolve_address(&sv.channel_addr)?.ok_or_else(|| {
+        let svpch_id_addr = rt.resolve_address(&sv.channel_addr).ok_or_else(|| {
             actor_error!(
                 ErrIllegalArgument,
                 "voucher payment channel address {} does not resolve to an ID address",
@@ -189,9 +189,7 @@ impl Actor {
         }
 
         if !sv.secret_pre_image.is_empty() {
-            let hashed_secret: &[u8] = &rt
-                .hash_blake2b(&params.secret)
-                .map_err(|e| e.downcast_fatal("unexpected error from blake2b hash"))?;
+            let hashed_secret: &[u8] = &rt.hash_blake2b(&params.secret);
             if hashed_secret != sv.secret_pre_image.as_slice() {
                 return Err(actor_error!(ErrIllegalArgument; "incorrect secret"));
             }
@@ -274,7 +272,7 @@ impl Actor {
                     "voucher would leave channel balance negative"));
             }
 
-            if new_send_balance > rt.current_balance()? {
+            if new_send_balance > rt.current_balance() {
                 return Err(actor_error!(ErrIllegalArgument;
                     "not enough funds in channel to cover voucher"));
             }

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -394,7 +394,7 @@ impl Actor {
                 )
             })?;
 
-            rt.charge_gas("OnSubmitVerifySeal", GAS_ON_SUBMIT_VERIFY_SEAL)?;
+            rt.charge_gas("OnSubmitVerifySeal", GAS_ON_SUBMIT_VERIFY_SEAL);
             st.proof_validation_batch = Some(mmrc);
             Ok(())
         })?;

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -108,7 +108,7 @@ impl Actor {
         RT: Runtime<BS>,
     {
         rt.validate_immediate_caller_is(std::iter::once(&*SYSTEM_ACTOR_ADDR))?;
-        let prior_balance = rt.current_balance()?;
+        let prior_balance = rt.current_balance();
         if params.penalty.sign() == Sign::Minus {
             return Err(actor_error!(
                 ErrIllegalArgument,
@@ -140,7 +140,7 @@ impl Actor {
         }
 
         let miner_addr = rt
-            .resolve_address(&params.miner)?
+            .resolve_address(&params.miner)
             .ok_or_else(|| actor_error!(ErrNotFound, "failed to resolve given owner address"))?;
 
         let penalty: TokenAmount = &params.penalty * PENALTY_MULTIPLIER;
@@ -149,7 +149,7 @@ impl Actor {
             let mut block_reward: TokenAmount = (&st.this_epoch_reward * params.win_count)
                 .div_floor(&TokenAmount::from(EXPECTED_LEADERS_PER_EPOCH));
             let mut total_reward = &params.gas_reward + &block_reward;
-            let curr_balance = rt.current_balance()?;
+            let curr_balance = rt.current_balance();
             if total_reward > curr_balance {
                 warn!(
                     "reward actor balance {} below totalReward expected {},\

--- a/actors/runtime/src/builtin/shared.rs
+++ b/actors/runtime/src/builtin/shared.rs
@@ -18,7 +18,7 @@ where
     RT: Runtime<BS>,
 {
     // if we are able to resolve it to an ID address, return the resolved address
-    if let Some(addr) = rt.resolve_address(address)? {
+    if let Some(addr) = rt.resolve_address(address) {
         return Ok(addr);
     }
 
@@ -36,7 +36,7 @@ where
         ))
     })?;
 
-    rt.resolve_address(address)?.ok_or_else(|| {
+    rt.resolve_address(address).ok_or_else(|| {
         anyhow::anyhow!(
             "failed to resolve address {} to ID address even after sending zero balance",
             address,

--- a/actors/runtime/src/runtime/fvm.rs
+++ b/actors/runtime/src/runtime/fvm.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use anyhow::{anyhow, Error};
 use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
@@ -88,7 +86,7 @@ where
     B: Blockstore,
 {
     fn network_version(&self) -> NetworkVersion {
-        fvm::network::version().unwrap()
+        fvm::network::version()
     }
 
     fn message(&self) -> &dyn MessageInfo {
@@ -96,7 +94,7 @@ where
     }
 
     fn curr_epoch(&self) -> ChainEpoch {
-        fvm::network::curr_epoch().unwrap()
+        fvm::network::curr_epoch()
     }
 
     fn validate_immediate_caller_accept_any(&mut self) -> Result<(), ActorError> {
@@ -128,7 +126,7 @@ where
 
         let caller_addr = self.message().caller();
         let caller_cid = self
-            .get_actor_code_cid(&caller_addr)?
+            .get_actor_code_cid(&caller_addr)
             .expect("failed to lookup caller code");
         if types.into_iter().any(|c| *c == caller_cid) {
             Ok(())
@@ -139,16 +137,16 @@ where
         }
     }
 
-    fn current_balance(&self) -> Result<TokenAmount, ActorError> {
-        Ok(fvm::sself::current_balance()?)
+    fn current_balance(&self) -> TokenAmount {
+        fvm::sself::current_balance()
     }
 
-    fn resolve_address(&self, address: &Address) -> Result<Option<Address>, ActorError> {
-        Ok(fvm::actor::resolve_address(*address)?.map(Address::new_id))
+    fn resolve_address(&self, address: &Address) -> Option<Address> {
+        fvm::actor::resolve_address(address).map(Address::new_id)
     }
 
-    fn get_actor_code_cid(&self, addr: &Address) -> Result<Option<Cid>, ActorError> {
-        Ok(fvm::actor::get_actor_code_cid(*addr)?)
+    fn get_actor_code_cid(&self, addr: &Address) -> Option<Cid> {
+        fvm::actor::get_actor_code_cid(addr)
     }
 
     fn get_randomness_from_tickets(
@@ -248,23 +246,23 @@ where
     }
 
     fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {
-        Ok(fvm::actor::create_actor(actor_id, code_id)?)
+        Ok(fvm::actor::create_actor(actor_id, &code_id)?)
     }
 
     fn delete_actor(&mut self, beneficiary: &Address) -> Result<(), ActorError> {
-        Ok(fvm::sself::self_destruct(*beneficiary)?)
+        Ok(fvm::sself::self_destruct(beneficiary)?)
     }
 
-    fn total_fil_circ_supply(&self) -> Result<TokenAmount, ActorError> {
-        Ok(fvm::network::total_fil_circ_supply()?)
+    fn total_fil_circ_supply(&self) -> TokenAmount {
+        fvm::network::total_fil_circ_supply()
     }
 
-    fn charge_gas(&mut self, name: &'static str, compute: i64) -> Result<(), ActorError> {
-        Ok(fvm::gas::charge(name, compute as u64)?)
+    fn charge_gas(&mut self, name: &'static str, compute: i64) {
+        fvm::gas::charge(name, compute as u64)
     }
 
     fn base_fee(&self) -> TokenAmount {
-        fvm::network::base_fee().unwrap()
+        fvm::network::base_fee()
     }
 }
 
@@ -284,9 +282,8 @@ where
         }
     }
 
-    fn hash_blake2b(&self, data: &[u8]) -> Result<[u8; 32], Error> {
+    fn hash_blake2b(&self, data: &[u8]) -> [u8; 32] {
         fvm::crypto::hash_blake2b(data)
-            .map_err(|e| anyhow!("failed to compute blake2b hash; exit code: {}", e))
     }
 
     fn compute_unsealed_sector_cid(

--- a/actors/runtime/src/runtime/mod.rs
+++ b/actors/runtime/src/runtime/mod.rs
@@ -52,15 +52,15 @@ pub trait Runtime<BS: Blockstore>: Syscalls {
         I: IntoIterator<Item = &'a Cid>;
 
     /// The balance of the receiver.
-    fn current_balance(&self) -> Result<TokenAmount, ActorError>;
+    fn current_balance(&self) -> TokenAmount;
 
     /// Resolves an address of any protocol to an ID address (via the Init actor's table).
     /// This allows resolution of externally-provided SECP, BLS, or actor addresses to the canonical form.
     /// If the argument is an ID address it is returned directly.
-    fn resolve_address(&self, address: &Address) -> Result<Option<Address>, ActorError>;
+    fn resolve_address(&self, address: &Address) -> Option<Address>;
 
     /// Look up the code ID at an actor address.
-    fn get_actor_code_cid(&self, addr: &Address) -> Result<Option<Cid>, ActorError>;
+    fn get_actor_code_cid(&self, addr: &Address) -> Option<Cid>;
 
     /// Randomness returns a (pseudo)random byte array drawing from the latest
     /// ticket chain from a given epoch and incorporating requisite entropy.
@@ -142,11 +142,11 @@ pub trait Runtime<BS: Blockstore>: Syscalls {
     /// - funds burnt,
     /// - pledge collateral locked in storage miner actors (recorded in the storage power actor)
     /// - deal collateral locked by the storage market actor
-    fn total_fil_circ_supply(&self) -> Result<TokenAmount, ActorError>;
+    fn total_fil_circ_supply(&self) -> TokenAmount;
 
     /// ChargeGas charges specified amount of `gas` for execution.
     /// `name` provides information about gas charging point
-    fn charge_gas(&mut self, name: &'static str, compute: i64) -> Result<(), ActorError>;
+    fn charge_gas(&mut self, name: &'static str, compute: i64);
 
     /// This function is a workaround for go-implementation's faulty exit code handling of
     /// parameters before version 7
@@ -193,7 +193,7 @@ pub trait Syscalls {
     ) -> Result<(), anyhow::Error>;
 
     /// Hashes input data using blake2b with 256 bit output.
-    fn hash_blake2b(&self, data: &[u8]) -> Result<[u8; 32], anyhow::Error>;
+    fn hash_blake2b(&self, data: &[u8]) -> [u8; 32];
 
     /// Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.
     fn compute_unsealed_sector_cid(

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -502,24 +502,24 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
         )
     }
 
-    fn current_balance(&self) -> Result<TokenAmount, ActorError> {
+    fn current_balance(&self) -> TokenAmount {
         self.require_in_call();
-        Ok(self.balance.borrow().clone())
+        self.balance.borrow().clone()
     }
 
-    fn resolve_address(&self, address: &Address) -> Result<Option<Address>, ActorError> {
+    fn resolve_address(&self, address: &Address) -> Option<Address> {
         self.require_in_call();
         if address.protocol() == Protocol::ID {
-            return Ok(Some(*address));
+            return Some(*address);
         }
 
-        Ok(self.id_addresses.get(address).cloned())
+        self.id_addresses.get(address).cloned()
     }
 
-    fn get_actor_code_cid(&self, addr: &Address) -> Result<Option<Cid>, ActorError> {
+    fn get_actor_code_cid(&self, addr: &Address) -> Option<Cid> {
         self.require_in_call();
 
-        Ok(self.actor_code_cids.get(addr).cloned())
+        self.actor_code_cids.get(addr).cloned()
     }
 
     fn get_randomness_from_tickets(
@@ -670,13 +670,13 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
         Ok(())
     }
 
-    fn total_fil_circ_supply(&self) -> Result<TokenAmount, ActorError> {
+    fn total_fil_circ_supply(&self) -> TokenAmount {
         unimplemented!();
     }
 
-    fn charge_gas(&mut self, _: &'static str, _: i64) -> Result<(), ActorError> {
+    fn charge_gas(&mut self, _: &'static str, _: i64) {
         // TODO implement functionality if needed for testing
-        Ok(())
+        ()
     }
 
     fn base_fee(&self) -> TokenAmount {
@@ -730,8 +730,8 @@ impl Syscalls for MockRuntime {
         Ok(())
     }
 
-    fn hash_blake2b(&self, data: &[u8]) -> anyhow::Result<[u8; 32]> {
-        Ok(blake2b_256(data))
+    fn hash_blake2b(&self, data: &[u8]) -> [u8; 32] {
+        blake2b_256(data)
     }
     fn compute_unsealed_sector_cid(
         &self,

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -676,7 +676,6 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
 
     fn charge_gas(&mut self, _: &'static str, _: i64) {
         // TODO implement functionality if needed for testing
-        ()
     }
 
     fn base_fee(&self) -> TokenAmount {

--- a/actors/runtime/src/util/chaos/mod.rs
+++ b/actors/runtime/src/util/chaos/mod.rs
@@ -139,7 +139,7 @@ impl Actor {
         RT: Runtime<BS>,
     {
         rt.validate_immediate_caller_accept_any()?;
-        let resolved = rt.resolve_address(&args)?;
+        let resolved = rt.resolve_address(&args);
         Ok(ResolveAddressResponse {
             address: resolved.unwrap_or_else(|| Address::new_id(0)),
             success: resolved.is_some(),
@@ -190,7 +190,7 @@ impl Actor {
             receiver: rt.message().receiver(),
             value_received: rt.message().value_received(),
             curr_epoch: rt.curr_epoch(),
-            current_balance: rt.current_balance()?,
+            current_balance: rt.current_balance(),
             state: rt.state()?,
         })
     }

--- a/actors/runtime/src/util/downcast.rs
+++ b/actors/runtime/src/util/downcast.rs
@@ -16,10 +16,6 @@ pub trait ActorDowncast {
     /// into an ActorError automatically, use the provided `ExitCode` to generate a new error.
     fn downcast_default(self, default_exit_code: ExitCode, msg: impl AsRef<str>) -> ActorError;
 
-    /// Downcast a dynamic std Error into an `ActorError`. If the error cannot be downcasted
-    /// then it will convert the error into a fatal error.
-    fn downcast_fatal(self, msg: impl AsRef<str>) -> ActorError;
-
     /// Wrap the error with a message, without overwriting an exit code.
     fn downcast_wrap(self, msg: impl AsRef<str>) -> anyhow::Error;
 }
@@ -31,12 +27,6 @@ impl ActorDowncast for anyhow::Error {
             Err(other) => {
                 ActorError::new(default_exit_code, format!("{}: {}", msg.as_ref(), other))
             }
-        }
-    }
-    fn downcast_fatal(self, msg: impl AsRef<str>) -> ActorError {
-        match downcast_util(self) {
-            Ok(actor_error) => actor_error.wrap(msg),
-            Err(other) => ActorError::new_fatal(format!("{}: {}", msg.as_ref(), other)),
         }
     }
     fn downcast_wrap(self, msg: impl AsRef<str>) -> anyhow::Error {
@@ -54,12 +44,6 @@ impl ActorDowncast for AmtError {
             other => ActorError::new(default_exit_code, format!("{}: {}", msg.as_ref(), other)),
         }
     }
-    fn downcast_fatal(self, msg: impl AsRef<str>) -> ActorError {
-        match self {
-            AmtError::Dynamic(e) => e.downcast_fatal(msg),
-            other => ActorError::new_fatal(format!("{}: {}", msg.as_ref(), other)),
-        }
-    }
     fn downcast_wrap(self, msg: impl AsRef<str>) -> anyhow::Error {
         match self {
             AmtError::Dynamic(e) => e.downcast_wrap(msg),
@@ -73,12 +57,6 @@ impl ActorDowncast for HamtError {
         match self {
             HamtError::Dynamic(e) => e.downcast_default(default_exit_code, msg),
             other => ActorError::new(default_exit_code, format!("{}: {}", msg.as_ref(), other)),
-        }
-    }
-    fn downcast_fatal(self, msg: impl AsRef<str>) -> ActorError {
-        match self {
-            HamtError::Dynamic(e) => e.downcast_fatal(msg),
-            other => ActorError::new_fatal(format!("{}: {}", msg.as_ref(), other)),
         }
     }
     fn downcast_wrap(self, msg: impl AsRef<str>) -> anyhow::Error {

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -66,7 +66,7 @@ impl Actor {
 
         // root should be an ID address
         let id_addr = rt
-            .resolve_address(&root_key)?
+            .resolve_address(&root_key)
             .ok_or_else(|| actor_error!(ErrIllegalArgument, "root should be an ID address"))?;
 
         let st = State::new(rt.store(), id_addr).map_err(|e| {

--- a/fvm/src/syscalls/network.rs
+++ b/fvm/src/syscalls/network.rs
@@ -4,8 +4,8 @@ use fvm_shared::sys;
 use super::Context;
 use crate::kernel::{ClassifyResult, Kernel, Result};
 
-pub fn curr_epoch(context: Context<'_, impl Kernel>) -> Result<u64> {
-    Ok(context.kernel.network_epoch() as u64)
+pub fn curr_epoch(context: Context<'_, impl Kernel>) -> Result<i64> {
+    Ok(context.kernel.network_epoch())
 }
 
 pub fn version(context: Context<'_, impl Kernel>) -> Result<u32> {

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -38,8 +38,10 @@ pub fn verify_signature(
 
 /// Hashes input data using blake2b with 256 bit output.
 #[allow(unused)]
-pub fn hash_blake2b(data: &[u8]) -> SyscallResult<[u8; 32]> {
+pub fn hash_blake2b(data: &[u8]) -> [u8; 32] {
+    // This can only fail if we manage to pass in corrupted memory.
     unsafe { sys::crypto::hash_blake2b(data.as_ptr(), data.len() as u32) }
+        .expect("failed to compute blake2b hash")
 }
 
 /// Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.

--- a/sdk/src/debug.rs
+++ b/sdk/src/debug.rs
@@ -36,9 +36,7 @@ impl log::Log for Logger {
         }
     }
 
-    fn flush(&self) {
-        ()
-    }
+    fn flush(&self) {}
 }
 
 /// Initialize logging if debuggig is enabled.

--- a/sdk/src/gas.rs
+++ b/sdk/src/gas.rs
@@ -1,6 +1,8 @@
-use crate::{sys, SyscallResult};
+use crate::sys;
 
 /// Charge gas for the operation identified by name.
-pub fn charge(name: &str, compute: u64) -> SyscallResult<()> {
+pub fn charge(name: &str, compute: u64) {
     unsafe { sys::gas::charge(name.as_ptr(), name.len() as u32, compute) }
+        // can only happen if name isn't utf8, memory corruption, etc.
+        .expect("failed to charge gas")
 }

--- a/sdk/src/ipld.rs
+++ b/sdk/src/ipld.rs
@@ -1,6 +1,6 @@
 use cid::Cid;
 
-use crate::{sself, sys, SyscallResult, MAX_CID_LEN};
+use crate::{sys, SyscallResult, MAX_CID_LEN};
 
 /// The unit/void object.
 pub const UNIT: u32 = sys::ipld::UNIT;
@@ -65,11 +65,4 @@ pub fn put_block(
     data: &[u8],
 ) -> SyscallResult<fvm_shared::sys::BlockId> {
     unsafe { sys::ipld::create(codec, data.as_ptr(), data.len() as u32) }
-}
-
-// Transform the IPLD DAG.
-pub fn transaction(f: impl FnOnce(Cid) -> Option<Cid>) -> SyscallResult<()> {
-    // TODO: Prevent calls, recursive transactions, etc.
-    f(sself::root()?).as_ref().map(sself::set_root);
-    Ok(())
 }

--- a/sdk/src/network.rs
+++ b/sdk/src/network.rs
@@ -4,30 +4,37 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::version::NetworkVersion;
 
-use crate::{sys, SyscallResult};
+use crate::sys;
 
-pub fn curr_epoch() -> SyscallResult<ChainEpoch> {
-    unsafe { Ok(sys::network::curr_epoch()? as ChainEpoch) }
+pub fn curr_epoch() -> ChainEpoch {
+    unsafe {
+        sys::network::curr_epoch()
+            // infallible
+            .expect("failed to get current epoch")
+    }
 }
 
-pub fn version() -> SyscallResult<NetworkVersion> {
+pub fn version() -> NetworkVersion {
     unsafe {
-        Ok(sys::network::version()?
+        sys::network::version()
+            .expect("failed to get network version")
             .try_into()
-            .expect("invalid version"))
+            .expect("invalid version")
     }
 }
 
-pub fn base_fee() -> SyscallResult<TokenAmount> {
+pub fn base_fee() -> TokenAmount {
     unsafe {
-        let v = sys::network::base_fee()?;
-        Ok(v.into())
+        sys::network::base_fee()
+            .expect("failed to get base fee")
+            .into()
     }
 }
 
-pub fn total_fil_circ_supply() -> SyscallResult<TokenAmount> {
+pub fn total_fil_circ_supply() -> TokenAmount {
     unsafe {
-        let v = sys::network::total_fil_circ_supply()?;
-        Ok(v.into())
+        sys::network::total_fil_circ_supply()
+            .expect("failed to get circulating supply")
+            .into()
     }
 }

--- a/sdk/src/sys/network.rs
+++ b/sdk/src/sys/network.rs
@@ -2,7 +2,7 @@ super::fvm_syscalls! {
     module = "network";
 
     /// Gets the current epoch.
-    pub fn curr_epoch() -> Result<u64>;
+    pub fn curr_epoch() -> Result<i64>;
 
     /// Gets the network version.
     pub fn version() -> Result<u32>;


### PR DESCRIPTION
Either:

1. These functions statically cannot fail (https://github.com/filecoin-project/fvm-specs/issues/580 to follow up on this).
2. These functions can only fail when passed invalid data that we've ensured is statically impossible with the type system.

Changes:

- FVM
    - `curr_epoch` syscall returns an i64 to be consistent everywhere.
- SDK
    - Newly infallible: `actor::resolve_address`, `actor::get_actor_code_cid`, `crypto::hash_blake2b`, `gas::charge`, `network::*`, `sself::current_balance`.
    - Removed `ipld::transaction` (dead code).
    - Changed `Address` and `Cid` to by-reference in some cases for better consistency.
- Actors
    - Removed "fatal" errors.
    - Adjusted to new infallible syscalls.

fixes #190