### PR TITLE
ci: allow custom package installation for cargo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
             args: --package fvm --no-default-features
           - name: test
             command: test
-            args: --all --exclude fvm --exclude conformance_tests
+            args: --all --exclude fvm --exclude conformance_tests --exclude fvm_token_actor
+          - name: test-fvm-token-actor
+            command: test
+            args: --package fvm_token_actor
             packages: ocl-icd-opencl-dev
           - name: conformance
             command: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,15 @@ jobs:
             command: clippy
             args: --all --all-targets
             components: clippy
+            # otherwise the include_bytes! macro fails because this file hasn't been generated
+            files: examples/fvm/fvm_example_actor.wasm
           - name: test-fvm
             command: test
             args: --package fvm --no-default-features
           - name: test
             command: test
             args: --all --exclude fvm --exclude conformance_tests
+            packages: ocl-icd-opencl-dev
           - name: conformance
             command: test
             args: --package conformance_tests
@@ -70,9 +73,11 @@ jobs:
         version: v0.2.15
         # change this to invalidate sccache for this job
         shared-key: v0
-    # otherwise the include_bytes! macro fails because this file hasn't been generated
-    - if: ${{ matrix.command == 'clippy' }}
-      run: touch examples/fvm/fvm_example_actor.wasm
+    - if: ${{ matrix.files != '' }}
+      run: touch ${{ matrix.files }}
+      shell: bash
+    - if: ${{ matrix.packages != '' }}
+      run: sudo apt-get install -y ${{ matrix.packages }}
       shell: bash
     - name: Runing ${{ matrix.command }}
       uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,3 @@ jobs:
     - name: Making examples
       run: make examples
       shell: bash
-    - name: Testing examples
-      run: make test-examples
-      shell: bash

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ build:
 	cargo build --features builtin_actors
 .PHONY: build
 
-test-examples: test-example-token
-.PHONY: test-examples
-
 #examples: example-actor example-fvm example-blockstore-cgo
 # take the fvm examples out of the build tree; the examples will be superseded
 # by tests
@@ -27,14 +24,6 @@ example-fvm: example-actor
 example-blockstore-cgo:
 	$(MAKE) -C ./examples/blockstore-cgo
 .PHONY: example-blockstore-cgo
-
-example-token:
-	cargo build --package fvm_token_actor
-.PHONY: example-token
-
-test-example-token:
-	cargo test --package fvm_token_actor
-.PHONY: test-example-token
 
 clean:
 	cargo clean


### PR DESCRIPTION
The new target in the makefile is not needed because testing `fvm_token_actor` package is covered by the check named `test`. To make it more explicit and faster, I extracted `fvm_token_actor` tests to another job.

I also made it possible to install additional packages per `cargo` target in the workflow. Then, I used it to install `ocl-icd-opencl-dev` in the new `test-fvm-token-actor` job.

@raulk heads up, looks like there is some flakiness in the tests. One of the CI runs failed as follows: https://github.com/filecoin-project/ref-fvm/runs/4935482784?check_suite_focus=true 

###### Testing
- [x] CI