### PR TITLE
actors: fix wasm build flags

### DIFF
--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -25,6 +25,6 @@ runtime-wasm = ["actors-runtime/runtime-wasm"]
 
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+wasm-builder = { package = "substrate-wasm-builder", git = "https://github.com/paritytech/substrate" }
 
 

--- a/actors/account/build.rs
+++ b/actors/account/build.rs
@@ -2,11 +2,10 @@ fn main() {
     use wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
-        .import_memory()
         .append_to_rust_flags("-Ctarget-feature=+crt-static")
         .append_to_rust_flags("-Cpanic=abort")
-        .append_to_rust_flags("-Coverflow-checks=true")
-        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Coverflow-checks=yes")
+        .append_to_rust_flags("-Clto=thin")
         .append_to_rust_flags("-Copt-level=z")
         .build()
 }

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -26,6 +26,6 @@ runtime-wasm = ["actors-runtime/runtime-wasm"]
 
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+wasm-builder = { package = "substrate-wasm-builder", git = "https://github.com/paritytech/substrate" }
 
 

--- a/actors/cron/build.rs
+++ b/actors/cron/build.rs
@@ -2,11 +2,10 @@ fn main() {
     use wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
-        .import_memory()
         .append_to_rust_flags("-Ctarget-feature=+crt-static")
         .append_to_rust_flags("-Cpanic=abort")
-        .append_to_rust_flags("-Coverflow-checks=true")
-        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Coverflow-checks=yes")
+        .append_to_rust_flags("-Clto=thin")
         .append_to_rust_flags("-Copt-level=z")
         .build()
 }

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -29,6 +29,6 @@ runtime-wasm = ["actors-runtime/runtime-wasm"]
 
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+wasm-builder = { package = "substrate-wasm-builder", git = "https://github.com/paritytech/substrate" }
 
 

--- a/actors/init/build.rs
+++ b/actors/init/build.rs
@@ -2,11 +2,10 @@ fn main() {
     use wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
-        .import_memory()
         .append_to_rust_flags("-Ctarget-feature=+crt-static")
         .append_to_rust_flags("-Cpanic=abort")
-        .append_to_rust_flags("-Coverflow-checks=true")
-        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Coverflow-checks=yes")
+        .append_to_rust_flags("-Clto=thin")
         .append_to_rust_flags("-Copt-level=z")
         .build()
 }

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -31,6 +31,6 @@ runtime-wasm = ["actors-runtime/runtime-wasm"]
 
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+wasm-builder = { package = "substrate-wasm-builder", git = "https://github.com/paritytech/substrate" }
 
 

--- a/actors/market/build.rs
+++ b/actors/market/build.rs
@@ -2,11 +2,10 @@ fn main() {
     use wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
-        .import_memory()
         .append_to_rust_flags("-Ctarget-feature=+crt-static")
         .append_to_rust_flags("-Cpanic=abort")
-        .append_to_rust_flags("-Coverflow-checks=true")
-        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Coverflow-checks=yes")
+        .append_to_rust_flags("-Clto=thin")
         .append_to_rust_flags("-Copt-level=z")
         .build()
 }

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -31,6 +31,6 @@ runtime-wasm = ["actors-runtime/runtime-wasm"]
 
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+wasm-builder = { package = "substrate-wasm-builder", git = "https://github.com/paritytech/substrate" }
 
 

--- a/actors/miner/build.rs
+++ b/actors/miner/build.rs
@@ -2,11 +2,10 @@ fn main() {
     use wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
-        .import_memory()
         .append_to_rust_flags("-Ctarget-feature=+crt-static")
         .append_to_rust_flags("-Cpanic=abort")
-        .append_to_rust_flags("-Coverflow-checks=true")
-        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Coverflow-checks=yes")
+        .append_to_rust_flags("-Clto=thin")
         .append_to_rust_flags("-Copt-level=z")
         .build()
 }

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -27,6 +27,6 @@ runtime-wasm = ["actors-runtime/runtime-wasm"]
 
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+wasm-builder = { package = "substrate-wasm-builder", git = "https://github.com/paritytech/substrate" }
 
 

