### PR TITLE
Revert "Remove unused deal ids from SealVerifyInfo"

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3606,6 +3606,7 @@ where
             miner: miner_actor_id,
             number: params.sector_num,
         },
+        deal_ids: params.deal_ids,
         interactive_randomness,
         proof: params.proof,
         randomness,

--- a/shared/src/sector/seal.rs
+++ b/shared/src/sector/seal.rs
@@ -21,6 +21,7 @@ pub type InteractiveSealRandomness = Randomness;
 pub struct SealVerifyInfo {
     pub registered_proof: RegisteredSealProof,
     pub sector_id: SectorID,
+    pub deal_ids: Vec<deal::DealID>,
     pub randomness: SealRandomness,
     pub interactive_randomness: InteractiveSealRandomness,
     #[serde(with = "serde_bytes")]


### PR DESCRIPTION
Reverts filecoin-project/ref-fvm#304

These get written to state when submitting seals for "bulk verification". This will require a network upgrade.

Unfortunately, when this PR was merged, conformance testing in CI was broken (see #310).