### PR TITLE
WIP: execution traces

### DIFF
--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -15,6 +15,7 @@ use num_traits::Zero;
 
 use super::{ApplyFailure, ApplyKind, ApplyRet, Executor};
 use crate::call_manager::{backtrace, CallManager, InvocationResult};
+use crate::executor::ExecutionTrace;
 use crate::gas::{GasCharge, GasOutputs};
 use crate::kernel::{ClassifyResult, Context as _, ExecutionError, Kernel};
 use crate::machine::{Machine, BURNT_FUNDS_ACTOR_ADDR, REWARD_ACTOR_ADDR};
@@ -66,7 +67,7 @@ where
         // Apply the message.
         let (res, gas_used, mut backtrace) = self.map_machine(|machine| {
             let mut cm = K::CallManager::new(machine, msg.gas_limit, msg.from, msg.sequence);
-            // This error is fatal because it should have already been acounted for inside
+            // This error is fatal because it should have already been accounted for inside
             // preflight_message.
             if let Err(e) = cm.charge_gas(inclusion_cost) {
                 return (Err(e), cm.finish().2);
@@ -124,7 +125,7 @@ where
                             "unexpected syscall error when processing message: {} ({})",
                             code,
                             code as u32
-                        ))
+                        ));
                     }
                 };
 
@@ -143,7 +144,7 @@ where
                     msg.sequence,
                     msg.method_num,
                     self.context().epoch
-                )))
+                )));
             }
         };
 
@@ -160,6 +161,9 @@ where
                 failure_info,
                 penalty: TokenAmount::zero(),
                 miner_tip: TokenAmount::zero(),
+                exec_trace: ExecutionTrace {
+                    error: "tayle".to_string(),
+                },
             }),
         }
     }
@@ -236,7 +240,7 @@ where
                     ExitCode::SysErrSenderInvalid,
                     "Sender invalid",
                     miner_penalty_amount,
-                )))
+                )));
             }
         };
 
@@ -255,7 +259,7 @@ where
                     ExitCode::SysErrSenderInvalid,
                     "Sender invalid",
                     miner_penalty_amount,
-                )))
+                )));
             }
         };
 
@@ -367,6 +371,9 @@ where
             failure_info,
             penalty: miner_penalty,
             miner_tip,
+            exec_trace: ExecutionTrace {
+                error: "swifc".to_string(),
+            },
         })
     }
 

--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::Display;
 
 pub use default::DefaultExecutor;
 use fvm_shared::bigint::{BigInt, Sign};
+use fvm_shared::encoding::tuple::*;
 use fvm_shared::encoding::RawBytes;
 use fvm_shared::error::ExitCode;
 use fvm_shared::message::Message;
@@ -60,6 +61,43 @@ pub struct ApplyRet {
     pub miner_tip: BigInt,
     /// Additional failure information for debugging, if any.
     pub failure_info: Option<ApplyFailure>,
+    /// Execution trace information, for debugging.
+    pub exec_trace: ExecutionTrace,
+}
+
+/// Execution Trace, only for informational and debugging purposes.
+#[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct ExecutionTrace {
+    // pub msg: Message,
+    // pub msg_receipt: Receipt,
+    pub error: String,
+    // pub subcalls: Vec<ExecutionTrace>,
+}
+
+impl ExecutionTrace {
+    pub fn empty() -> ExecutionTrace {
+        return ExecutionTrace {
+            // msg_receipt: Receipt {
+            //     exit_code: ExitCode::Ok,
+            //     return_data: Default::default(),
+            //     gas_used: 0,
+            // },
+            // msg: Message {
+            //     version: 0,
+            //     from: Address::new_id(0),
+            //     to: Address::new_id(0),
+            //     sequence: 0,
+            //     value: Default::default(),
+            //     method_num: 0,
+            //     params: Default::default(),
+            //     gas_limit: 0,
+            //     gas_fee_cap: Default::default(),
+            //     gas_premium: Default::default(),
+            // },
+            error: "alison".to_string(),
+            // subcalls: vec![],
+        };
+    }
 }
 
 impl ApplyRet {
@@ -78,6 +116,7 @@ impl ApplyRet {
             penalty: miner_penalty,
             failure_info: Some(ApplyFailure::PreValidation(message.into())),
             miner_tip: BigInt::zero(),
+            exec_trace: ExecutionTrace::empty(),
         }
     }
 


### PR DESCRIPTION
Addresses #318 

The flow as prototyped in Lotus is:

- FVM-shared has a new execution trace object that the executor returns
- FFI serializes this object (CBOR) and returns the bytes to Lotus
- Lotus deserializes this `FvmExecutionTrace` object and puts the appropriate fields into its `ExecutionTrace` object

True completeness would be achieved when `FvmExecutionTrace` and `ExecutionTrace` coalesce into the same type.