### PR TITLE
Remove all uses of hash maps in actors

### DIFF
--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -22,6 +22,7 @@ byteorder = "1.3.4"
 ipld_hamt = { path = "../../ipld/hamt" }
 ahash = "0.7"
 anyhow = "1.0.51"
+itertools = "0.10.3"
 
 [features]
 default = []

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -20,7 +20,6 @@ lazy_static = "1.4.0"
 log = "0.4.8"
 byteorder = "1.3.4"
 ipld_hamt = { path = "../../ipld/hamt" }
-ahash = "0.7"
 anyhow = "1.0.51"
 itertools = "0.10.3"
 

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1291,8 +1291,8 @@ impl Actor {
             }
 
             let mut chain_infos = Vec::with_capacity(params.sectors.len());
-            let mut total_deposit_required= BigInt::zero();
-            let mut clean_up_events: HashMap<ChainEpoch,Vec<u64>> = HashMap::new();
+            let mut total_deposit_required = BigInt::zero();
+            let mut clean_up_events = Vec::with_capacity(params.sectors.len());
             let deal_count_max = sector_deals_max(info.sector_size);
 
             for (i, precommit) in params.sectors.iter().enumerate() {
@@ -1343,11 +1343,7 @@ impl Actor {
 			    // due epoch, ProveCommitSector would accept it, then the expiry event would remove it, and then
 			    // ConfirmSectorProofsValid would fail to find it.
                 let clean_up_bound = curr_epoch + msd + EXPIRED_PRE_COMMIT_CLEAN_UP_DELAY;
-                if let Some(cleanups) = clean_up_events.get_mut(&clean_up_bound) {
-                    cleanups.push(precommit.sector_number);
-                } else {
-                    clean_up_events.insert(clean_up_bound, vec![precommit.sector_number]);
-                }
+                clean_up_events.push((clean_up_bound, precommit.sector_number));
             }
             // Batch update actor state.
             if available_balance < total_deposit_required {

--- a/actors/miner/src/sector_map.rs
+++ b/actors/miner/src/sector_map.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use anyhow::anyhow;
 use bitfield::{BitField, UnvalidatedBitField, Validate};
@@ -11,7 +11,7 @@ use super::WPOST_PERIOD_DEADLINES;
 
 /// Maps deadlines to partition maps.
 #[derive(Default)]
-pub struct DeadlineSectorMap(HashMap<u64, PartitionSectorMap>);
+pub struct DeadlineSectorMap(BTreeMap<u64, PartitionSectorMap>);
 
 impl DeadlineSectorMap {
     pub fn new() -> Self {
@@ -97,23 +97,19 @@ impl DeadlineSectorMap {
     }
 
     /// Returns a sorted vec of deadlines in the map.
-    pub fn deadlines(&self) -> Vec<u64> {
-        let mut deadlines: Vec<_> = self.0.keys().copied().collect();
-        deadlines.sort_unstable();
-        deadlines
+    pub fn deadlines(&self) -> impl Iterator<Item = u64> + '_ {
+        self.0.keys().copied()
     }
 
     /// Walks the deadlines in deadline order.
     pub fn iter(&mut self) -> impl Iterator<Item = (u64, &mut PartitionSectorMap)> + '_ {
-        let mut vec: Vec<_> = self.0.iter_mut().map(|(&i, x)| (i, x)).collect();
-        vec.sort_unstable_by_key(|&(i, _)| i);
-        vec.into_iter()
+        self.0.iter_mut().map(|(&i, x)| (i, x))
     }
 }
 
 /// Maps partitions to sector bitfields.
 #[derive(Default, Serialize, Deserialize)]
-pub struct PartitionSectorMap(HashMap<u64, UnvalidatedBitField>);
+pub struct PartitionSectorMap(BTreeMap<u64, UnvalidatedBitField>);
 
 impl PartitionSectorMap {
     /// Records the given sectors at the given partition.
@@ -172,17 +168,13 @@ impl PartitionSectorMap {
     }
 
     /// Returns a sorted vec of partitions in the map.
-    pub fn partitions(&self) -> Vec<u64> {
-        let mut partitions: Vec<_> = self.0.keys().copied().collect();
-        partitions.sort_unstable();
-        partitions
+    pub fn partitions(&self) -> impl Iterator<Item = u64> + '_ {
+        self.0.keys().copied()
     }
 
     /// Walks the partitions in the map, in order of increasing index.
     pub fn iter(&mut self) -> impl Iterator<Item = (u64, &mut UnvalidatedBitField)> + '_ {
-        let mut vec: Vec<_> = self.0.iter_mut().map(|(&i, x)| (i, x)).collect();
-        vec.sort_unstable_by_key(|&(i, _)| i);
-        vec.into_iter()
+        self.0.iter_mut().map(|(&i, x)| (i, x))
     }
 
     pub fn len(&self) -> usize {

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -1003,7 +1003,10 @@ impl State {
         epochs.sort_unstable();
         for cleanup_epoch in epochs.iter() {
             // Can unwrap here safely because cleanup epochs are taken from the keys of that hashmap.
-            queue.add_to_queue_values(*cleanup_epoch, &cleanup_events[cleanup_epoch])?;
+            queue.add_to_queue_values(
+                *cleanup_epoch,
+                cleanup_events[cleanup_epoch].iter().copied(),
+            )?;
         }
         self.pre_committed_sectors_cleanup = queue.amt.flush()?;
         Ok(())

--- a/actors/miner/src/termination.rs
+++ b/actors/miner/src/termination.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::ops::AddAssign;
 
 use bitfield::BitField;
@@ -10,7 +10,7 @@ use fvm_shared::clock::ChainEpoch;
 #[derive(Default)]
 pub struct TerminationResult {
     /// Sectors maps epochs at which sectors expired, to bitfields of sector numbers.
-    pub sectors: HashMap<ChainEpoch, BitField>,
+    pub sectors: BTreeMap<ChainEpoch, BitField>,
     pub partitions_processed: u64,
     pub sectors_processed: u64,
 }
@@ -46,8 +46,7 @@ impl TerminationResult {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (ChainEpoch, &BitField)> {
-        let mut epochs: Vec<_> = self.sectors.iter().collect();
-        epochs.sort_by_key(|&(&epoch, _)| epoch);
-        epochs.into_iter().map(|(&i, bf)| (i, bf))
+        // The btreemap is already sorted.
+        self.sectors.iter().map(|(&epoch, bf)| (epoch, bf))
     }
 }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -14,7 +14,6 @@ num-traits = "0.2"
 num-derive = "0.3.0"
 log = "0.4.8"
 indexmap = { version = "1.7.0", features = ["serde-1"] }
-ahash = "0.7"
 cid = { version = "0.7", default-features = false, features = ["serde-codec"] }
 integer-encoding = { version = "3.0", default-features = false }
 lazy_static = "1.4.0"

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::collections::BTreeSet;
 use std::convert::TryInto;
 
 use actors_runtime::runtime::{ActorCode, Runtime};
@@ -9,7 +10,6 @@ use actors_runtime::{
     Multimap, CALLER_TYPES_SIGNABLE, CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, MINER_ACTOR_CODE_ID,
     REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
-use ahash::AHashSet;
 use anyhow::anyhow;
 use ext::init;
 use fvm_shared::address::Address;
@@ -535,7 +535,7 @@ impl Actor {
                 .map(|(info, _)| info.sector_id.number)
                 // Deduplicate
                 .filter({
-                    let mut seen = AHashSet::<_>::with_capacity(count);
+                    let mut seen = BTreeSet::<_>::new();
                     move |snum| seen.insert(*snum)
                 })
                 .collect();

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -18,7 +18,6 @@ fvm_shared = { path = "../../shared", default-features = false }
 unsigned-varint = "0.7.1"
 integer-encoding = { version = "3.0", default-features = false }
 byteorder = "1.3.4"
-ahash = "0.7"
 cid = { version = "0.7", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.15", default-features = false, features = ["identity"] }
 base64 = "0.13"

--- a/ipld/bitfield/Cargo.toml
+++ b/ipld/bitfield/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/ChainSafe/forest"
 unsigned-varint = "0.7.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
-ahash = "0.7"
 fvm_shared = { version = "0.1.0", path = "../../shared" }
 
 [dev-dependencies]

--- a/ipld/bitfield/src/lib.rs
+++ b/ipld/bitfield/src/lib.rs
@@ -39,8 +39,12 @@ impl PartialEq for BitField {
 impl FromIterator<u64> for BitField {
     fn from_iter<I: IntoIterator<Item = u64>>(iter: I) -> Self {
         let mut vec: Vec<_> = iter.into_iter().collect();
-        vec.sort_unstable();
-        Self::from_ranges(ranges_from_bits(vec))
+        if vec.is_empty() {
+            Self::new()
+        } else {
+            vec.sort_unstable();
+            Self::from_ranges(ranges_from_bits(vec))
+        }
     }
 }
 

--- a/ipld/bitfield/tests/bitfield_tests.rs
+++ b/ipld/bitfield/tests/bitfield_tests.rs
@@ -1,9 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::collections::HashSet;
 use std::iter::FromIterator;
 
-use ahash::AHashSet;
 use forest_bitfield::{bitfield, BitField};
 use fvm_shared::encoding;
 use rand::{Rng, SeedableRng};
@@ -66,7 +66,7 @@ fn set_up_test_bitfields() -> (Vec<u64>, Vec<u64>, BitField, BitField) {
 fn bitfield_union() {
     let (a, b, bf_a, bf_b) = set_up_test_bitfields();
 
-    let mut expected: AHashSet<_> = a.iter().copied().collect();
+    let mut expected: HashSet<_> = a.iter().copied().collect();
     expected.extend(b);
 
     let merged = &bf_a | &bf_b;
@@ -77,9 +77,9 @@ fn bitfield_union() {
 fn bitfield_intersection() {
     let (a, b, bf_a, bf_b) = set_up_test_bitfields();
 
-    let hs_a: AHashSet<_> = a.into_iter().collect();
-    let hs_b: AHashSet<_> = b.into_iter().collect();
-    let expected: AHashSet<_> = hs_a.intersection(&hs_b).copied().collect();
+    let hs_a: HashSet<_> = a.into_iter().collect();
+    let hs_b: HashSet<_> = b.into_iter().collect();
+    let expected: HashSet<_> = hs_a.intersection(&hs_b).copied().collect();
 
     let merged = &bf_a & &bf_b;
     assert_eq!(expected, merged.iter().collect());
@@ -89,7 +89,7 @@ fn bitfield_intersection() {
 fn bitfield_difference() {
     let (a, b, bf_a, bf_b) = set_up_test_bitfields();
 
-    let mut expected: AHashSet<_> = a.into_iter().collect();
+    let mut expected: HashSet<_> = a.into_iter().collect();
     for i in b.iter() {
         expected.remove(i);
     }


### PR DESCRIPTION
HashMaps/Sets have worst-case O(N) runtime for most operations. Runtime perf is _expected_ to be `O(1)`, but that makes randomness assumptions. Unfortunately, in a deterministic system (e.g., actors compiled to  WASM), we can't make these assumption (in the presence of malicious agents, at least).

Basically, I'm concerned an attacker may be able to pick "keys" (addresses, sector infos, etc.) such that some `O(n)` algorithm turns into an `O(n^2)` algorithm.

In practice:

1. This doesn't _really_ matter for _most_ actors. It only matters for "shared" actors where some malicious party might influence the state in such a way that some other actor (e.g., cron, in our case), might get stuck.
2. This could be significantly mitigated by seeding HashMaps with chain randomness. It would still be possible to pull off attacks, but the attacks would likely be expensive and would maybe result in a single small block delay. However, seeding HashMaps with randomness may impact gas estimation.

Overall, it's likely better to just "fix" this. In nearly all cases, the changes here shouldn't noticably impact the runtime because the theoretical runtime was _already_ `O(n log(n))`. In some cases, these changes may actually improve it.

Fixes #232.