### PR TITLE
various fixes to the VM found on the new conformance tests

### DIFF
--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -40,7 +40,7 @@ pub fn verify_signature(
     let addr: Address = context.memory.read_address(addr_off, addr_len)?;
     // plaintext doesn't need to be a mutable borrow, but otherwise we would be
     // borrowing the ctx both immutably and mutably.
-    let plaintext = context.memory.try_slice(plaintext_len, plaintext_off)?;
+    let plaintext = context.memory.try_slice(plaintext_off, plaintext_len)?;
     context
         .kernel
         .verify_signature(&sig, &addr, plaintext)
@@ -55,7 +55,7 @@ pub fn hash_blake2b(
     data_off: u32,
     data_len: u32,
 ) -> Result<[u8; 32]> {
-    let data = context.memory.try_slice(data_len, data_off)?;
+    let data = context.memory.try_slice(data_off, data_len)?;
     context.kernel.hash_blake2b(data)
 }
 

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -1,10 +1,10 @@
-use crate::kernel::Result;
+use crate::kernel::{ClassifyResult, Result};
 use crate::syscalls::context::Context;
 use crate::Kernel;
 
 pub fn log(context: Context<'_, impl Kernel>, msg_off: u32, msg_len: u32) -> Result<()> {
     let msg = context.memory.try_slice(msg_off, msg_len)?;
-    let msg = String::from_utf8(msg.to_owned()).unwrap();
+    let msg = String::from_utf8(msg.to_owned()).or_illegal_argument()?;
     context.kernel.log(msg);
     Ok(())
 }

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -22,7 +22,7 @@ pub fn verify_signature(
     let signature = signature
         .marshal_cbor()
         .expect("failed to marshal signature");
-    let signer = signer.marshal_cbor().expect("failed to marshal address");
+    let signer = signer.to_bytes();
     unsafe {
         sys::crypto::verify_signature(
             signature.as_ptr(),

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -391,14 +391,14 @@ where
         self.0.batch_verify_seals(vis)
     }
 
-    // NOT forwarded
+    // forwarded
     fn verify_signature(
         &mut self,
-        _signature: &Signature,
-        _signer: &Address,
-        _plaintext: &[u8],
+        signature: &Signature,
+        signer: &Address,
+        plaintext: &[u8],
     ) -> Result<bool> {
-        Ok(true)
+        self.0.verify_signature(signature, signer, plaintext)
     }
 
     // NOT forwarded


### PR DESCRIPTION
1. Check the exit code in the actors runtime, in addition to checking the syscall result.
2. Verify signatures in conformance tests.
3. Correctly marshal the signer address in the sdk (don't use CBOR).
4. Avoid panicking when passing non-utf8 log messages (drive-by fix).
5. Fix parameter order in some crypto syscalls.

Unfortunately, I'm not updating the conformance tests in this PR due to some outstanding issues.