### PR TITLE
refactor: split out syscall errors from exit codes

### DIFF
--- a/actors/runtime/src/actor_error.rs
+++ b/actors/runtime/src/actor_error.rs
@@ -59,6 +59,34 @@ impl From<fvm_shared::encoding::error::Error> for ActorError {
     }
 }
 
+#[cfg(feature = "runtime-wasm")]
+impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
+    fn from(e: fvm_sdk::error::ActorDeleteError) -> Self {
+        use fvm_sdk::error::ActorDeleteError::*;
+        Self {
+            // FIXME: These shouldn't be "system" errors, but we're trying to match existing
+            // behavior here.
+            exit_code: match e {
+                BeneficiaryIsSelf => ExitCode::SysErrIllegalActor,
+                BeneficiaryDoesNotExist => ExitCode::SysErrIllegalArgument,
+            },
+            msg: e.to_string(),
+        }
+    }
+}
+
+#[cfg(feature = "runtime-wasm")]
+impl From<fvm_sdk::error::NoStateError> for ActorError {
+    fn from(e: fvm_sdk::error::NoStateError) -> Self {
+        Self {
+            // FIXME: These shouldn't be "system" errors, but we're trying to match existing
+            // behavior here.
+            exit_code: ExitCode::SysErrIllegalActor,
+            msg: e.to_string(),
+        }
+    }
+}
+
 /// Performs conversions from SyscallResult, whose error type is ExitCode,
 /// to ActorErrors. This facilitates propagation.
 impl From<ExitCode> for ActorError {

--- a/actors/runtime/src/actor_error.rs
+++ b/actors/runtime/src/actor_error.rs
@@ -59,6 +59,8 @@ impl From<fvm_shared::encoding::error::Error> for ActorError {
     }
 }
 
+/// Converts an actor deletion error into an actor error with the appropriate exit code. This
+/// facilitates propagation.
 #[cfg(feature = "runtime-wasm")]
 impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
     fn from(e: fvm_sdk::error::ActorDeleteError) -> Self {
@@ -75,6 +77,8 @@ impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
     }
 }
 
