### PR TITLE
feat: cache block existence

### DIFF
--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::RawBytes;
@@ -40,7 +42,7 @@ pub trait CallManager: 'static {
     ) -> Result<InvocationResult>;
 
     /// Finishes execution, returning the gas used and the machine.
-    fn finish(self) -> (i64, backtrace::Backtrace, Self::Machine);
+    fn finish(self) -> (i64, backtrace::Backtrace, WasmStats, Self::Machine);
 
     /// Returns a reference to the machine.
     fn machine(&self) -> &Self::Machine;
@@ -117,4 +119,12 @@ impl InvocationResult {
             Self::Failure(e) => *e,
         }
     }
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct WasmStats {
+    /// Wasm fuel used over the course of the message execution.
+    pub fuel_used: u64,
+    /// Time spent inside wasm code.
+    pub wasm_duration: Duration,
 }

--- a/fvm/src/machine/engine.rs
+++ b/fvm/src/machine/engine.rs
@@ -13,12 +13,6 @@ use crate::Kernel;
 #[derive(Clone)]
 pub struct Engine(Arc<EngineInner>);
 
-impl Default for Engine {
-    fn default() -> Self {
-        Engine::new(&wasmtime::Config::default()).unwrap()
-    }
-}
-
 struct EngineInner {
     engine: wasmtime::Engine,
     module_cache: Mutex<HashMap<Cid, Module>>,
@@ -33,10 +27,16 @@ impl Deref for Engine {
     }
 }
 
+impl Default for Engine {
+    fn default() -> Self {
+        Engine::new(&wasmtime::Config::new()).unwrap()
+    }
+}
+
 impl Engine {
     /// Create a new Engine from a wasmtime config.
     pub fn new(c: &wasmtime::Config) -> anyhow::Result<Self> {
-        Ok(wasmtime::Engine::new(c)?.into())
+        Ok(wasmtime::Engine::new(c.clone().consume_fuel(true))?.into())
     }
 }
 

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use cid::Cid;
 use wasmtime::Linker;
 
@@ -28,6 +30,9 @@ pub struct InvocationData<K> {
     /// The last-seen syscall error. This error is considered the abort "cause" if an actor aborts
     /// after receiving this error without calling any other syscalls.
     pub last_error: Option<backtrace::Cause>,
+    /// The time spent processing syscalls, including sends to other actors.
+    /// TODO: make this optional.
+    pub syscall_time: Duration,
 }
 
 impl<K> InvocationData<K> {
@@ -35,6 +40,7 @@ impl<K> InvocationData<K> {
         Self {
             kernel,
             last_error: None,
+            syscall_time: Duration::default(),
         }
     }
 }

--- a/testing/conformance/src/bin/perf-conformance.rs
+++ b/testing/conformance/src/bin/perf-conformance.rs
@@ -40,6 +40,7 @@ fn main() {
     }
     let engine = Engine::new(
         wasmtime::Config::default()
+            .consume_fuel(true)
             .profiler(wasmtime::ProfilingStrategy::VTune)
             .expect("failed to configure profiler"),
     )

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
 use cid::Cid;
-use fvm::call_manager::{Backtrace, CallManager, DefaultCallManager, InvocationResult};
+use fvm::call_manager::{Backtrace, CallManager, DefaultCallManager, InvocationResult, WasmStats};
 use fvm::gas::{GasTracker, PriceList};
 use fvm::kernel::*;
 use fvm::machine::{DefaultMachine, Engine, Machine, MachineContext};
@@ -191,7 +191,7 @@ where
         })
     }
 
-    fn finish(self) -> (i64, Backtrace, Self::Machine) {
+    fn finish(self) -> (i64, Backtrace, WasmStats, Self::Machine) {
         self.0.finish()
     }
 


### PR DESCRIPTION
When we read blocks from the underlying blockstore, cache that they exist. That way we can skip them in flush in case we write them back unchanged (which is, unfortunately, something we tend to do quite frequently).

Lotus does this by checking if we "have" blocks in the datastore before recursively copying some subdag. I'm trying to cheat here a bit to avoid the overhead of calling into cgo.