### PR TITLE
clean child in link node only if child is deleted

### DIFF
--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -390,10 +390,10 @@ where
                 let deleted = child_node.rm_value(hashed_key, bit_width, depth + 1, key, store)?;
                 if deleted.is_some() {
                     *child = Pointer::Dirty(std::mem::take(child_node));
+                    // Clean to retrieve canonical form
+                    child.clean()?;
                 }
 
-                // Clean to retrieve canonical form
-                child.clean()?;
                 Ok(deleted)
             }
             Pointer::Dirty(n) => {


### PR DESCRIPTION
Ran into an issue when attempting to sync calibnet on Forest. Seems to prevent panics and allows the node to sync up to the network