### PR TITLE
actors v7: implement FIP29, ability to remove DataCap

### DIFF
--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/filecoin-project/fvm"
 [dependencies]
 actors-runtime = { path = "../runtime" }
 fvm_shared = { path = "../../shared", default-features = false }
+fvm_sdk = { path = "../../sdk" }
 ipld_hamt = { path = "../../ipld/hamt" }
 serde = { version = "1.0", features = ["derive"] }
 num-traits = "0.2"
@@ -27,5 +28,3 @@ runtime-wasm = ["actors-runtime/runtime-wasm"]
 
 [build-dependencies]
 wasm-builder = "3.0.1"
-
-

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/filecoin-project/fvm"
 [dependencies]
 actors-runtime = { path = "../runtime" }
 fvm_shared = { path = "../../shared", default-features = false }
+ipld_hamt = { path = "../../ipld/hamt" }
 serde = { version = "1.0", features = ["derive"] }
 num-traits = "0.2"
 num-derive = "0.3.0"

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -748,6 +748,7 @@ where
         verified_client: client,
     };
 
+    // TODO: in lotus this does rt.Abortf, what's the equivalent here?
     let buf = RawBytes::serialize(proposal).map_err(|e| {
         actor_error!(
             ErrSerialization,
@@ -757,6 +758,15 @@ where
     })?;
 
     // verify signature of proposal
+    // TOOD: same here w/ the Abortf
+    rt.verify_signature(&request.signature, &request.verifier, &buf)
+        .map_err(|e| {
+            actor_error!(
+                ErrIllegalArgument,
+                "invalid signature for datacap removal request: {}",
+                e
+            )
+        })?;
 
     Ok(())
 }

--- a/actors/verifreg/src/state.rs
+++ b/actors/verifreg/src/state.rs
@@ -14,6 +14,7 @@ pub struct State {
     pub root_key: Address,
     pub verifiers: Cid,
     pub verified_clients: Cid,
+    pub remove_data_cap_proposal_ids: Cid,
 }
 
 impl State {
@@ -26,6 +27,7 @@ impl State {
             root_key,
             verifiers: empty_map,
             verified_clients: empty_map,
+            remove_data_cap_proposal_ids: empty_map,
         })
     }
 }

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -8,6 +8,7 @@ use fvm_shared::encoding::tuple::*;
 use fvm_shared::sector::StoragePower;
 use lazy_static::lazy_static;
 use num_traits::FromPrimitive;
+use serde::{Deserialize, Serialize};
 
 #[cfg(not(feature = "devnet"))]
 lazy_static! {
@@ -67,4 +68,35 @@ pub struct RemoveDataCapReturn {
     pub data_cap_removed: DataCap,
 }
 
-pub type RemoveDataCapProposalID = u64;
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct RemoveDataCapProposalID(pub u64);
+
+#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct RemoveDataCapProposal {
+    pub verified_client: Address,
+    #[serde(with = "bigint_ser")]
+    pub data_cap_amount: DataCap,
+    pub removal_proposal_id: RemoveDataCapProposalID,
+}
+
+pub struct AddrPairKey {
+    pub first: Address,
+    pub second: Address,
+}
+
+impl AddrPairKey {
+    pub fn new(first: Address, second: Address) -> Self {
+        AddrPairKey {
+            first: first,
+            second: second,
+        }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut first = self.first.to_bytes();
+        let mut second = self.second.to_bytes();
+        first.append(&mut second);
+        first
+    }
+}

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -66,3 +66,5 @@ pub struct RemoveDataCapReturn {
     #[serde(with = "bigint_ser")]
     pub data_cap_removed: DataCap,
 }
+
+pub type RemoveDataCapProposalID = u64;

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -3,6 +3,7 @@
 
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
+use fvm_shared::crypto::signature::Signature;
 use fvm_shared::encoding::tuple::*;
 use fvm_shared::sector::StoragePower;
 use lazy_static::lazy_static;
@@ -43,3 +44,25 @@ pub struct BytesParams {
 
 pub type UseBytesParams = BytesParams;
 pub type RestoreBytesParams = BytesParams;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct RemoveDataCapParams {
+    pub verified_client_to_remove: Address,
+    #[serde(with = "bigint_ser")]
+    pub data_cap_amount_to_remove: DataCap,
+    pub verifier_request_1: RemoveDataCapRequest,
+    pub verifier_request_2: RemoveDataCapRequest,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct RemoveDataCapRequest {
+    pub verifier: Address,
+    pub signature: Signature,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct RemoveDataCapReturn {
+    pub verified_client: Address,
+    #[serde(with = "bigint_ser")]
+    pub data_cap_removed: DataCap,
+}


### PR DESCRIPTION
implements FIP29, here's the Lotus PR for comparison: https://github.com/filecoin-project/specs-actors/pull/1546

I still need to add unit tests and update the test vectors.