### PR TITLE
fix: prove_replica_update gas-mismatch

### DIFF
--- a/actors/runtime/src/runtime/actor_blockstore.rs
+++ b/actors/runtime/src/runtime/actor_blockstore.rs
@@ -9,6 +9,9 @@ use fvm_shared::blockstore::Block;
 use crate::actor_error;
 
 /// A blockstore suitable for use within actors.
+///
+/// Cloning simply clones a reference and does not copy the underlying blocks.
+#[derive(Debug, Clone)]
 pub struct ActorBlockstore;
 
 /// Implements a blockstore delegating to IPLD syscalls.

--- a/actors/runtime/src/runtime/actor_code.rs
+++ b/actors/runtime/src/runtime/actor_code.rs
@@ -17,6 +17,8 @@ pub trait ActorCode {
         params: &RawBytes,
     ) -> Result<RawBytes, ActorError>
     where
-        BS: Blockstore,
+        // TODO: remove the clone requirement on the blockstore when we fix "replica update" to not
+        // hold onto state between transactions.
+        BS: Blockstore + Clone,
         RT: Runtime<BS>;
 }


### PR DESCRIPTION
Usually, we should avoid hanging onto state between transactions because there might be a recursive call. Unfortunately, while _rust_ can statically prevent this, go doesn't.

For now, we hack around this by making it possible to copy the blockstore in go (where "copy" just references it). In nv16, we'll want to change this to avoid re-using state across calls.