### PR TITLE
feat: optimize actor loading

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -57,6 +57,7 @@ fvm_actor_power = { path = "../actors/power", optional = true }
 fvm_actor_reward = { path = "../actors/reward", optional = true }
 fvm_actor_system = { path = "../actors/system", optional = true }
 fvm_actor_verifreg = { path = "../actors/verifreg", optional = true }
+anymap = "0.12.1"
 
 [dependencies.wasmtime]
 version = "0.33.0"

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -2,9 +2,8 @@ use cid::Cid;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::ActorID;
-use wasmtime::{Engine, Module};
 
-use super::{Machine, MachineContext};
+use super::{Engine, Machine, MachineContext};
 use crate::kernel::Result;
 use crate::state_tree::{ActorState, StateTree};
 use crate::Config;
@@ -51,11 +50,6 @@ impl<M: Machine> Machine for Box<M> {
     #[inline(always)]
     fn create_actor(&mut self, addr: &Address, act: ActorState) -> Result<ActorID> {
         (&mut **self).create_actor(addr, act)
-    }
-
-    #[inline(always)]
-    fn load_module(&self, code: &Cid) -> Result<Module> {
-        (&**self).load_module(code)
     }
 
     #[inline(always)]

--- a/fvm/src/machine/engine.rs
+++ b/fvm/src/machine/engine.rs
@@ -1,16 +1,36 @@
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::ops::Deref;
+use std::sync::{Arc, Mutex};
 
 use cid::Cid;
-use derive_more::Deref;
-use wasmtime::Module;
+use wasmtime::{Linker, Module};
+
+use crate::syscalls::{bind_syscalls, InvocationData};
+use crate::Kernel;
 
 /// A caching wasmtime engine.
-#[derive(Deref, Default, Clone)]
-pub struct Engine {
-    #[deref]
+#[derive(Clone)]
+pub struct Engine(Arc<EngineInner>);
+
+impl Default for Engine {
+    fn default() -> Self {
+        Engine::new(&wasmtime::Config::default()).unwrap()
+    }
+}
+
+struct EngineInner {
     engine: wasmtime::Engine,
-    modules: Arc<RwLock<HashMap<Cid, Module>>>,
+    module_cache: Mutex<HashMap<Cid, Module>>,
+    instance_cache: Mutex<anymap::Map<dyn anymap::any::Any + Send>>,
+}
+
+impl Deref for Engine {
+    type Target = wasmtime::Engine;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0.engine
+    }
 }
 
 impl Engine {
@@ -22,40 +42,151 @@ impl Engine {
 
 impl From<wasmtime::Engine> for Engine {
     fn from(engine: wasmtime::Engine) -> Self {
-        Engine {
+        let engine = Engine(Arc::new(EngineInner {
             engine,
-            modules: Default::default(),
-        }
+            module_cache: Default::default(),
+            instance_cache: Mutex::new(anymap::Map::new()),
+        }));
+
+        #[cfg(feature = "builtin_actors")]
+        engine.preload();
+
+        engine
     }
 }
 
+struct Cache<K> {
+    linker: wasmtime::Linker<InvocationData<K>>,
+    instances: HashMap<Cid, wasmtime::InstancePre<InvocationData<K>>>,
+}
+
 impl Engine {
-    /// Lookup a loaded wasmtime module.
-    pub fn get(&self, k: &Cid) -> Option<Module> {
-        self.modules
-            .read()
-            .expect("modules poisoned")
-            .get(k)
-            .cloned()
+    #[cfg(feature = "builtin_actors")]
+    fn preload(&self) {
+        let actors = [
+            (
+                &*crate::builtin::SYSTEM_ACTOR_CODE_ID,
+                fvm_actor_system::wasm::WASM_BINARY_BLOATY,
+            ),
+            (
+                &*crate::builtin::INIT_ACTOR_CODE_ID,
+                fvm_actor_init::wasm::WASM_BINARY_BLOATY,
+            ),
+            (
+                &*crate::builtin::CRON_ACTOR_CODE_ID,
+                fvm_actor_cron::wasm::WASM_BINARY_BLOATY,
+            ),
+            (
+                &*crate::builtin::ACCOUNT_ACTOR_CODE_ID,
+                fvm_actor_account::wasm::WASM_BINARY_BLOATY,
+            ),
+            (
+                &*crate::builtin::POWER_ACTOR_CODE_ID,
+                fvm_actor_power::wasm::WASM_BINARY_BLOATY,
+            ),
+            (
+                &*crate::builtin::MINER_ACTOR_CODE_ID,
+                fvm_actor_miner::wasm::WASM_BINARY_BLOATY,
+            ),
+            (
+                &*crate::builtin::MARKET_ACTOR_CODE_ID,
+                fvm_actor_market::wasm::WASM_BINARY_BLOATY,
+            ),
+            (
+                &*crate::builtin::PAYCH_ACTOR_CODE_ID,
+                fvm_actor_paych::wasm::WASM_BINARY_BLOATY,
+            ),
+            (
+                &*crate::builtin::MULTISIG_ACTOR_CODE_ID,
+                fvm_actor_multisig::wasm::WASM_BINARY_BLOATY,
+            ),
+            (
+                &*crate::builtin::REWARD_ACTOR_CODE_ID,
+                fvm_actor_reward::wasm::WASM_BINARY_BLOATY,
+            ),
+            (
+                &*crate::builtin::VERIFREG_ACTOR_CODE_ID,
+                fvm_actor_verifreg::wasm::WASM_BINARY_BLOATY,
+            ),
+        ];
+
+        for (k, bytecode) in actors {
+            self.load_bytecode(k, bytecode.expect("precompiled actor not found"))
+                .expect("failed to compile built-in actor");
+        }
     }
 
     /// Load some wasm code into the engine.
-    pub fn load(&self, k: &Cid, wasm: &[u8]) -> anyhow::Result<Module> {
-        let module = Module::from_binary(&self.engine, wasm)?;
-        self.modules
-            .write()
-            .expect("modules poisoned")
+    pub fn load_bytecode(&self, k: &Cid, wasm: &[u8]) -> anyhow::Result<Module> {
+        let module = Module::from_binary(&self.0.engine, wasm)?;
+        self.0
+            .module_cache
+            .lock()
+            .expect("module_cache poisoned")
             .insert(*k, module.clone());
         Ok(module)
     }
 
     /// Load compiled wasm code into the engine.
     pub unsafe fn load_compiled(&self, k: &Cid, compiled: &[u8]) -> anyhow::Result<Module> {
-        let module = Module::deserialize(&self.engine, compiled)?;
-        self.modules
-            .write()
-            .expect("modules poisoned")
+        let module = Module::deserialize(&self.0.engine, compiled)?;
+        self.0
+            .module_cache
+            .lock()
+            .expect("module_cache poisoned")
             .insert(*k, module.clone());
         Ok(module)
+    }
+
+    /// Lookup a loaded wasmtime module.
+    pub fn get_module(&self, k: &Cid) -> Option<Module> {
+        self.0
+            .module_cache
+            .lock()
+            .expect("module_cache poisoned")
+            .get(k)
+            .cloned()
+    }
+
+    /// Lookup and instantiate a loaded wasmtime module with the given store. This will cache the
+    /// linker, syscalls, "pre" isntance, etc.
+    pub fn get_instance<K: Kernel>(
+        &self,
+        store: &mut wasmtime::Store<InvocationData<K>>,
+        k: &Cid,
+    ) -> anyhow::Result<Option<wasmtime::Instance>> {
+        let mut instance_cache = self.0.instance_cache.lock().expect("cache poisoned");
+
+        let cache = match instance_cache.entry() {
+            anymap::Entry::Occupied(e) => e.into_mut(),
+            anymap::Entry::Vacant(e) => e.insert({
+                let mut linker = Linker::new(&self.0.engine);
+                bind_syscalls(&mut linker)?;
+                Cache {
+                    linker,
+                    instances: HashMap::new(),
+                }
+            }),
+        };
+        let instance_pre = match cache.instances.entry(*k) {
+            Entry::Occupied(e) => e.into_mut(),
+            Entry::Vacant(e) => {
+                let module_cache = self.0.module_cache.lock().expect("module_cache poisoned");
+                let module = match module_cache.get(k) {
+                    Some(module) => module,
+                    None => return Ok(None),
+                };
+                // We can cache the "pre instance" because our linker only has host functions.
+                let pre = cache.linker.instantiate_pre(&mut *store, module)?;
+                e.insert(pre)
+            }
+        };
+        let instance = instance_pre.instantiate(&mut *store)?;
+        Ok(Some(instance))
+    }
+
+    /// Construct a new wasmtime "store" from the given kernel.
+    pub fn new_store<K: Kernel>(&self, kernel: K) -> wasmtime::Store<InvocationData<K>> {
+        wasmtime::Store::new(&self.0.engine, InvocationData::new(kernel))
     }
 }

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -5,7 +5,6 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::ActorID;
-use wasmtime::Module;
 
 use crate::externs::Externs;
 use crate::gas::PriceList;
@@ -29,9 +28,9 @@ pub trait Machine: 'static {
     type Blockstore: Blockstore;
     type Externs: Externs;
 
-    /// Returns the underlying wasmtime engine. Cloning it will simply create a new handle
-    /// with a static lifetime.
-    fn engine(&self) -> &wasmtime::Engine;
+    /// Returns the underlying WASM engine. Cloning it will simply create a new handle with a
+    /// static lifetime.
+    fn engine(&self) -> &Engine;
 
     /// Returns the FVM's configuration.
     fn config(&self) -> &Config;
@@ -55,9 +54,6 @@ pub trait Machine: 'static {
     /// Creates an uninitialized actor.
     // TODO: Remove
     fn create_actor(&mut self, addr: &Address, act: ActorState) -> Result<ActorID>;
-
-    /// Loads a wasm module by CID.
-    fn load_module(&self, code: &Cid) -> Result<Module>;
 
     /// Transfers tokens from one actor to another.
     ///

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -16,7 +16,6 @@ use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, SealVerifyInfo, WindowPoStVerifyInfo,
 };
 use fvm_shared::{sys, ActorID};
-use wasmtime::{Caller, Trap};
 
 use super::Context;
 use crate::kernel::{BlockId, ClassifyResult, ExecutionError, Result, SyscallError};

--- a/testing/conformance/benches/bench_drivers.rs
+++ b/testing/conformance/benches/bench_drivers.rs
@@ -50,7 +50,6 @@ pub fn bench_vector_variant(
                 // TODO next few lines don't impact the benchmarks, but it might make them run waaaay more slowly... ought to make a base copy of the machine and exec and deepcopy them each time.
                 let machine = TestMachine::new_for_vector(vector, variant, bs, engine.clone());
                 // can assume this works because it passed a test before this ran
-                machine.load_builtin_actors_modules().unwrap();
                 let exec: DefaultExecutor<TestKernel> = DefaultExecutor::new(machine);
                 (messages_with_lengths.clone(), exec)
             },

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -23,7 +23,6 @@ use fvm_shared::sector::{
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum, TOTAL_FILECOIN};
 use num_traits::Zero;
-use wasmtime::Module;
 
 use crate::externs::TestExterns;
 use crate::vector::{MessageVector, Variant};
@@ -92,26 +91,6 @@ impl TestMachine<Box<DefaultMachine<MemoryBlockstore, TestExterns>>> {
             },
         }
     }
-
-    pub fn load_builtin_actors_modules(&self) -> Result<Vec<Module>> {
-        let actor_codes = vec![
-            &*fvm::builtin::SYSTEM_ACTOR_CODE_ID,
-            &*fvm::builtin::INIT_ACTOR_CODE_ID,
-            &*fvm::builtin::CRON_ACTOR_CODE_ID,
-            &*fvm::builtin::ACCOUNT_ACTOR_CODE_ID,
-            &*fvm::builtin::POWER_ACTOR_CODE_ID,
-            &*fvm::builtin::MINER_ACTOR_CODE_ID,
-            &*fvm::builtin::MARKET_ACTOR_CODE_ID,
-            &*fvm::builtin::PAYCH_ACTOR_CODE_ID,
-            &*fvm::builtin::MULTISIG_ACTOR_CODE_ID,
-            &*fvm::builtin::REWARD_ACTOR_CODE_ID,
-            &*fvm::builtin::VERIFREG_ACTOR_CODE_ID,
-        ];
-        actor_codes
-            .iter()
-            .map(|code| self.load_module(*code))
-            .collect()
-    }
 }
 
 impl<M> Machine for TestMachine<M>
@@ -121,7 +100,7 @@ where
     type Blockstore = M::Blockstore;
     type Externs = M::Externs;
 
-    fn engine(&self) -> &wasmtime::Engine {
+    fn engine(&self) -> &Engine {
         self.machine.engine()
     }
 
@@ -151,10 +130,6 @@ where
 
     fn create_actor(&mut self, addr: &Address, act: ActorState) -> Result<ActorID> {
         self.machine.create_actor(addr, act)
-    }
-
-    fn load_module(&self, code: &Cid) -> Result<wasmtime::Module> {
-        self.machine.load_module(code)
     }
 
     fn transfer(&mut self, from: ActorID, to: ActorID, value: &TokenAmount) -> Result<()> {


### PR DESCRIPTION
- cache syscall linker and constructed syscalls
- cache "pre instantiated" modules

This reduces conformance test run time from ~600s to ~100s on my machine and significantly increases network sync performance.