### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Here's what you'll find in each directory:
   - Focus: theoretical correctness.
   - Estimated: end of January '22.
 - Beta: 
-  - Declared when: all of the above + syncing mainnet consistently, keeping up with chain consistently.
+  - Declared when: all of the above + syncing mainnet consistently, keeping up with chain consistently, i.e. when Phase 0 from the [FVM milestone roadmap](https://filecoin.io/blog/posts/introducing-the-filecoin-virtual-machine/) is reached.
   - Focus: production-readiness, performance, live consensus correctness.
   - Estimated: late February '22.
 - RC:
@@ -78,7 +78,7 @@ Here's what you'll find in each directory:
   - Focus: pre-mainnet preparations.
   - Estimated: March '22.
 - Final:
-  - Declared when: FVM v0 is securing mainnet, i.e. when M1 from the [FVM milestone roadmap](https://filecoin.io/blog/posts/introducing-the-filecoin-virtual-machine/) is reached.
+  - Declared when: FVM v0 is securing mainnet, i.e. when Phase 1 from the [FVM milestone roadmap](https://filecoin.io/blog/posts/introducing-the-filecoin-virtual-machine/) is reached.
   - Estimated: end of March '22.
 
 ### v1: Fully-programmable FVM (with EVM foreign runtime support)
@@ -96,7 +96,7 @@ Here's what you'll find in each directory:
   - Focus: pre-mainnet preparations.
   - Estimated: June '22.
 - Final:
-  - Declared when: FVM v1 is operating mainnet, i.e. when M2 from the [FVM milestone roadmap](https://filecoin.io/blog/posts/introducing-the-filecoin-virtual-machine/) is reached.
+  - Declared when: FVM v1 is operating mainnet, i.e. when Ph****ase 2 from the [FVM milestone roadmap](https://filecoin.io/blog/posts/introducing-the-filecoin-virtual-machine/) is reached.
   - Estimated: end of June '22.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Here's what you'll find in each directory:
   - Focus: pre-mainnet preparations.
   - Estimated: June '22.
 - Final:
-  - Declared when: FVM v1 is operating mainnet, i.e. when Ph****ase 2 from the [FVM milestone roadmap](https://filecoin.io/blog/posts/introducing-the-filecoin-virtual-machine/) is reached.
+  - Declared when: FVM v1 is operating mainnet, i.e. when Phase 2 from the [FVM milestone roadmap](https://filecoin.io/blog/posts/introducing-the-filecoin-virtual-machine/) is reached.
   - Estimated: end of June '22.
 
 ## License

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -186,7 +186,7 @@ pub trait CircSupplyOps {
 ///
 /// TODO this is unsafe; most gas charges should occur as part of syscalls, but
 ///  some built-in actors currently charge gas explicitly for concrete actions.
-///  In the future (M1), this should disappear and be replaced by gas instrumentation
+///  In the future (Phase 1), this should disappear and be replaced by gas instrumentation
 ///  at the WASM level.
 pub trait GasOps {
     /// ChargeGas charges specified amount of `gas` for execution.


### PR DESCRIPTION
Update the milestone name to match the roadmap shared in https://filecoin.io/blog/posts/introducing-the-filecoin-virtual-machine/ (which uses Phase 0/1/2/3/4 instead of M0/1/2/3)