### PR TITLE
fix: exclude test-vectors submodule from crate

### DIFF
--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -3,6 +3,7 @@ name = "conformance_tests"
 version = "0.1.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"
+exclude = ["/test-vectors"]
 
 [dependencies]
 anyhow = "1.0.47"


### PR DESCRIPTION
Related to #344, but this doesn't fix it (see the linked cargo issue).