### PR TITLE
feat: remove sdk::message::* error cases

### DIFF
--- a/actors/runtime/src/runtime/fvm.rs
+++ b/actors/runtime/src/runtime/fvm.rs
@@ -69,15 +69,15 @@ struct FvmMessage;
 
 impl MessageInfo for FvmMessage {
     fn caller(&self) -> Address {
-        Address::new_id(fvm::message::caller().unwrap())
+        Address::new_id(fvm::message::caller())
     }
 
     fn receiver(&self) -> Address {
-        Address::new_id(fvm::message::receiver().unwrap())
+        Address::new_id(fvm::message::receiver())
     }
 
     fn value_received(&self) -> TokenAmount {
-        fvm::message::value_received().unwrap()
+        fvm::message::value_received()
     }
 }
 
@@ -349,7 +349,7 @@ where
 pub fn trampoline<C: ActorCode>(params: u32) -> u32 {
     fvm::debug::init_logging();
 
-    let method = fvm::message::method_number().expect("no method number");
+    let method = fvm::message::method_number();
     let params = if params > 0 {
         log::debug!("fetching parameters block: {}", params);
         let params = fvm::message::params_raw(params)

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -11,20 +11,20 @@ pub const NO_DATA_BLOCK_ID: u32 = 0;
 
 /// Returns the ID address of the caller.
 #[inline(always)]
-pub fn caller() -> SyscallResult<ActorID> {
-    unsafe { sys::message::caller() }
+pub fn caller() -> ActorID {
+    unsafe { sys::message::caller().expect("failed to lookup caller ID") }
 }
 
 /// Returns the ID address of the actor.
 #[inline(always)]
-pub fn receiver() -> SyscallResult<ActorID> {
-    unsafe { sys::message::receiver() }
+pub fn receiver() -> ActorID {
+    unsafe { sys::message::receiver().expect("failed to lookup actor ID") }
 }
 
 /// Returns the message's method number.
 #[inline(always)]
-pub fn method_number() -> SyscallResult<MethodNum> {
-    unsafe { sys::message::method_number() }
+pub fn method_number() -> MethodNum {
+    unsafe { sys::message::method_number().expect("failed to lookup method number") }
 }
 
 /// Returns the message codec and parameters.
@@ -56,10 +56,11 @@ pub fn params_raw(id: BlockId) -> SyscallResult<(Codec, Vec<u8>)> {
 
 /// Returns the value received from the caller in AttoFIL.
 #[inline(always)]
-pub fn value_received() -> SyscallResult<TokenAmount> {
+pub fn value_received() -> TokenAmount {
     unsafe {
-        let v = sys::message::value_received()?;
-        Ok(v.into())
+        sys::message::value_received()
+            .expect("failed to lookup received value")
+            .into()
     }
 }
 


### PR DESCRIPTION
These are all infallible, so we might as well just panic at the syscall level.