--- a/actors/multisig/build.rs
+++ b/actors/multisig/build.rs
@@ -2,11 +2,10 @@ fn main() {
     use wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
-        .import_memory()
         .append_to_rust_flags("-Ctarget-feature=+crt-static")
         .append_to_rust_flags("-Cpanic=abort")
-        .append_to_rust_flags("-Coverflow-checks=true")
-        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Coverflow-checks=yes")
+        .append_to_rust_flags("-Clto=thin")
         .append_to_rust_flags("-Copt-level=z")
         .build()
 }

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -29,6 +29,6 @@ runtime-wasm = ["actors-runtime/runtime-wasm"]
 
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+wasm-builder = { package = "substrate-wasm-builder", git = "https://github.com/paritytech/substrate" }
 
 

--- a/actors/paych/build.rs
+++ b/actors/paych/build.rs
@@ -2,11 +2,10 @@ fn main() {
     use wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
-        .import_memory()
         .append_to_rust_flags("-Ctarget-feature=+crt-static")
         .append_to_rust_flags("-Cpanic=abort")
-        .append_to_rust_flags("-Coverflow-checks=true")
-        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Coverflow-checks=yes")
+        .append_to_rust_flags("-Clto=thin")
         .append_to_rust_flags("-Copt-level=z")
         .build()
 }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -29,6 +29,6 @@ runtime-wasm = ["actors-runtime/runtime-wasm"]
 
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+wasm-builder = { package = "substrate-wasm-builder", git = "https://github.com/paritytech/substrate" }
 
 

--- a/actors/power/build.rs
+++ b/actors/power/build.rs
@@ -2,11 +2,10 @@ fn main() {
     use wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
-        .import_memory()
         .append_to_rust_flags("-Ctarget-feature=+crt-static")
         .append_to_rust_flags("-Cpanic=abort")
-        .append_to_rust_flags("-Coverflow-checks=true")
-        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Coverflow-checks=yes")
+        .append_to_rust_flags("-Clto=thin")
         .append_to_rust_flags("-Copt-level=z")
         .build()
 }

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -28,6 +28,6 @@ runtime-wasm = ["actors-runtime/runtime-wasm"]
 
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+wasm-builder = { package = "substrate-wasm-builder", git = "https://github.com/paritytech/substrate" }
 
 

--- a/actors/reward/build.rs
+++ b/actors/reward/build.rs
@@ -2,11 +2,10 @@ fn main() {
     use wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
-        .import_memory()
         .append_to_rust_flags("-Ctarget-feature=+crt-static")
         .append_to_rust_flags("-Cpanic=abort")
-        .append_to_rust_flags("-Coverflow-checks=true")
-        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Coverflow-checks=yes")
+        .append_to_rust_flags("-Clto=thin")
         .append_to_rust_flags("-Copt-level=z")
         .build()
 }

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -46,4 +46,4 @@ test_utils = ["hex"]
 runtime-wasm = ["fvm_sdk"]
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+wasm-builder = { package = "substrate-wasm-builder", git = "https://github.com/paritytech/substrate" }

--- a/actors/runtime/build.rs
+++ b/actors/runtime/build.rs
@@ -2,11 +2,10 @@ fn main() {
     use wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
-        .import_memory()
         .append_to_rust_flags("-Ctarget-feature=+crt-static")
         .append_to_rust_flags("-Cpanic=abort")
-        .append_to_rust_flags("-Coverflow-checks=true")
-        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Coverflow-checks=yes")
+        .append_to_rust_flags("-Clto=thin")
         .append_to_rust_flags("-Copt-level=z")
         .build()
 }

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -22,6 +22,6 @@ runtime-wasm = ["actors-runtime/runtime-wasm"]
 
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+wasm-builder = { package = "substrate-wasm-builder", git = "https://github.com/paritytech/substrate" }
 
 

