### PR TITLE
Make the FVM use tuple-based TokenAmount only

### DIFF
--- a/fvm/src/account_actor.rs
+++ b/fvm/src/account_actor.rs
@@ -10,9 +10,9 @@
 use cid::Cid;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
-use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::tuple::*;
 use fvm_shared::encoding::Cbor;
+use fvm_shared::sys::TokenAmount;
 use lazy_static::lazy_static;
 
 use crate::builtin::{ACCOUNT_ACTOR_CODE_ID, EMPTY_ARR_CID};

--- a/fvm/src/account_actor.rs
+++ b/fvm/src/account_actor.rs
@@ -9,7 +9,6 @@
 
 use cid::Cid;
 use fvm_shared::address::Address;
-use fvm_shared::bigint::Zero;
 use fvm_shared::encoding::tuple::*;
 use fvm_shared::encoding::Cbor;
 use fvm_shared::sys::TokenAmount;

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -1,8 +1,8 @@
 use derive_more::{Deref, DerefMut};
 use fvm_shared::address::{Address, Protocol};
-use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::{RawBytes, DAG_CBOR};
 use fvm_shared::error::ExitCode;
+use fvm_shared::sys::TokenAmount;
 use fvm_shared::{ActorID, MethodNum, METHOD_SEND};
 use num_traits::Zero;
 use wasmtime::{Linker, Store};
@@ -27,7 +27,6 @@ use crate::syscalls::error::unwrap_trap;
 ///    2. Call `send` on the call manager to execute the new message.
 ///    3. Re-attach the call manager.
 ///    4. Return.
-
 #[repr(transparent)]
 pub struct DefaultCallManager<M>(Option<InnerDefaultCallManager<M>>);
 
@@ -92,7 +91,7 @@ where
         to: Address,
         method: MethodNum,
         params: &RawBytes,
-        value: &TokenAmount,
+        value: TokenAmount,
     ) -> Result<InvocationResult>
     where
         K: Kernel<CallManager = Self>,
@@ -209,7 +208,7 @@ where
             id,
             fvm_shared::METHOD_CONSTRUCTOR,
             &params,
-            &TokenAmount::from(0u32),
+            TokenAmount::from(0u64),
         )?;
 
         Ok(id)
@@ -222,7 +221,7 @@ where
         to: Address,
         method: MethodNum,
         params: &RawBytes,
-        value: &TokenAmount,
+        value: TokenAmount,
     ) -> Result<InvocationResult>
     where
         K: Kernel<CallManager = Self>,
@@ -240,7 +239,7 @@ where
                     return Err(
                         syscall_error!(SysErrInvalidReceiver; "actor does not exist: {}", to)
                             .into(),
-                    )
+                    );
                 }
             },
         };
@@ -257,7 +256,7 @@ where
         to: ActorID,
         method: MethodNum,
         params: &RawBytes,
-        value: &TokenAmount,
+        value: TokenAmount,
     ) -> Result<InvocationResult>
     where
         K: Kernel<CallManager = Self>,

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -4,7 +4,6 @@ use fvm_shared::encoding::{RawBytes, DAG_CBOR};
 use fvm_shared::error::ExitCode;
 use fvm_shared::sys::TokenAmount;
 use fvm_shared::{ActorID, MethodNum, METHOD_SEND};
-use num_traits::Zero;
 use wasmtime::{Linker, Store};
 
 use super::{CallManager, InvocationResult, NO_DATA_BLOCK_ID};

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -1,7 +1,7 @@
 use fvm_shared::address::Address;
-use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::RawBytes;
 use fvm_shared::error::ExitCode;
+use fvm_shared::sys::TokenAmount;
 use fvm_shared::{ActorID, MethodNum};
 
 use crate::gas::{GasCharge, GasTracker, PriceList};
@@ -11,6 +11,7 @@ use crate::state_tree::StateTree;
 use crate::Kernel;
 
 mod default;
+
 pub use default::DefaultCallManager;
 
 /// BlockID representing nil parameters or return data.
@@ -28,7 +29,7 @@ pub trait CallManager: 'static {
         to: Address,
         method: MethodNum,
         params: &RawBytes,
-        value: &TokenAmount,
+        value: TokenAmount,
     ) -> Result<InvocationResult>;
 
     /// Execute some operation (usually a send) within a transaction.

--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -1,10 +1,10 @@
 mod default;
 
 pub use default::DefaultExecutor;
-use fvm_shared::bigint::{BigInt, Sign};
 use fvm_shared::encoding::RawBytes;
 use fvm_shared::message::Message;
 use fvm_shared::receipt::Receipt;
+use fvm_shared::sys::TokenAmount;
 use num_traits::Zero;
 
 use crate::kernel::SyscallError;
