### PR TITLE
update conformance vectors

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -278,6 +278,7 @@ where
 
         // Abort early if we have a send.
         if method == METHOD_SEND {
+            log::trace!("sent {} -> {}: {}", from, to, &value);
             return Ok(InvocationResult::Return(Default::default()));
         }
 

--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -30,6 +30,7 @@ impl GasTracker {
         let to_use = charge.total();
         match self.gas_used.checked_add(to_use) {
             None => {
+                log::trace!("gas overflow: {}", charge.name);
                 self.gas_used = self.gas_available;
                 Err(syscall_error!(SysErrOutOfGas;
                     "adding gas_used={} and to_use={} overflowed",
@@ -37,7 +38,9 @@ impl GasTracker {
                 ))
             }
             Some(used) => {
+                log::trace!("charged {} gas: {}", used, charge.name);
                 if used > self.gas_available {
+                    log::trace!("out of gas: {}", charge.name);
                     self.gas_used = self.gas_available;
                     Err(syscall_error!(SysErrOutOfGas;
                             "not enough gas (used={}) (available={})",

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -40,11 +40,11 @@ either = "1.6.1"
 itertools = "0.10.3"
 num_cpus = "1.13.1"
 serde_cbor = "0.11.2"
+serde_json = { version = "1.0", features = ["raw_value"] }
 
 [dev-dependencies]
 regex = { version = "1.0" }
 walkdir = "2.3"
-serde_json = "1.0"
 flate2 = "1.0"
 lazy_static = "1.4"
 pretty_env_logger = "0.4.0"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -39,6 +39,7 @@ colored = "2"
 either = "1.6.1"
 itertools = "0.10.3"
 num_cpus = "1.13.1"
+serde_cbor = "0.11.2"
 
 [dev-dependencies]
 regex = { version = "1.0" }

--- a/testing/conformance/src/vector.rs
+++ b/testing/conformance/src/vector.rs
@@ -45,9 +45,9 @@ pub struct MetaData {
 pub struct PreConditions {
     pub state_tree: StateTreeVector,
     #[serde(default)]
-    pub basefee: Option<f64>,
+    pub basefee: Option<u128>,
     #[serde(default)]
-    pub circ_supply: Option<f64>,
+    pub circ_supply: Option<u128>,
     #[serde(default)]
     pub variants: Vec<Variant>,
 }
@@ -112,13 +112,6 @@ pub struct RandomnessRule {
     pub epoch: ChainEpoch,
     #[serde(with = "base64_bytes")]
     pub entropy: Vec<u8>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(tag = "class")]
-pub enum TestVector {
-    #[serde(rename = "message")]
-    Message(MessageVector),
 }
 
 #[derive(Debug, Deserialize)]

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -8,7 +8,7 @@ use fvm::machine::{CallError, DefaultMachine, Machine, MachineContext};
 use fvm::state_tree::{ActorState, StateTree};
 use fvm::{Config, DefaultKernel};
 use fvm_shared::address::Address;
-use fvm_shared::bigint::{BigInt, ToBigInt};
+use fvm_shared::bigint::BigInt;
 use fvm_shared::blockstore::MemoryBlockstore;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
@@ -52,7 +52,7 @@ impl TestMachine<Box<DefaultMachine<MemoryBlockstore, TestExterns>>> {
         let base_fee = v
             .preconditions
             .basefee
-            .map(|i| i.to_bigint().unwrap())
+            .map(|i| i.into())
             .unwrap_or_else(|| BigInt::from(DEFAULT_BASE_FEE));
         let epoch = variant.epoch;
         let state_root = v.preconditions.state_tree.root_cid;
@@ -90,7 +90,7 @@ impl TestMachine<Box<DefaultMachine<MemoryBlockstore, TestExterns>>> {
                 circ_supply: v
                     .preconditions
                     .circ_supply
-                    .map(|i| i.to_bigint().unwrap())
+                    .map(|i| i.into())
                     .unwrap_or_else(|| TOTAL_FILECOIN.clone()),
                 price_list: price_list,
             },

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use cid::Cid;
 use fvm::call_manager::{CallManager, DefaultCallManager, InvocationResult};
-use fvm::gas::GasTracker;
+use fvm::gas::{GasTracker, PriceList};
 use fvm::kernel::*;
 use fvm::machine::{CallError, DefaultMachine, Machine, MachineContext};
 use fvm::state_tree::{ActorState, StateTree};
@@ -33,6 +33,7 @@ const DEFAULT_BASE_FEE: u64 = 100;
 #[derive(Clone)]
 pub struct TestData {
     circ_supply: TokenAmount,
+    price_list: PriceList,
 }
 
 pub struct TestMachine<M = Box<DefaultMachine<MemoryBlockstore, TestExterns>>> {
@@ -81,6 +82,8 @@ impl TestMachine<Box<DefaultMachine<MemoryBlockstore, TestExterns>>> {
         )
         .unwrap();
 
+        let price_list = machine.context().price_list.clone();
+
         TestMachine::<Box<DefaultMachine<_, _>>> {
             machine: Box::new(machine),
             data: TestData {
@@ -89,6 +92,7 @@ impl TestMachine<Box<DefaultMachine<MemoryBlockstore, TestExterns>>> {
                     .circ_supply
                     .map(|i| i.to_bigint().unwrap())
                     .unwrap_or_else(|| TOTAL_FILECOIN.clone()),
+                price_list: price_list,
             },
         }
     }
@@ -387,11 +391,6 @@ where
     }
 
     // forwarded
-    fn batch_verify_seals(&mut self, vis: &[SealVerifyInfo]) -> Result<Vec<bool>> {
-        self.0.batch_verify_seals(vis)
-    }
-
-    // forwarded
     fn verify_signature(
         &mut self,
         signature: &Signature,
@@ -402,12 +401,21 @@ where
     }
 
     // NOT forwarded
-    fn verify_seal(&mut self, _vi: &SealVerifyInfo) -> Result<bool> {
+    fn batch_verify_seals(&mut self, vis: &[SealVerifyInfo]) -> Result<Vec<bool>> {
+        Ok(vec![true; vis.len()])
+    }
+
+    // NOT forwarded
+    fn verify_seal(&mut self, vi: &SealVerifyInfo) -> Result<bool> {
+        let charge = self.1.price_list.on_verify_seal(vi);
+        self.0.charge_gas(charge.name, charge.total())?;
         Ok(true)
     }
 
     // NOT forwarded
-    fn verify_post(&mut self, _verify_info: &WindowPoStVerifyInfo) -> Result<bool> {
+    fn verify_post(&mut self, vi: &WindowPoStVerifyInfo) -> Result<bool> {
+        let charge = self.1.price_list.on_verify_post(vi);
+        self.0.charge_gas(charge.name, charge.total())?;
         Ok(true)
     }
 
@@ -418,12 +426,16 @@ where
         _h2: &[u8],
         _extra: &[u8],
     ) -> Result<Option<ConsensusFault>> {
+        let charge = self.1.price_list.on_verify_consensus_fault();
+        self.0.charge_gas(charge.name, charge.total())?;
         // TODO this seems wrong, should probably be parameterized.
         Ok(None)
     }
 
     // NOT forwarded
-    fn verify_aggregate_seals(&mut self, _agg: &AggregateSealVerifyProofAndInfos) -> Result<bool> {
+    fn verify_aggregate_seals(&mut self, agg: &AggregateSealVerifyProofAndInfos) -> Result<bool> {
+        let charge = self.1.price_list.on_verify_aggregate_seals(agg);
+        self.0.charge_gas(charge.name, charge.total())?;
         Ok(true)
     }
 }


### PR DESCRIPTION
There were no more bugs in the FVM itself but this PR fixes a few bugs in the conformance test system:

1. Charge gas even for operations that aren't forwarded.
2. Correctly decode the circulating supply in test vectors (doesn't fit in an f64).

Additionally, it improves debuggability a bit:

1. Traces gas charges.
2. Traces value-only sends.
3. Make state-diffing work with partial states (i.e., just diff the relevant actors).
4. Very basic actor state diffing (diffs the root object as cbor).