+/// Converts a no-state error into an an actor error with the appropriate exit code (illegal actor).
+/// This facilitates propagation.
 #[cfg(feature = "runtime-wasm")]
 impl From<fvm_sdk::error::NoStateError> for ActorError {
     fn from(e: fvm_sdk::error::NoStateError) -> Self {

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -215,7 +215,7 @@ impl MockRuntime {
     }
     fn check_argument(&self, predicate: bool, msg: String) -> Result<(), ActorError> {
         if !predicate {
-            return Err(actor_error!(SysErrIllegalArgument; msg));
+            return Err(actor_error!(SysErrIllegalActor; msg));
         }
         Ok(())
     }

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -213,12 +213,6 @@ impl MockRuntime {
             "invalid runtime invocation outside of method call",
         )
     }
-    fn check_argument(&self, predicate: bool, msg: String) -> Result<(), ActorError> {
-        if !predicate {
-            return Err(actor_error!(SysErrIllegalActor; msg));
-        }
-        Ok(())
-    }
     fn put<C: Cbor>(&self, o: &C) -> Result<Cid, ActorError> {
         Ok(self.store.put_cbor(&o, Code::Blake2b256).unwrap())
     }
@@ -426,8 +420,6 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
 
         let addrs: Vec<Address> = addresses.into_iter().cloned().collect();
 
-        self.check_argument(!addrs.is_empty(), "addrs must be non-empty".to_owned())?;
-
         assert!(
             self.expectations
                 .borrow_mut()
@@ -465,9 +457,6 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
     {
         self.require_in_call();
         let types: Vec<Cid> = types.into_iter().cloned().collect();
-
-        self.check_argument(!types.is_empty(), "types must be non-empty".to_owned())?;
-
         assert!(
             self.expectations
                 .borrow_mut()

--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -4,8 +4,7 @@
 pub use self::charge::GasCharge;
 pub(crate) use self::outputs::GasOutputs;
 pub use self::price_list::{price_list_by_epoch, PriceList};
-use crate::kernel::SyscallError;
-use crate::syscall_error;
+use crate::kernel::{ExecutionError, Result};
 
 mod charge;
 mod outputs;
@@ -26,26 +25,20 @@ impl GasTracker {
 
     /// Safely consumes gas and returns an out of gas error if there is not sufficient
     /// enough gas remaining for charge.
-    pub fn charge_gas(&mut self, charge: GasCharge) -> Result<(), SyscallError> {
+    pub fn charge_gas(&mut self, charge: GasCharge) -> Result<()> {
         let to_use = charge.total();
         match self.gas_used.checked_add(to_use) {
             None => {
                 log::trace!("gas overflow: {}", charge.name);
                 self.gas_used = self.gas_available;
-                Err(syscall_error!(SysErrOutOfGas;
-                    "adding gas_used={} and to_use={} overflowed",
-                    self.gas_used, to_use
-                ))
+                Err(ExecutionError::OutOfGas)
             }
             Some(used) => {
                 log::trace!("charged {} gas: {}", used, charge.name);
                 if used > self.gas_available {
                     log::trace!("out of gas: {}", charge.name);
                     self.gas_used = self.gas_available;
-                    Err(syscall_error!(SysErrOutOfGas;
-                            "not enough gas (used={}) (available={})",
-                       used, self.gas_available
-                    ))
+                    Err(ExecutionError::OutOfGas)
                 } else {
                     self.gas_used = used;
                     Ok(())

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -3,7 +3,7 @@ use fvm_shared::address::Address;
 use fvm_shared::blockstore::Blockstore;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::error::ExitCode;
+use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::ActorID;
 use wasmtime::{Engine, Module};
@@ -78,9 +78,15 @@ pub struct CallError {
     /// The source of the error or 0 for a syscall error.
     pub source: ActorID,
     /// The error code.
-    pub code: ExitCode,
+    pub code: CallErrorCode,
     /// The error message.
     pub message: String,
+}
+
+#[derive(Clone, Debug)]
+pub enum CallErrorCode {
+    Exit(ExitCode),
+    Syscall(ErrorNumber),
 }
 
 /// Execution context supplied to the machine.

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -539,7 +539,7 @@ impl ActorState {
     /// TODO return a system error with exit code "insufficient funds"
     pub fn deduct_funds(&mut self, amt: &TokenAmount) -> Result<()> {
         if &self.balance < amt {
-            return Err(syscall_error!(SysErrInsufficientFunds; "not enough funds").into());
+            return Err(syscall_error!(InsufficientFunds; "not enough funds").into());
         }
         self.balance -= amt;
 

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -50,7 +50,7 @@ pub fn new_actor_address(
 ) -> Result<u32> {
     if obuf_len < 21 {
         return Err(
-            syscall_error!(SysErrIllegalArgument; "output buffer must have a minimum capacity of 21 bytes").into(),
+            syscall_error!(IllegalArgument; "output buffer must have a minimum capacity of 21 bytes").into(),
         );
     }
 
@@ -59,7 +59,7 @@ pub fn new_actor_address(
 
     let len = bytes.len();
     if len > obuf_len as usize {
-        return Err(syscall_error!(SysErrIllegalArgument;
+        return Err(syscall_error!(IllegalArgument;
             "insufficient output buffer capacity; {} (new address) > {} (buffer capacity)",
             len, obuf_len
         )

--- a/fvm/src/syscalls/bind.rs
+++ b/fvm/src/syscalls/bind.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use fvm_shared::error::ExitCode;
+use fvm_shared::error::ErrorNumber;
 use wasmtime::{Caller, Linker, Trap, WasmTy};
 
 use super::error::trap_from_error;
@@ -86,7 +86,7 @@ where
     fn into(self) -> Result<Result<Self::Value, SyscallError>, Trap> {
         match self {
             Ok(value) => Ok(Ok(value)),
-            Err(ExecutionError::Syscall(err)) if err.is_recoverable() => Ok(Err(err)),
+            Err(ExecutionError::Syscall(err)) => Ok(Err(err)),
             Err(e) => Err(trap_from_error(e)),
         }
     }
@@ -133,7 +133,7 @@ macro_rules! impl_bind_syscalls {
                         // We need to check to make sure we can store the return value _before_ we do anything.
                         if (ret as u64) > (ctx.memory.len() as u64)
                             || ctx.memory.len() - (ret as usize) < mem::size_of::<Ret::Value>() {
-                            let code = ExitCode::SysErrIllegalArgument;
+                            let code = ErrorNumber::IllegalArgument;
                             ctx.kernel.push_syscall_error(SyscallError(format!("no space for return value"), code));
                             return Ok(code as u32);
                         }

--- a/fvm/src/syscalls/context.rs
+++ b/fvm/src/syscalls/context.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, DerefMut};
 use cid::Cid;
 use fvm_shared::address::Address;
 use fvm_shared::encoding::{from_slice, Cbor};
-use fvm_shared::error::ExitCode;
+use fvm_shared::error::ErrorNumber;
 
 use crate::kernel::{ClassifyResult, Context as _, Result};
 use crate::syscalls::MAX_CID_LEN;
@@ -69,28 +69,28 @@ impl Memory {
         self.get(offset as usize..)
             .and_then(|data| data.get(..len as usize))
             .ok_or_else(|| format!("buffer {} (length {}) out of bounds", offset, len))
-            .or_error(ExitCode::SysErrIllegalArgument)
+            .or_error(ErrorNumber::IllegalArgument)
     }
     pub fn try_slice_mut(&mut self, offset: u32, len: u32) -> Result<&mut [u8]> {
         self.get_mut(offset as usize..)
             .and_then(|data| data.get_mut(..len as usize))
             .ok_or_else(|| format!("buffer {} (length {}) out of bounds", offset, len))
-            .or_error(ExitCode::SysErrIllegalArgument)
+            .or_error(ErrorNumber::IllegalArgument)
     }
 
     pub fn read_cid(&self, offset: u32) -> Result<Cid> {
         Cid::read_bytes(self.try_slice(offset, MAX_CID_LEN as u32)?)
-            .or_error(ExitCode::SysErrIllegalArgument)
+            .or_error(ErrorNumber::IllegalArgument)
             .context("failed to parse CID")
     }
 
     pub fn read_address(&self, offset: u32, len: u32) -> Result<Address> {
         let bytes = self.try_slice(offset, len)?;
-        Address::from_bytes(bytes).or_error(ExitCode::SysErrIllegalArgument)
+        Address::from_bytes(bytes).or_error(ErrorNumber::IllegalArgument)
     }
 
     pub fn read_cbor<T: Cbor>(&self, offset: u32, len: u32) -> Result<T> {
         let bytes = self.try_slice(offset, len)?;
-        from_slice(bytes).or_error(ExitCode::SysErrIllegalArgument)
+        from_slice(bytes).or_error(ErrorNumber::IllegalArgument)
     }
 }

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -10,7 +10,7 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::encoding::{Cbor, DAG_CBOR};
-use fvm_shared::error::ExitCode::SysErrIllegalArgument;
+use fvm_shared::error::ErrorNumber::IllegalArgument;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
@@ -84,7 +84,7 @@ pub fn compute_unsealed_sector_cid(
     let len = bytes.len();
     if len > out.len() {
         return Err(syscall_error!(
-            SysErrIllegalArgument;
+            IllegalArgument;
             "output buffer too small; CID length: {}, buffer length: {}", len, out.len())
         .into());
     }

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -8,7 +8,7 @@ use num_traits::FromPrimitive;
 use wasmtime::Trap;
 
 use crate::call_manager::InvocationResult;
-use crate::kernel::{ClassifyResult, ExecutionError, SyscallError};
+use crate::kernel::{ClassifyResult, ExecutionError};
 
 /// Wraps an execution error in a Trap.
 pub fn trap_from_error(e: ExecutionError) -> Trap {
@@ -40,7 +40,7 @@ pub fn unwrap_trap(e: Trap) -> crate::kernel::Result<InvocationResult> {
     }
 
     if e.trap_code().is_some() {
-        return Err(SyscallError(e.to_string(), ExitCode::SysErrIllegalActor).into());
+        return Ok(InvocationResult::Failure(ExitCode::SysErrActorPanic));
     }
 
     // Do whatever we can to pull the original error back out (if it exists).

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -13,3 +13,4 @@ fvm_shared = { path = "../shared" }
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = "1.4.0"
 log = "0.4.14"
+thiserror = "1.0.30"

--- a/sdk/src/actor.rs
+++ b/sdk/src/actor.rs
@@ -50,11 +50,12 @@ pub fn get_actor_code_cid(addr: &Address) -> Option<Cid> {
 
 /// Generates a new actor address for an actor deployed
 /// by the calling actor.
-pub fn new_actor_address() -> SyscallResult<Address> {
+pub fn new_actor_address() -> Address {
     let mut buf = [0u8; MAX_ACTOR_ADDR_LEN];
     unsafe {
-        let len = sys::actor::new_actor_address(buf.as_mut_ptr(), MAX_ACTOR_ADDR_LEN as u32)?;
-        Ok(Address::from_bytes(&buf[..len as usize]).expect("syscall returned invalid address"))
+        let len = sys::actor::new_actor_address(buf.as_mut_ptr(), MAX_ACTOR_ADDR_LEN as u32)
+            .expect("failed to create a new actor address");
+        Address::from_bytes(&buf[..len as usize]).expect("syscall returned invalid address")
     }
 }
 

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -3,7 +3,6 @@ use fvm_shared::address::Address;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::encoding::{to_vec, Cbor};
-use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
@@ -18,7 +17,7 @@ pub fn verify_signature(
     signature: &Signature,
     signer: &Address,
     plaintext: &[u8],
-) -> Result<bool, ExitCode> {
+) -> SyscallResult<bool> {
     let signature = signature
         .marshal_cbor()
         .expect("failed to marshal signature");

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Copy, Clone, Debug, Error)]
+#[error("actor does not exist in state-tree")]
+pub struct NoStateError;
+
+#[derive(Copy, Clone, Debug, Error)]
+pub enum ActorDeleteError {
+    #[error("deletion beneficiary is the current actor")]
+    BeneficiaryIsSelf,
+    #[error("deletion beneficiary does not exist")]
+    BeneficiaryDoesNotExist,
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod actor;
 pub mod crypto;
 pub mod debug;
+pub mod error;
 pub mod gas;
 pub mod ipld;
 pub mod message;
@@ -30,4 +31,4 @@ pub(crate) fn status_code_to_bool(code: i32) -> bool {
 ///
 /// Error messages don't make it across the boundary, but are logged at the FVM
 /// level for debugging and informational purposes.
-pub type SyscallResult<T> = core::result::Result<T, fvm_shared::error::ExitCode>;
+pub type SyscallResult<T> = core::result::Result<T, fvm_shared::error::ErrorNumber>;

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -1,6 +1,6 @@
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::{Cbor, DAG_CBOR};
-use fvm_shared::error::ExitCode;
+use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::sys::{BlockId, Codec};
 use fvm_shared::{ActorID, MethodNum};
 
@@ -71,7 +71,7 @@ pub fn value_received() -> TokenAmount {
 /// provided.
 pub fn params_cbor<T: Cbor>(id: BlockId) -> SyscallResult<T> {
     if id == NO_DATA_BLOCK_ID {
-        return Err(ExitCode::ErrIllegalArgument);
+        return Err(ErrorNumber::IllegalArgument);
     }
     let (codec, raw) = params_raw(id)?;
     debug_assert!(codec == DAG_CBOR, "parameters codec was not cbor");

--- a/sdk/src/send.rs
+++ b/sdk/src/send.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::{RawBytes, DAG_CBOR};
-use fvm_shared::error::ExitCode;
+use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::receipt::Receipt;
 use fvm_shared::MethodNum;
 use num_traits::FromPrimitive;
@@ -23,7 +23,7 @@ pub fn send(
     let recipient = to.to_bytes();
     let value: fvm_shared::sys::TokenAmount = value
         .try_into()
-        .map_err(|_| ExitCode::ErrInsufficientFunds)?;
+        .map_err(|_| ErrorNumber::InsufficientFunds)?;
     unsafe {
         // Insert parameters as a block. Nil parameters is represented as the
         // NO_DATA_BLOCK_ID block ID in the FFI interface.
@@ -47,7 +47,7 @@ pub fn send(
         )?;
 
         // Process the result.
-        let exit_code = ExitCode::from_u32(exit_code).unwrap_or(ExitCode::ErrIllegalState);
+        let exit_code = ExitCode::from_u32(exit_code).unwrap_or(ExitCode::SysErrIllegalActor);
         let return_data = match exit_code {
             ExitCode::Ok if return_id != NO_DATA_BLOCK_ID => {
                 // Allocate a buffer to read the return data.

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -97,3 +97,38 @@ impl std::fmt::Display for ExitCode {
         write!(f, "exit code: {}", *self as u32)
     }
 }
+
+#[repr(u32)]
+#[derive(Copy, Clone, Eq, Debug, PartialEq, Error, FromPrimitive)]
+pub enum ErrorNumber {
+    IllegalArgument = 1,
+    IllegalOperation = 2,
+    LimitExceeded = 3,
+    AssertionFailed = 4,
+    InsufficientFunds = 5,
+    NotFound = 6,
+    InvalidHandle = 7,
+    IllegalCid = 8,
+    IllegalCodec = 9,
+    Serialization = 10,
+    Forbidden = 11,
+}
+
+impl std::fmt::Display for ErrorNumber {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use ErrorNumber::*;
+        f.write_str(match *self {
+            IllegalArgument => "illegal argument",
+            IllegalOperation => "illegal operation",
+            LimitExceeded => "limit exceeded",
+            AssertionFailed => "filecoin assertion failed",
+            InsufficientFunds => "insufficient funds",
+            NotFound => "resource not found",
+            InvalidHandle => "invalid ipld block handle",
+            IllegalCid => "illegal cid specification",
+            IllegalCodec => "illegal ipld codec",
+            Serialization => "serialization error",
+            Forbidden => "operation forbidden",
+        })
+    }
+}


### PR DESCRIPTION
This compiles now but will need some work:

1. https://github.com/filecoin-project/fvm-specs/pull/53 needs to be finalized.
2. We need to figure out how we want to handle "unexpected" errors. Currently, I'm panicking, but maybe we want to call `abort` with some exit code?