@@ -31,14 +31,14 @@ pub struct ApplyRet {
     /// A backtrace for the transaction, if it failed.
     pub backtrace: Vec<CallError>,
     /// Gas penalty from transaction, if any.
-    pub penalty: BigInt,
+    pub penalty: TokenAmount,
     /// Tip given to miner from message.
-    pub miner_tip: BigInt,
+    pub miner_tip: TokenAmount,
 }
 
 impl ApplyRet {
     #[inline]
-    pub fn prevalidation_fail(error: SyscallError, miner_penalty: BigInt) -> ApplyRet {
+    pub fn prevalidation_fail(error: SyscallError, miner_penalty: TokenAmount) -> ApplyRet {
         ApplyRet {
             msg_receipt: Receipt {
                 exit_code: error.1,
@@ -51,13 +51,13 @@ impl ApplyRet {
                 code: error.1,
                 message: error.0,
             }],
-            miner_tip: BigInt::zero(),
+            miner_tip: TokenAmount::zero(),
         }
     }
-
-    pub fn assign_from_slice(&mut self, sign: Sign, slice: &[u32]) {
-        self.miner_tip.assign_from_slice(sign, slice)
-    }
+    // review: was this used?
+    // pub fn assign_from_slice(&mut self, sign: Sign, slice: &[u32]) {
+    //     self.miner_tip.assign_from_slice(sign, slice)
+    // }
 }
 
 pub enum ApplyKind {

--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -5,7 +5,6 @@ use fvm_shared::encoding::RawBytes;
 use fvm_shared::message::Message;
 use fvm_shared::receipt::Receipt;
 use fvm_shared::sys::TokenAmount;
-use num_traits::Zero;
 
 use crate::kernel::SyscallError;
 use crate::machine::CallError;

--- a/fvm/src/gas/outputs.rs
+++ b/fvm/src/gas/outputs.rs
@@ -29,27 +29,31 @@ impl GasOutputs {
 
         if base_fee > fee_cap {
             base_fee_to_pay = fee_cap;
-            out.miner_penalty = (base_fee - fee_cap) * gas_used
+            out.miner_penalty = ((base_fee - fee_cap).unwrap() * gas_used).unwrap();
         }
 
-        out.base_fee_burn = base_fee_to_pay * gas_used;
+        out.base_fee_burn = (base_fee_to_pay * gas_used).unwrap();
 
         let mut miner_tip = gas_premium.clone();
-        if (base_fee_to_pay + miner_tip) > fee_cap {
-            miner_tip = fee_cap - base_fee_to_pay;
+        if (base_fee_to_pay + miner_tip).unwrap() > fee_cap {
+            miner_tip = (fee_cap - base_fee_to_pay).unwrap();
         }
-        out.miner_tip = &miner_tip * gas_limit;
+        out.miner_tip = (miner_tip * gas_limit).unwrap();
 
         let (out_gas_refund, out_gas_burned) = compute_gas_overestimation_burn(gas_used, gas_limit);
         out.gas_refund = out_gas_refund;
         out.gas_burned = out_gas_burned;
 
         if out.gas_burned != 0 {
-            out.over_estimation_burn = base_fee_to_pay * out.gas_burned;
-            out.miner_penalty = out.miner_penalty + (base_fee - base_fee_to_pay) * out.gas_burned;
+            out.over_estimation_burn = (base_fee_to_pay * out.gas_burned).unwrap();
+            out.miner_penalty = (out.miner_penalty
+                + ((base_fee - base_fee_to_pay).unwrap() * out.gas_burned).unwrap())
+            .unwrap();
         }
-        let required_funds = fee_cap * gas_limit;
-        let refund = required_funds - out.base_fee_burn - out.miner_tip - out.over_estimation_burn;
+        let required_funds = (fee_cap * gas_limit).unwrap();
+        let refund = (((required_funds - out.base_fee_burn).unwrap() - out.miner_tip).unwrap()
+            - out.over_estimation_burn)
+            .unwrap();
         out.refund = refund;
 
         out

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -4,12 +4,12 @@
 use ahash::AHashMap;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::SignatureType;
-use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredPoStProof, RegisteredSealProof, SealVerifyInfo,
     WindowPoStVerifyInfo,
 };
+use fvm_shared::sys::TokenAmount;
 use fvm_shared::{MethodNum, METHOD_SEND};
 use lazy_static::lazy_static;
 use num_traits::Zero;
@@ -132,6 +132,7 @@ pub(crate) struct ScalingCost {
 
 #[derive(Clone, Debug)]
 pub(crate) struct StepCost(Vec<Step>);
+
 #[derive(Clone, Debug, Copy)]
 pub(crate) struct Step {
     start: i64,
@@ -268,11 +269,11 @@ impl PriceList {
     #[inline]
     pub fn on_method_invocation(
         &self,
-        value: &TokenAmount,
+        value: TokenAmount,
         method_num: MethodNum,
     ) -> GasCharge<'static> {
         let mut ret = self.send_base;
-        if value != &TokenAmount::zero() {
+        if !value.is_zero() {
             ret += self.send_transfer_funds;
             if method_num == METHOD_SEND {
                 ret += self.send_transfer_only_premium;

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -12,7 +12,6 @@ use fvm_shared::sector::{
 use fvm_shared::sys::TokenAmount;
 use fvm_shared::{MethodNum, METHOD_SEND};
 use lazy_static::lazy_static;
-use num_traits::Zero;
 
 use super::GasCharge;
 

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -5,7 +5,6 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::randomness::DomainSeparationTag;
 use fvm_shared::crypto::signature::Signature;
-use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::RawBytes;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PieceInfo;
@@ -13,6 +12,7 @@ use fvm_shared::randomness::{Randomness, RANDOMNESS_LENGTH};
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
 };
+use fvm_shared::sys::TokenAmount;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum};
 
@@ -20,6 +20,7 @@ mod blocks;
 pub mod default;
 
 mod error;
+
 pub use error::{ClassifyResult, Context, ExecutionError, Result, SyscallError};
 
 use crate::call_manager::{CallManager, InvocationResult};
@@ -60,7 +61,7 @@ pub trait Kernel:
 pub trait NetworkOps {
     fn network_epoch(&self) -> ChainEpoch;
     fn network_version(&self) -> NetworkVersion;
-    fn network_base_fee(&self) -> &TokenAmount;
+    fn network_base_fee(&self) -> TokenAmount;
 }
 
 /// Accessors to query attributes of the incoming message.
@@ -166,7 +167,7 @@ pub trait SendOps {
         recipient: &Address,
         method: u64,
         params: &RawBytes,
-        value: &TokenAmount,
+        value: TokenAmount,
     ) -> Result<InvocationResult>;
 }
 

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -58,7 +58,7 @@ impl Default for Config {
 mod test {
     use fvm_shared::blockstore::MemoryBlockstore;
     use fvm_shared::state::StateTreeVersion;
-    use num_traits::Zero;
+    use fvm_shared::sys::TokenAmount;
 
     use crate::call_manager::DefaultCallManager;
     use crate::machine::DefaultMachine;
@@ -75,8 +75,8 @@ mod test {
         let machine = DefaultMachine::new(
             Config::default(),
             0,
-            Zero::zero(),
-            Zero::zero(),
+            TokenAmount::zero(),
+            TokenAmount::zero(),
             fvm_shared::version::NetworkVersion::V14,
             root,
             bs,

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -1,6 +1,6 @@
 use cid::Cid;
 use fvm_shared::address::Address;
-use fvm_shared::econ::TokenAmount;
+use fvm_shared::sys::TokenAmount;
 use fvm_shared::ActorID;
 use wasmtime::{Engine, Module};
 
@@ -59,7 +59,7 @@ impl<M: Machine> Machine for Box<M> {
     }
 
     #[inline(always)]
-    fn transfer(&mut self, from: ActorID, to: ActorID, value: &TokenAmount) -> Result<()> {
+    fn transfer(&mut self, from: ActorID, to: ActorID, value: TokenAmount) -> Result<()> {
         (&mut **self).transfer(from, to, value)
     }
 

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -3,13 +3,12 @@ use cid::Cid;
 use fvm_shared::address::Address;
 use fvm_shared::blockstore::{Blockstore, Buffered};
 use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
+use fvm_shared::sys::TokenAmount;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::ActorID;
 use log::Level::Trace;
 use log::{debug, log_enabled, trace};
-use num_traits::Signed;
 use wasmtime::{Engine, Module};
 
 use super::{Machine, MachineContext};
@@ -235,15 +234,16 @@ where
         )))
     }
 
-    fn transfer(&mut self, from: ActorID, to: ActorID, value: &TokenAmount) -> Result<()> {
+    fn transfer(&mut self, from: ActorID, to: ActorID, value: TokenAmount) -> Result<()> {
         if from == to {
             return Ok(());
         }
-        if value.is_negative() {
-            return Err(syscall_error!(SysErrForbidden;
-                "attempted to transfer negative transfer value {}", value)
-            .into());
-        }
+        // review: scary?
+        // if value.is_negative() {
+        //     return Err(syscall_error!(SysErrForbidden;
+        //         "attempted to transfer negative transfer value {}", value)
+        //     .into());
+        // }
 
         let mut from_actor = self
             .state_tree

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -262,7 +262,7 @@ where
                            "transfer failed when deducting funds ({}) from balance ({}): {}",
                            value, &from_actor.balance, e)
         })?;
-        to_actor.deposit_funds(value);
+        to_actor.deposit_funds(value)?;
 
         self.state_tree.set_actor_id(from, from_actor)?;
         self.state_tree.set_actor_id(to, to_actor)?;

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -2,8 +2,8 @@ use cid::Cid;
 use fvm_shared::address::Address;
 use fvm_shared::blockstore::Blockstore;
 use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
+use fvm_shared::sys::TokenAmount;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::ActorID;
 use wasmtime::{Engine, Module};
@@ -15,6 +15,7 @@ use crate::state_tree::{ActorState, StateTree};
 use crate::Config;
 
 mod default;
+
 pub use default::DefaultMachine;
 
 mod boxed;
@@ -61,7 +62,7 @@ pub trait Machine: 'static {
     ///
     /// If either the receiver or the sender do not exist, this method fails with a FATAL error.
     /// Otherwise, if the amounts are invalid, etc., it fails with a syscall error.
-    fn transfer(&mut self, from: ActorID, to: ActorID, value: &TokenAmount) -> Result<()>;
+    fn transfer(&mut self, from: ActorID, to: ActorID, value: TokenAmount) -> Result<()>;
 
     /// Flushes the state-tree and returns the new root CID.
     fn flush(&mut self) -> Result<Cid> {

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -636,7 +636,6 @@ mod tests {
     use cid::multihash::MultihashDigest;
     use cid::Cid;
     use fvm_shared::address::{Address, SECP_PUB_LEN};
-    use fvm_shared::bigint::BigInt;
     use fvm_shared::blockstore::{CborStore, MemoryBlockstore};
     use fvm_shared::encoding::DAG_CBOR;
     use fvm_shared::state::StateTreeVersion;

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -540,13 +540,14 @@ impl ActorState {
         if self.balance < amt {
             return Err(syscall_error!(SysErrInsufficientFunds; "not enough funds").into());
         }
-        self.balance = self.balance - amt;
+        self.balance = (self.balance - amt).unwrap();
 
         Ok(())
     }
     /// Deposits funds to an Actor
-    pub fn deposit_funds(&mut self, amt: TokenAmount) {
-        self.balance = self.balance + amt;
+    pub fn deposit_funds(&mut self, amt: TokenAmount) -> Result<()> {
+        self.balance = (self.balance + amt).unwrap();
+        Ok(())
     }
 }
 

--- a/fvm/src/syscalls/network.rs
+++ b/fvm/src/syscalls/network.rs
@@ -14,12 +14,7 @@ pub fn version(context: Context<'_, impl Kernel>) -> Result<u32> {
 
 /// Returns the base fee split as two u64 ordered in little endian.
 pub fn base_fee(context: Context<'_, impl Kernel>) -> Result<sys::TokenAmount> {
-    context
-        .kernel
-        .network_base_fee()
-        .try_into()
-        .context("base-fee exceeds u128 limit")
-        .or_fatal()
+    Ok(context.kernel.network_base_fee())
 }
 
 /// Returns the network circ supply split as two u64 ordered in little endian.

--- a/fvm/src/syscalls/send.rs
+++ b/fvm/src/syscalls/send.rs
@@ -1,8 +1,8 @@
 use fvm_shared::address::Address;
-use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::DAG_CBOR;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sys;
+use fvm_shared::sys::TokenAmount;
 
 use super::Context;
 use crate::call_manager::{InvocationResult, NO_DATA_BLOCK_ID};
@@ -25,6 +25,7 @@ pub fn send(
     value_lo: u64,
 ) -> Result<sys::out::send::Send> {
     let recipient: Address = context.memory.read_address(recipient_off, recipient_len)?;
+    // review: i assume From a tuple is possible? idk how.
     let value = TokenAmount::from((value_hi as u128) << 64 | value_lo as u128);
     // TODO: consider just passing the block ID directly into the kernel.
     let (code, params) = if params_id > NO_DATA_BLOCK_ID {
@@ -38,7 +39,7 @@ pub fn send(
     let (exit_code, return_id) =
         match context
             .kernel
-            .send(&recipient, method, &params.into(), &value)?
+            .send(&recipient, method, &params.into(), value)?
         {
             InvocationResult::Return(value) => (
                 ExitCode::Ok as u32,

--- a/sdk/src/send.rs
+++ b/sdk/src/send.rs
@@ -24,6 +24,8 @@ pub fn send(
     let value: fvm_shared::sys::TokenAmount = value
         .try_into()
         .map_err(|_| ExitCode::ErrInsufficientFunds)?;
+
+    let (value_hi, value_lo) = value.high_low();
     unsafe {
         // Insert parameters as a block. Nil parameters is represented as the
         // NO_DATA_BLOCK_ID block ID in the FFI interface.
@@ -42,8 +44,8 @@ pub fn send(
             recipient.len() as u32,
             method,
             params_id,
-            value.hi,
-            value.lo,
+            value_hi,
+            value_lo,
         )?;
 
         // Process the result.

--- a/sdk/src/send.rs
+++ b/sdk/src/send.rs
@@ -25,7 +25,7 @@ pub fn send(
         .try_into()
         .map_err(|_| ExitCode::ErrInsufficientFunds)?;
 
-    let (value_hi, value_lo) = value.high_low();
+    let (value_hi, value_lo) = value.to_high_low();
     unsafe {
         // Insert parameters as a block. Nil parameters is represented as the
         // NO_DATA_BLOCK_ID block ID in the FFI interface.

--- a/shared/src/message.rs
+++ b/shared/src/message.rs
@@ -4,11 +4,11 @@
 use anyhow::anyhow;
 
 use crate::address::Address;
-use crate::bigint::bigint_ser::{BigIntDe, BigIntSer};
-use crate::econ::TokenAmount;
 use crate::encoding::de::{Deserialize, Deserializer};
 use crate::encoding::ser::{Serialize, Serializer};
 use crate::encoding::{Cbor, RawBytes};
+use crate::sys::tokenamount_ser::{TokenAmountDe, TokenAmountSer};
+use crate::sys::TokenAmount;
 use crate::MethodNum;
 
 /// Default Unsigned VM message type which includes all data needed for a state transition
@@ -58,10 +58,10 @@ impl Serialize for Message {
             &self.to,
             &self.from,
             &self.sequence,
-            BigIntSer(&self.value),
+            TokenAmountSer(&self.value),
             &self.gas_limit,
-            BigIntSer(&self.gas_fee_cap),
-            BigIntSer(&self.gas_premium),
+            TokenAmountSer(&self.gas_fee_cap),
+            TokenAmountSer(&self.gas_premium),
             &self.method_num,
             &self.params,
         )
@@ -79,10 +79,10 @@ impl<'de> Deserialize<'de> for Message {
             to,
             from,
             sequence,
-            BigIntDe(value),
+            TokenAmountDe(value),
             gas_limit,
-            BigIntDe(gas_fee_cap),
-            BigIntDe(gas_premium),
+            TokenAmountDe(gas_fee_cap),
+            TokenAmountDe(gas_premium),
             method_num,
             params,
         ) = Deserialize::deserialize(deserializer)?;

--- a/shared/src/sys/mod.rs
+++ b/shared/src/sys/mod.rs
@@ -1,7 +1,15 @@
 //! This module contains types exchanged at the syscall layer between actors
 //! (usually through the SDK) and the FVM.
 
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::{Add, Mul, Sub};
+
+use num_traits::Zero;
+
 pub mod out;
+pub mod tokenamount_ser;
 
 pub type BlockId = u32;
 pub type Codec = u64;
@@ -13,12 +21,65 @@ pub struct TokenAmount {
     pub hi: u64,
 }
 
+impl TokenAmount {
+    pub fn checked_sub(&self, v: &TokenAmount) -> Option<TokenAmount> {
+        if self < v {
+            return None;
+        }
+
+        crate::econ::TokenAmount::from(self)
+            .checked_sub(&crate::econ::TokenAmount::from(v))
+            .unwrap()
+            .try_into()
+            .ok()
+    }
+
+    pub fn checked_add(&self, v: &TokenAmount) -> Option<TokenAmount> {
+        crate::econ::TokenAmount::from(self)
+            .checked_add(&crate::econ::TokenAmount::from(v))
+            .unwrap()
+            .try_into()
+            .ok()
+    }
+}
+
 impl From<TokenAmount> for crate::econ::TokenAmount {
     fn from(v: TokenAmount) -> Self {
         crate::econ::TokenAmount::from(v.hi) << 64 | crate::econ::TokenAmount::from(v.lo)
     }
 }
 
+impl From<&TokenAmount> for crate::econ::TokenAmount {
+    fn from(v: &TokenAmount) -> Self {
+        crate::econ::TokenAmount::from(v.hi) << 64 | crate::econ::TokenAmount::from(v.lo)
+    }
+}
+
+impl From<u32> for TokenAmount {
+    fn from(v: u32) -> Self {
+        TokenAmount {
+            hi: 0,
+            lo: v as u64,
+        }
+    }
+}
+
+impl From<u64> for TokenAmount {
+    fn from(v: u64) -> Self {
+        TokenAmount { hi: 0, lo: v }
+    }
+}
+
+impl From<u128> for TokenAmount {
+    fn from(v: u128) -> Self {
+        TokenAmount {
+            hi: (v >> u64::BITS) as u64,
+            lo: v as u64,
+        }
+    }
+}
+
+// review: these next 2 methods should fail on negative input, unless the map to u128 does that for you
 impl TryFrom<crate::econ::TokenAmount> for TokenAmount {
     type Error = <crate::econ::TokenAmount as TryInto<u128>>::Error;
     fn try_from(v: crate::econ::TokenAmount) -> Result<Self, Self::Error> {
@@ -36,5 +97,131 @@ impl<'a> TryFrom<&'a crate::econ::TokenAmount> for TokenAmount {
             hi: (v >> u64::BITS) as u64,
             lo: v as u64,
         })
+    }
+}
+
+impl fmt::Display for TokenAmount {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", crate::econ::TokenAmount::from(self))
+    }
+}
+
+impl Add<Self> for TokenAmount {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        crate::econ::TokenAmount::from(self)
+            .add(&crate::econ::TokenAmount::from(rhs))
+            .try_into()
+            .unwrap()
+    }
+}
+
+impl Sub<Self> for TokenAmount {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        // panic if rhs > self?
+        crate::econ::TokenAmount::from(self)
+            .sub(&crate::econ::TokenAmount::from(rhs))
+            .try_into()
+            .unwrap()
+    }
+}
+
+impl Zero for TokenAmount {
+    #[inline]
+    fn zero() -> TokenAmount {
+        TokenAmount { hi: 0, lo: 0 }
+    }
+
+    #[inline]
+    fn set_zero(&mut self) {
+        self.hi = 0;
+        self.lo = 0;
+    }
+
+    #[inline]
+    fn is_zero(&self) -> bool {
+        self.hi == 0 && self.lo == 0
+    }
+}
+
+impl Default for TokenAmount {
+    #[inline]
+    fn default() -> TokenAmount {
+        Zero::zero()
+    }
+}
+
+impl PartialEq<Self> for TokenAmount {
+    fn eq(&self, other: &Self) -> bool {
+        self.hi == other.hi && self.lo == other.lo
+    }
+}
+
+impl Eq for TokenAmount {}
+
+impl Hash for TokenAmount {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.lo.hash(state);
+        if self.hi != 0 {
+            self.hi.hash(state);
+        }
+    }
+}
+
+impl Mul<u64> for TokenAmount {
+    type Output = TokenAmount;
+
+    fn mul(self, rhs: u64) -> Self::Output {
+        let eta: crate::econ::TokenAmount = self.into();
+        crate::econ::TokenAmount::from(eta * rhs)
+            .try_into()
+            .unwrap()
+    }
+}
+
+impl Mul<i64> for TokenAmount {
+    type Output = TokenAmount;
+
+    fn mul(self, rhs: i64) -> Self::Output {
+        if rhs < 0 {
+            // panic?
+        }
+
+        self * rhs as u64
+    }
+}
+
+impl Mul<u64> for &TokenAmount {
+    type Output = TokenAmount;
+
+    fn mul(self, rhs: u64) -> Self::Output {
+        *self * rhs
+    }
+}
+
+impl Mul<i64> for &TokenAmount {
+    type Output = TokenAmount;
+
+    fn mul(self, rhs: i64) -> Self::Output {
+        *self * rhs
+    }
+}
+
+impl PartialOrd<Self> for TokenAmount {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(match self.hi.cmp(&other.hi) {
+            Ordering::Less => Ordering::Less,
+            Ordering::Equal => self.lo.cmp(&other.lo),
+            Ordering::Greater => Ordering::Greater,
+        })
+    }
+}
+
+impl Ord for TokenAmount {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
     }
 }

--- a/shared/src/sys/mod.rs
+++ b/shared/src/sys/mod.rs
@@ -233,7 +233,11 @@ impl TokenAmount {
         self.hi == 0 && self.lo == 0
     }
 
-    pub fn high_low(&self) -> (u64, u64) {
+    pub fn to_high_low(&self) -> (u64, u64) {
         (self.hi, self.lo)
+    }
+
+    pub fn from_high_low(hi: u64, lo: u64) -> Self {
+        TokenAmount { hi, lo }
     }
 }

--- a/shared/src/sys/mod.rs
+++ b/shared/src/sys/mod.rs
@@ -6,7 +6,9 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::{Add, Mul, Sub};
 
-use num_traits::Zero;
+use num_bigint::Sign;
+
+use crate::sys::TokenAmountError::{Overflow, Underflow};
 
 pub mod out;
 pub mod tokenamount_ser;
@@ -17,41 +19,101 @@ pub type Codec = u64;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TokenAmount {
-    pub lo: u64,
-    pub hi: u64,
+    // DO NOT reorder these fields. The layout is equivalent to u128 on a big-endian system, and
+    // optimizes well.
+    lo: u64,
+    hi: u64,
 }
 
-impl TokenAmount {
-    pub fn checked_sub(&self, v: &TokenAmount) -> Option<TokenAmount> {
-        if self < v {
-            return None;
+#[derive(Debug)]
+pub enum TokenAmountError {
+    Overflow,
+    Underflow,
+}
+
+impl Add<Self> for TokenAmount {
+    type Output = Result<TokenAmount, TokenAmountError>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        self.checked_add(rhs).ok_or(Overflow)
+    }
+}
+
+impl Sub<Self> for TokenAmount {
+    type Output = Result<TokenAmount, TokenAmountError>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.checked_add(rhs).ok_or(Underflow)
+    }
+}
+//
+// impl Mul<u64> for TokenAmount {
+//     type Output = TokenAmount;
+//
+//     fn mul(self, rhs: u64) -> Self::Output {
+//         let eta: crate::econ::TokenAmount = self.into();
+//         crate::econ::TokenAmount::from(eta * rhs)
+//             .try_into()
+//             .unwrap()
+//     }
+// }
+//
+
+impl Mul<i64> for TokenAmount {
+    type Output = Result<TokenAmount, TokenAmountError>;
+
+    fn mul(self, rhs: i64) -> Self::Output {
+        if rhs < 0 {
+            return Err(Underflow);
         }
 
-        crate::econ::TokenAmount::from(self)
-            .checked_sub(&crate::econ::TokenAmount::from(v))
-            .unwrap()
-            .try_into()
-            .ok()
+        match u128::from(self).checked_mul(rhs as u128) {
+            None => Err(Overflow),
+            Some(v) => Ok(v.into()),
+        }
     }
+}
 
-    pub fn checked_add(&self, v: &TokenAmount) -> Option<TokenAmount> {
-        crate::econ::TokenAmount::from(self)
-            .checked_add(&crate::econ::TokenAmount::from(v))
-            .unwrap()
-            .try_into()
-            .ok()
+//
+// impl Mul<u64> for &TokenAmount {
+//     type Output = TokenAmount;
+//
+//     fn mul(self, rhs: u64) -> Self::Output {
+//         *self * rhs
+//     }
+// }
+//
+// impl Mul<i64> for &TokenAmount {
+//     type Output = TokenAmount;
+//
+//     fn mul(self, rhs: i64) -> Self::Output {
+//         *self * rhs
+//     }
+// }
+
+impl From<TokenAmount> for u128 {
+    #[inline]
+    fn from(v: TokenAmount) -> Self {
+        (v.hi as u128) << u64::BITS | (v.lo as u128)
+    }
+}
+
+impl From<&TokenAmount> for u128 {
+    #[inline]
+    fn from(v: &TokenAmount) -> Self {
+        (v.hi as u128) << u64::BITS | (v.lo as u128)
     }
 }
 
 impl From<TokenAmount> for crate::econ::TokenAmount {
     fn from(v: TokenAmount) -> Self {
-        crate::econ::TokenAmount::from(v.hi) << 64 | crate::econ::TokenAmount::from(v.lo)
+        crate::econ::TokenAmount::from(u128::from(v))
     }
 }
 
 impl From<&TokenAmount> for crate::econ::TokenAmount {
     fn from(v: &TokenAmount) -> Self {
-        crate::econ::TokenAmount::from(v.hi) << 64 | crate::econ::TokenAmount::from(v.lo)
+        crate::econ::TokenAmount::from(u128::from(v))
     }
 }
 
@@ -81,76 +143,36 @@ impl From<u128> for TokenAmount {
 
 // review: these next 2 methods should fail on negative input, unless the map to u128 does that for you
 impl TryFrom<crate::econ::TokenAmount> for TokenAmount {
-    type Error = <crate::econ::TokenAmount as TryInto<u128>>::Error;
+    type Error = TokenAmountError;
     fn try_from(v: crate::econ::TokenAmount) -> Result<Self, Self::Error> {
-        v.try_into().map(|v: u128| Self {
-            hi: (v >> u64::BITS) as u64,
-            lo: v as u64,
-        })
+        match v.sign() {
+            Sign::Minus => Err(Underflow),
+            Sign::NoSign => Ok(TokenAmount::zero()),
+            Sign::Plus => match u128::try_from(v) {
+                Ok(v128) => Ok(v128.into()),
+                Err(_) => Err(Overflow),
+            },
+        }
     }
 }
 
 impl<'a> TryFrom<&'a crate::econ::TokenAmount> for TokenAmount {
-    type Error = <&'a crate::econ::TokenAmount as TryInto<u128>>::Error;
+    type Error = TokenAmountError;
     fn try_from(v: &'a crate::econ::TokenAmount) -> Result<Self, Self::Error> {
-        v.try_into().map(|v: u128| Self {
-            hi: (v >> u64::BITS) as u64,
-            lo: v as u64,
-        })
+        match v.sign() {
+            Sign::Minus => Err(Underflow),
+            Sign::NoSign => Ok(TokenAmount::zero()),
+            Sign::Plus => match u128::try_from(v) {
+                Ok(v128) => Ok(v128.into()),
+                Err(_) => Err(Overflow),
+            },
+        }
     }
 }
 
 impl fmt::Display for TokenAmount {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", crate::econ::TokenAmount::from(self))
-    }
-}
-
-impl Add<Self> for TokenAmount {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        crate::econ::TokenAmount::from(self)
-            .add(&crate::econ::TokenAmount::from(rhs))
-            .try_into()
-            .unwrap()
-    }
-}
-
-impl Sub<Self> for TokenAmount {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        // panic if rhs > self?
-        crate::econ::TokenAmount::from(self)
-            .sub(&crate::econ::TokenAmount::from(rhs))
-            .try_into()
-            .unwrap()
-    }
-}
-
-impl Zero for TokenAmount {
-    #[inline]
-    fn zero() -> TokenAmount {
-        TokenAmount { hi: 0, lo: 0 }
-    }
-
-    #[inline]
-    fn set_zero(&mut self) {
-        self.hi = 0;
-        self.lo = 0;
-    }
-
-    #[inline]
-    fn is_zero(&self) -> bool {
-        self.hi == 0 && self.lo == 0
-    }
-}
-
-impl Default for TokenAmount {
-    #[inline]
-    fn default() -> TokenAmount {
-        Zero::zero()
     }
 }
 
@@ -164,64 +186,54 @@ impl Eq for TokenAmount {}
 
 impl Hash for TokenAmount {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.lo.hash(state);
-        if self.hi != 0 {
-            self.hi.hash(state);
-        }
-    }
-}
-
-impl Mul<u64> for TokenAmount {
-    type Output = TokenAmount;
-
-    fn mul(self, rhs: u64) -> Self::Output {
-        let eta: crate::econ::TokenAmount = self.into();
-        crate::econ::TokenAmount::from(eta * rhs)
-            .try_into()
-            .unwrap()
-    }
-}
-
-impl Mul<i64> for TokenAmount {
-    type Output = TokenAmount;
-
-    fn mul(self, rhs: i64) -> Self::Output {
-        if rhs < 0 {
-            // panic?
-        }
-
-        self * rhs as u64
-    }
-}
-
-impl Mul<u64> for &TokenAmount {
-    type Output = TokenAmount;
-
-    fn mul(self, rhs: u64) -> Self::Output {
-        *self * rhs
-    }
-}
-
-impl Mul<i64> for &TokenAmount {
-    type Output = TokenAmount;
-
-    fn mul(self, rhs: i64) -> Self::Output {
-        *self * rhs
+        u128::from(self).hash(state)
     }
 }
 
 impl PartialOrd<Self> for TokenAmount {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(match self.hi.cmp(&other.hi) {
-            Ordering::Less => Ordering::Less,
-            Ordering::Equal => self.lo.cmp(&other.lo),
-            Ordering::Greater => Ordering::Greater,
-        })
+        u128::from(self).partial_cmp(&u128::from(other))
     }
 }
 
 impl Ord for TokenAmount {
     fn cmp(&self, other: &Self) -> Ordering {
         self.partial_cmp(other).unwrap()
+    }
+}
+
+impl Default for TokenAmount {
+    #[inline]
+    fn default() -> TokenAmount {
+        TokenAmount::zero()
+    }
+}
+
+impl TokenAmount {
+    pub fn checked_sub(&self, rhs: TokenAmount) -> Option<TokenAmount> {
+        match u128::from(self).checked_sub(u128::from(rhs)) {
+            None => None,
+            Some(v) => Some(v.into()),
+        }
+    }
+
+    pub fn checked_add(&self, rhs: TokenAmount) -> Option<TokenAmount> {
+        match u128::from(self).checked_add(u128::from(rhs)) {
+            None => None,
+            Some(v) => Some(v.into()),
+        }
+    }
+
+    // should they have inline directives?
+    pub fn zero() -> TokenAmount {
+        TokenAmount { hi: 0, lo: 0 }
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.hi == 0 && self.lo == 0
+    }
+
+    pub fn high_low(&self) -> (u64, u64) {
+        (self.hi, self.lo)
     }
 }

--- a/shared/src/sys/tokenamount_ser.rs
+++ b/shared/src/sys/tokenamount_ser.rs
@@ -1,0 +1,62 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::borrow::Cow;
+
+use num_bigint::{BigInt, Sign};
+use serde::{Deserialize, Serialize};
+
+use crate::sys::TokenAmount;
+
+/// Wrapper for serializing token amounts to match filecoin spec. Serializes as bytes.
+#[derive(Serialize)]
+#[serde(transparent)]
+pub struct TokenAmountSer<'a>(#[serde(with = "self")] pub &'a TokenAmount);
+
+/// Wrapper for deserializing as TokenAmount from bytes.
+#[derive(Deserialize, Serialize, Clone, Default, PartialEq)]
+#[serde(transparent)]
+pub struct TokenAmountDe(#[serde(with = "self")] pub TokenAmount);
+
+/// Serializes TokenAmount as bytes following Filecoin spec.
+pub fn serialize<S>(token: &TokenAmount, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    // review note: safe to deref? should we have a second impl of from with pointer rcvr?
+    let int = crate::econ::TokenAmount::from(*token);
+    // let int: crate::econ::TokenAmount = token.into();
+    let (sign, mut bz) = int.to_bytes_be();
+
+    // Insert sign byte at start of encoded bytes
+    match sign {
+        Sign::Minus => bz.insert(0, 1),
+        Sign::Plus => bz.insert(0, 0),
+        Sign::NoSign => bz = Vec::new(),
+    }
+
+    // Serialize as bytes
+    serde_bytes::Serialize::serialize(&bz, serializer)
+}
+
+/// Deserializes bytes into TokenAmount
+pub fn deserialize<'de, D>(deserializer: D) -> Result<TokenAmount, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let bz: Cow<'de, [u8]> = serde_bytes::Deserialize::deserialize(deserializer)?;
+    if bz.is_empty() {
+        return Ok(TokenAmount::default());
+    }
+    let sign_byte = bz[0];
+    let sign: Sign = match sign_byte {
+        1 => Sign::Minus,
+        0 => Sign::Plus,
+        _ => {
+            return Err(serde::de::Error::custom(
+                "First byte must be valid sign (0, 1)",
+            ));
+        }
+    };
+    Ok(BigInt::from_bytes_be(sign, &bz[1..]).try_into().unwrap())
+}

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -23,7 +23,6 @@ use fvm_shared::sector::{
 use fvm_shared::sys::TokenAmount;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum, TOTAL_FILECOIN};
-use num_traits::Zero;
 
 use crate::externs::TestExterns;
 use crate::vector::{MessageVector, Variant};


### PR DESCRIPTION
This needs some cleanup, but ready for a review. Some notes:

- I moved to always using values since it's just 2 u64s now, but I'm not sure whether that was the right thing to do
- The new type's methods need to be scrutinized for correctness. As far as possible I converted to BigInt before performing any operations.