### PR TITLE
Release v0.2.1

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -20,7 +20,7 @@ ahash = "0.7"
 num-derive = "0.3.3"
 cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.1", default-features = false }
-fvm_shared = { version = "0.2.0", path = "../shared", features = ["crypto"] }
+fvm_shared = { version = "0.2.1", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.2.0", path = "../ipld/hamt"}
 fvm_ipld_amt = { version = "0.2.0", path = "../ipld/amt"}
 serde = { version = "1.0", features = ["derive"] }

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { version = "0.8.2", default-features = false }
-fvm_shared = { version = "0.2.0", path = "../shared" }
+fvm_shared = { version = "0.2.1", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = "1.4.0"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
@@ -11,7 +11,7 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
 # TODO remove fork in future (allowing non utf8 strings to be cbor deserialized)
-serde_ipld_dagcbor = "0.1.0"
+serde_ipld_dagcbor = "0.1.2"
 serde_tuple = "0.5"
 serde_repr = "0.1"
 chrono = "0.4.9"


### PR DESCRIPTION
Of the FVM, shared crate, and the sdk. Primarily, this completely removes the "identity" multihash feature.