### PR TITLE
feat: properly handle implicit messages

### DIFF
--- a/fvm/src/call_manager/backtrace.rs
+++ b/fvm/src/call_manager/backtrace.rs
@@ -29,6 +29,11 @@ impl Display for Backtrace {
 }
 
 impl Backtrace {
+    /// Returns true if the backtrace is completely empty.
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty() && self.cause.is_none()
+    }
+
     /// Clear the backtrace. This should be called:
     ///
     /// 1. Before all syscalls except "abort"

--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -86,6 +86,13 @@ impl ApplyRet {
     }
 }
 
+/// The kind of message being applied:
+///
+/// 1. Explicit messages may only come from account actors and charge the sending account for gas
+/// consumed.
+/// 2. Implicit messages may come from any actor, ignore the nonce, and charge no gas (but still
+/// account for it).
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
 pub enum ApplyKind {
     Explicit,
     Implicit,


### PR DESCRIPTION
We still account for gas, but we:

1. Don't charge on-chain gas.
2. Don't debt for gas.
3. Don't check the nonce.

NOTES:

1. We still _use_ the nonce (e.g., for actor creation).
2. We still account for gas.

Honestly, we should probably just have _two_ methods, but untangling these is a bit tricky.