--- a/actors/system/build.rs
+++ b/actors/system/build.rs
@@ -2,11 +2,10 @@ fn main() {
     use wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
-        .import_memory()
         .append_to_rust_flags("-Ctarget-feature=+crt-static")
         .append_to_rust_flags("-Cpanic=abort")
-        .append_to_rust_flags("-Coverflow-checks=true")
-        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Coverflow-checks=yes")
+        .append_to_rust_flags("-Clto=thin")
         .append_to_rust_flags("-Copt-level=z")
         .build()
 }

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -25,6 +25,6 @@ runtime-wasm = ["actors-runtime/runtime-wasm"]
 
 
 [build-dependencies]
-wasm-builder = "3.0.1"
+wasm-builder = { package = "substrate-wasm-builder", git = "https://github.com/paritytech/substrate" }
 
 

--- a/actors/verifreg/build.rs
+++ b/actors/verifreg/build.rs
@@ -2,11 +2,10 @@ fn main() {
     use wasm_builder::WasmBuilder;
     WasmBuilder::new()
         .with_current_project()
-        .import_memory()
         .append_to_rust_flags("-Ctarget-feature=+crt-static")
         .append_to_rust_flags("-Cpanic=abort")
-        .append_to_rust_flags("-Coverflow-checks=true")
-        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Coverflow-checks=yes")
+        .append_to_rust_flags("-Clto=thin")
         .append_to_rust_flags("-Copt-level=z")
         .build()
 }

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -172,27 +172,27 @@ where
         // Otherwise, load it.
         use anyhow::Context;
         let binary = if code == &*crate::builtin::SYSTEM_ACTOR_CODE_ID {
-            fvm_actor_system::wasm::WASM_BINARY
+            fvm_actor_system::wasm::WASM_BINARY_BLOATY
         } else if code == &*crate::builtin::INIT_ACTOR_CODE_ID {
-            fvm_actor_init::wasm::WASM_BINARY
+            fvm_actor_init::wasm::WASM_BINARY_BLOATY
         } else if code == &*crate::builtin::CRON_ACTOR_CODE_ID {
-            fvm_actor_cron::wasm::WASM_BINARY
+            fvm_actor_cron::wasm::WASM_BINARY_BLOATY
         } else if code == &*crate::builtin::ACCOUNT_ACTOR_CODE_ID {
-            fvm_actor_account::wasm::WASM_BINARY
+            fvm_actor_account::wasm::WASM_BINARY_BLOATY
         } else if code == &*crate::builtin::POWER_ACTOR_CODE_ID {
-            fvm_actor_power::wasm::WASM_BINARY
+            fvm_actor_power::wasm::WASM_BINARY_BLOATY
         } else if code == &*crate::builtin::MINER_ACTOR_CODE_ID {
-            fvm_actor_miner::wasm::WASM_BINARY
+            fvm_actor_miner::wasm::WASM_BINARY_BLOATY
         } else if code == &*crate::builtin::MARKET_ACTOR_CODE_ID {
-            fvm_actor_market::wasm::WASM_BINARY
+            fvm_actor_market::wasm::WASM_BINARY_BLOATY
         } else if code == &*crate::builtin::PAYCH_ACTOR_CODE_ID {
-            fvm_actor_paych::wasm::WASM_BINARY
+            fvm_actor_paych::wasm::WASM_BINARY_BLOATY
         } else if code == &*crate::builtin::MULTISIG_ACTOR_CODE_ID {
-            fvm_actor_multisig::wasm::WASM_BINARY
+            fvm_actor_multisig::wasm::WASM_BINARY_BLOATY
         } else if code == &*crate::builtin::REWARD_ACTOR_CODE_ID {
-            fvm_actor_reward::wasm::WASM_BINARY
+            fvm_actor_reward::wasm::WASM_BINARY_BLOATY
         } else if code == &*crate::builtin::VERIFREG_ACTOR_CODE_ID {
-            fvm_actor_verifreg::wasm::WASM_BINARY
+            fvm_actor_verifreg::wasm::WASM_BINARY_BLOATY
         } else {
             None
         };


### PR DESCRIPTION
- Use substrate-wasm-builder (upstream) not wasm-builder (a fork).
- Use the latest git to make sure the flags are actually applied
- Fix the flags:
    - overflow-checks=yes
    - lto=thin (I tried fat, but the build times were significantly and the binary sizes were no smaller)

fixes #322