### PR TITLE
Switch price_list_by_epoch to price_list_by_network_version

### DIFF
--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -3,7 +3,7 @@
 
 pub use self::charge::GasCharge;
 pub(crate) use self::outputs::GasOutputs;
-pub use self::price_list::{price_list_by_epoch, PriceList};
+pub use self::price_list::{price_list_by_network_version, PriceList};
 use crate::kernel::{ExecutionError, Result};
 
 mod charge;

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use ahash::AHashMap;
-use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::SignatureType;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PieceInfo;
@@ -10,6 +9,7 @@ use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredPoStProof, RegisteredSealProof, ReplicaUpdateInfo,
     SealVerifyInfo, WindowPoStVerifyInfo,
 };
+use fvm_shared::version::NetworkVersion;
 use fvm_shared::{MethodNum, METHOD_SEND};
 use lazy_static::lazy_static;
 use num_traits::Zero;
@@ -17,7 +17,7 @@ use num_traits::Zero;
 use super::GasCharge;
 
 lazy_static! {
-    static ref CALICO_PRICES: PriceList = PriceList {
+    static ref OH_SNAP_PRICES: PriceList = PriceList {
         compute_gas_multiplier: 1,
         storage_gas_multiplier: 1300,
 
@@ -418,7 +418,7 @@ impl PriceList {
     }
 }
 
-/// Returns gas price list by Epoch for gas consumption.
-pub fn price_list_by_epoch(_: ChainEpoch) -> PriceList {
-    CALICO_PRICES.clone()
+/// Returns gas price list by NetworkVersion for gas consumption.
+pub fn price_list_by_network_version(_: NetworkVersion) -> PriceList {
+    OH_SNAP_PRICES.clone()
 }

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -16,7 +16,7 @@ use num_traits::{Signed, Zero};
 use super::{Engine, Machine, MachineContext};
 use crate::blockstore::BufferedBlockstore;
 use crate::externs::Externs;
-use crate::gas::price_list_by_epoch;
+use crate::gas::price_list_by_network_version;
 use crate::kernel::{ClassifyResult, Context as _, Result};
 use crate::state_tree::{ActorState, StateTree};
 use crate::{syscall_error, Config};
@@ -83,7 +83,7 @@ where
             circ_supply,
             network_version,
             initial_state_root: state_root,
-            price_list: price_list_by_epoch(epoch),
+            price_list: price_list_by_network_version(network_version),
             debug: config.debug,
         };
 


### PR DESCRIPTION
Although this has no practical consequence today (there's only one PriceList in the FVM), this future-proofs us so that the evil that is `price_list_by_epoch` may not endure.