### PR TITLE
feat: remove a block copy on read

### DIFF
--- a/fvm/src/kernel/blocks.rs
+++ b/fvm/src/kernel/blocks.rs
@@ -1,5 +1,4 @@
 use std::convert::TryInto;
-use std::rc::Rc;
 
 use cid::Cid;
 use thiserror::Error;
@@ -24,13 +23,12 @@ pub struct BlockStat {
 
 #[derive(Clone)]
 pub struct Block {
-    // TODO rm pub, provide accessors and constructor instead?
-    pub(crate) codec: u64,
-    pub(crate) data: Rc<[u8]>,
+    codec: u64,
+    data: Box<[u8]>,
 }
 
 impl Block {
-    pub fn new(codec: u64, data: impl Into<Rc<[u8]>>) -> Self {
+    pub fn new(codec: u64, data: impl Into<Box<[u8]>>) -> Self {
         // TODO: check size on the way in?
         Self {
             codec,
@@ -38,18 +36,22 @@ impl Block {
         }
     }
 
+    #[inline(always)]
     pub fn codec(&self) -> u64 {
         self.codec
     }
 
+    #[inline(always)]
     pub fn data(&self) -> &[u8] {
         &self.data
     }
 
+    #[inline(always)]
     pub fn size(&self) -> u32 {
         self.data.len() as u32
     }
 
+    #[inline(always)]
     pub fn stat(&self) -> BlockStat {
         BlockStat {
             codec: self.codec(),

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -321,7 +321,7 @@ where
                 syscall_error!(IllegalArgument; "invalid hash length: {}", hash_len).into(),
             );
         }
-        let k = Cid::new_v1(block.codec, hash.truncate(hash_len as u8));
+        let k = Cid::new_v1(block.codec(), hash.truncate(hash_len as u8));
         // TODO: for now, we _put_ the block here. In the future, we should put it into a write
         // cache, then flush it later.
         self.call_manager
@@ -332,7 +332,7 @@ where
     }
 
     fn block_read(&self, id: BlockId, offset: u32, buf: &mut [u8]) -> Result<u32> {
-        let data = &self.blocks.get(id).or_illegal_argument()?.data;
+        let data = self.blocks.get(id).or_illegal_argument()?.data();
         Ok(if offset as usize >= data.len() {
             0
         } else {


### PR DESCRIPTION
By using a `Box` instead of an `Rc`. We had an `Rc` to facilitate sharing (immutable) blocks between actors, but we never used it for that _anyways_.

Also make the block fields private.