### PR TITLE
Remove unused deal ids from SealVerifyInfo

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3606,7 +3606,6 @@ where
             miner: miner_actor_id,
             number: params.sector_num,
         },
-        deal_ids: params.deal_ids,
         interactive_randomness,
         proof: params.proof,
         randomness,

--- a/shared/src/sector/seal.rs
+++ b/shared/src/sector/seal.rs
@@ -21,7 +21,6 @@ pub type InteractiveSealRandomness = Randomness;
 pub struct SealVerifyInfo {
     pub registered_proof: RegisteredSealProof,
     pub sector_id: SectorID,
-    pub deal_ids: Vec<deal::DealID>,
     pub randomness: SealRandomness,
     pub interactive_randomness: InteractiveSealRandomness,
     #[serde(with = "serde_bytes")]


### PR DESCRIPTION
The deal IDs are unused in `SealVerifyInfo`. It was an error that they remained in the Go version of this struct, which was replicated here. This is a nice opportunity to clean it up without prompting updates to a bunch of Go repos (such as filecoin-project/filecoin-ffi).