### PR TITLE
update maturity status to beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Reference Filecoin VM implementation (v0; pre-alpha)
+# Reference Filecoin VM implementation (v0; beta)
 
 [![Continuous integration](https://github.com/filecoin-project/fvm/actions/workflows/ci.yml/badge.svg)](https://github.com/filecoin-project/fvm/actions/workflows/ci.yml)
 


### PR DESCRIPTION
According to the maturity roadmap specified in the README, ref-fvm is at beta stage.