### PR TITLE
fix: use a different CBOR library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ default-members = [
     # "examples/*"
 ]
 
-[patch.crates-io]
-cid = { git = "https://github.com/multiformats/rust-cid", branch = "steb/cbor-hack" }
-
 [profile.actor]
 inherits = "release"
 panic = "abort"

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -18,6 +18,7 @@ once_cell = "1.5"
 forest_hash_utils = "0.1"
 fvm_shared = { version = "0.1.0", path = "../../shared" }
 anyhow = "1.0.51"
+libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [features]
 identity = []

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::cmp::Ordering;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 use cid::Cid;
+use libipld_core::ipld::Ipld;
 use once_cell::unsync::OnceCell;
-use serde::de::DeserializeOwned;
+use serde::de::{self, DeserializeOwned};
 use serde::{ser, Deserialize, Deserializer, Serialize, Serializer};
 
 use super::node::Node;
@@ -34,25 +35,7 @@ impl<K: PartialEq, V: PartialEq, H> PartialEq for Pointer<K, V, H> {
     }
 }
 
-#[derive(Serialize)]
-#[serde(untagged)]
-enum PointerSer<'a, K, V> {
-    Vals(&'a [KeyValuePair<K, V>]),
-    Link(&'a Cid),
-}
-
-impl<'a, K, V, H> TryFrom<&'a Pointer<K, V, H>> for PointerSer<'a, K, V> {
-    type Error = &'static str;
-
-    fn try_from(pointer: &'a Pointer<K, V, H>) -> Result<Self, Self::Error> {
-        match pointer {
-            Pointer::Values(vals) => Ok(PointerSer::Vals(vals.as_ref())),
-            Pointer::Link { cid, .. } => Ok(PointerSer::Link(cid)),
-            Pointer::Dirty(_) => Err("Cannot serialize cached values"),
-        }
-    }
-}
-
+/// Serialize the Pointer like an untagged enum.
 impl<K, V, H> Serialize for Pointer<K, V, H>
 where
     K: Serialize,
@@ -62,31 +45,41 @@ where
     where
         S: Serializer,
     {
-        PointerSer::try_from(self)
-            .map_err(ser::Error::custom)?
-            .serialize(serializer)
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-#[serde(untagged)]
-enum PointerDe<K, V> {
-    Vals(Vec<KeyValuePair<K, V>>),
-    Link(Cid),
-}
-
-impl<K, V, H> From<PointerDe<K, V>> for Pointer<K, V, H> {
-    fn from(pointer: PointerDe<K, V>) -> Self {
-        match pointer {
-            PointerDe::Link(cid) => Pointer::Link {
-                cid,
-                cache: Default::default(),
-            },
-            PointerDe::Vals(vals) => Pointer::Values(vals),
+        match self {
+            Pointer::Values(vals) => vals.serialize(serializer),
+            Pointer::Link { cid, .. } => cid.serialize(serializer),
+            Pointer::Dirty(_) => Err(ser::Error::custom("Cannot serialize cached values")),
         }
     }
 }
 
+impl<K, V, H> TryFrom<Ipld> for Pointer<K, V, H>
+where
+    K: DeserializeOwned,
+    V: DeserializeOwned,
+{
+    type Error = String;
+
+    fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
+        match ipld {
+            ipld_list @ Ipld::List(_) => {
+                let values: Vec<KeyValuePair<K, V>> =
+                    Deserialize::deserialize(ipld_list).map_err(|error| error.to_string())?;
+                Ok(Self::Values(values))
+            }
+            Ipld::Link(cid) => Ok(Self::Link {
+                cid,
+                cache: Default::default(),
+            }),
+            other => Err(format!(
+                "Expected `Ipld::List` or `Ipld::Link`, got {:#?}",
+                other
+            )),
+        }
+    }
+}
+
+/// Deserialize the Pointer like an untagged enum.
 impl<'de, K, V, H> Deserialize<'de> for Pointer<K, V, H>
 where
     K: DeserializeOwned,
@@ -96,8 +89,7 @@ where
     where
         D: Deserializer<'de>,
     {
-        let pointer_de: PointerDe<K, V> = Deserialize::deserialize(deserializer)?;
-        Ok(Pointer::from(pointer_de))
+        Ipld::deserialize(deserializer).and_then(|ipld| ipld.try_into().map_err(de::Error::custom))
     }
 }
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
 # TODO remove fork in future (allowing non utf8 strings to be cbor deserialized)
-serde_cbor = { package = "cs_serde_cbor", version = "0.12", features = ["tags"]}
+serde_ipld_dagcbor = "0.1.0"
 serde_tuple = "0.5"
 serde_repr = "0.1"
 chrono = "0.4.9"

--- a/shared/src/encoding/errors.rs
+++ b/shared/src/encoding/errors.rs
@@ -4,7 +4,7 @@
 use std::{fmt, io};
 
 use cid::Error as CidError;
-use serde_cbor::error::Error as CborError;
+use serde_ipld_dagcbor::error::Error as CborError;
 use thiserror::Error;
 
 /// Error type for encoding and decoding data through any Forest supported protocol.

--- a/shared/src/encoding/mod.rs
+++ b/shared/src/encoding/mod.rs
@@ -9,7 +9,7 @@ mod vec;
 
 pub use serde::{de, ser};
 pub use serde_bytes;
-pub use serde_cbor::{error, from_reader, from_slice, tags, to_writer};
+pub use serde_ipld_dagcbor::{error, from_reader, from_slice, to_writer};
 
 pub use self::bytes::*;
 pub use self::cbor::*;
@@ -32,11 +32,11 @@ pub mod repr {
 // TODO: upstream this. Upstream doesn't allow encoding unsized types (e.g., slices).
 
 /// Serializes a value to a vector.
-pub fn to_vec<T>(value: &T) -> serde_cbor::Result<Vec<u8>>
+pub fn to_vec<T>(value: &T) -> serde_ipld_dagcbor::Result<Vec<u8>>
 where
     T: ser::Serialize + ?Sized,
 {
     let mut vec = Vec::new();
-    value.serialize(&mut serde_cbor::Serializer::new(&mut vec))?;
+    value.serialize(&mut serde_ipld_dagcbor::Serializer::new(&mut vec))?;
     Ok(vec)
 }

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -40,12 +40,12 @@ colored = "2"
 either = "1.6.1"
 itertools = "0.10.3"
 num_cpus = "1.13.1"
-serde_cbor = { package = "cs_serde_cbor", version = "0.12", features = ["tags"]}
 serde_json = { version = "1.0", features = ["raw_value"] }
 walkdir = "2.3"
 regex = { version = "1.0" }
 ittapi-rs = { version = "0.1.6", optional = true }
 actors-v6 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "v6" }
+libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [features]
 vtune = ["wasmtime/vtune", "ittapi-rs"]

--- a/testing/conformance/src/driver.rs
+++ b/testing/conformance/src/driver.rs
@@ -14,6 +14,7 @@ use fvm_shared::encoding::Cbor;
 use fvm_shared::message::Message;
 use fvm_shared::receipt::Receipt;
 use lazy_static::lazy_static;
+use libipld_core::ipld::Ipld;
 use regex::Regex;
 use walkdir::DirEntry;
 
@@ -103,8 +104,8 @@ fn compare_actors(
 
     match (actual, expected) {
         (Some(a), Some(e)) if a.state != e.state => {
-            let a_root: Vec<serde_cbor::Value> = bs.get_cbor(&a.state)?.unwrap();
-            let e_root: Vec<serde_cbor::Value> = bs.get_cbor(&e.state)?.unwrap();
+            let a_root: Vec<Ipld> = bs.get_cbor(&a.state)?.unwrap();
+            let e_root: Vec<Ipld> = bs.get_cbor(&e.state)?.unwrap();
             if a_root.len() != e_root.len() {
                 log::error!("states have different numbers of fields")
             } else {


### PR DESCRIPTION
Use a CBOR library that is tailored towards DAG-CBOR.

CIDs don't work as expected with Serde untagged enums, hence add a custom
implementation for the Pointer (de)serialization. That implementation works
similarly to the Serde untagged enum implementation.

First the data is deserialized into a common format that supports all types.
In our case that's `Ipld`, in Serde it's `Content`. Those are then converted
into the actual types the enum is using.

Directly converting from the serialized form into the concrete enum types is
not possible. One would need to try each of the possibilities sequentially
until one of them matches. The deserializer is consumed when deserializing,
hence it can only be used once. This is the reason to have the intermediate
step.