### PR TITLE
detailed gas and fuel tracing.

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -25,6 +25,7 @@ fvm_ipld_hamt = { version = "0.2.0", path = "../ipld/hamt"}
 fvm_ipld_amt = { version = "0.2.0", path = "../ipld/amt"}
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = "0.5"
+serde_json = { version = "1.0.79", optional = true }
 serde_repr = "0.1"
 lazy_static = "1.4.0"
 derive-getters = "0.2.0"
@@ -46,3 +47,4 @@ features = ["cranelift", "pooling-allocator", "parallel-compilation"]
 default = ["opencl"]
 opencl = ["filecoin-proofs-api/opencl"]
 cuda = ["filecoin-proofs-api/cuda"]
+tracing = ["serde_json"]

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -116,6 +116,15 @@ pub trait CallManager: 'static {
         self.gas_tracker_mut().charge_gas(charge)?;
         Ok(())
     }
+
+    /// Record a gas trace.
+    #[cfg(feature = "tracing")]
+    fn record_trace(
+        &self,
+        context: crate::gas::tracer::Context,
+        point: crate::gas::tracer::Point,
+        consumption: crate::gas::tracer::Consumption,
+    );
 }
 
 /// The result of a method invocation.

--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -10,6 +10,9 @@ mod charge;
 mod outputs;
 mod price_list;
 
+#[cfg(feature = "tracing")]
+pub mod tracer;
+
 pub struct GasTracker {
     gas_available: i64,
     gas_used: i64,

--- a/fvm/src/gas/tracer.rs
+++ b/fvm/src/gas/tracer.rs
@@ -1,0 +1,170 @@
+use cid::Cid;
+use fvm_shared::MethodNum;
+use serde::Serialize;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Serialize)]
+pub struct GasTracer {
+    #[serde(skip_serializing)]
+    started: Instant,
+    #[serde(skip_serializing)]
+    previous: Instant,
+    /// Accumulated traces.
+    traces: Vec<GasTrace>,
+}
+
+impl GasTracer {
+    pub fn new() -> GasTracer {
+        let now = Instant::now();
+        GasTracer {
+            started: now,
+            previous: now,
+            traces: Default::default(),
+        }
+    }
+
+    pub fn record(&mut self, context: Context, point: Point, consumption: Consumption) {
+        let trace = GasTrace {
+            context,
+            point,
+            consumption,
+            timing: {
+                let now = Instant::now();
+                let prev = self.previous;
+                self.previous = now;
+                Timing {
+                    elapsed_cum: now.duration_since(self.started),
+                    elapsed_rel: now.duration_since(prev),
+                }
+            },
+        };
+        self.traces.push(trace)
+    }
+
+    pub fn finish(self) -> Vec<GasTrace> {
+        self.traces
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct GasTrace {
+    /// Context annotates the trace with the source context.   
+    pub context: Context,
+    /// Point represents the location from where the trace was emitted.
+    pub point: Point,
+    /// The consumption at the moment of trace.
+    pub consumption: Consumption,
+    /// Timing information.
+    pub timing: Timing,
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct Consumption {
+    /// Wasmtime fuel consumed reports how much fuel has been consumed at this point.
+    /// May be optional if the point had no access to this information, or if non applicable.
+    pub fuel_consumed: Option<u64>,
+    /// Gas consumed reports how much gas has been consumed at this point.
+    /// May be optional if the point had no access to this information, or if non applicable.
+    pub gas_consumed: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Timing {
+    /// Total time elapsed since the GasTracer was created.
+    #[serde(
+        serialize_with = "ser::serialize_duration_as_nanos",
+        rename = "elapsed_cum_ns"
+    )]
+    pub elapsed_cum: Duration,
+    /// Relative time elapsed since the previous trace was recorded.
+    #[serde(
+        serialize_with = "ser::serialize_duration_as_nanos",
+        rename = "elapsed_rel_ns"
+    )]
+    pub elapsed_rel: Duration,
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct Context {
+    #[serde(serialize_with = "ser::serialize_cid")]
+    pub code_cid: Cid,
+    pub method_num: MethodNum,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Point {
+    pub event: Event,
+    pub label: String,
+}
+
+#[derive(Debug, Serialize)]
+pub enum Event {
+    Started,
+    EnterCall,
+    PreSyscall,
+    PostSyscall,
+    PreExtern,
+    PostExtern,
+    ExitCall,
+    Finished,
+}
+
+#[test]
+fn test_tracer() {
+    let mut tracer = GasTracer::new();
+    tracer.record(
+        Context {
+            code_cid: Default::default(),
+            method_num: 0,
+        },
+        Point {
+            event: Event::Started,
+            label: "".to_string(),
+        },
+        Consumption {
+            fuel_consumed: None,
+            gas_consumed: None,
+        },
+    );
+
+    std::thread::sleep(Duration::from_millis(1000));
+    tracer.record(
+        Context {
+            code_cid: Default::default(),
+            method_num: 0,
+        },
+        Point {
+            event: Event::Started,
+            label: "".to_string(),
+        },
+        Consumption {
+            fuel_consumed: None,
+            gas_consumed: None,
+        },
+    );
+    let traces = tracer.finish();
+    println!("{:?}", traces);
+
+    let str = serde_json::to_string(&traces).unwrap();
+    println!("{}", str);
+}
+
+mod ser {
+    use cid::Cid;
+    use serde::{Serialize, Serializer};
+    use std::time::Duration;
+
+    pub fn serialize_cid<S>(c: &Cid, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        c.to_string().serialize(serializer)
+    }
+
+    pub fn serialize_duration_as_nanos<S>(d: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        d.as_nanos().serialize(serializer)
+    }
+}

--- a/fvm/src/gas/tracer.rs
+++ b/fvm/src/gas/tracer.rs
@@ -1,7 +1,8 @@
+use std::time::{Duration, Instant};
+
 use cid::Cid;
 use fvm_shared::MethodNum;
 use serde::Serialize;
-use std::time::{Duration, Instant};
 
 #[derive(Debug, Serialize)]
 pub struct GasTracer {
@@ -150,9 +151,10 @@ fn test_tracer() {
 }
 
 mod ser {
+    use std::time::Duration;
+
     use cid::Cid;
     use serde::{Serialize, Serializer};
-    use std::time::Duration;
 
     pub fn serialize_cid<S>(c: &Cid, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -93,6 +93,7 @@ pub struct DefaultKernel<C> {
     debug: DebugInfo,
 }
 
+#[cfg(feature = "tracing")]
 #[derive(Default)]
 struct DebugInfo {
     code_cid: Cid,
@@ -120,6 +121,7 @@ where
         method: MethodNum,
         value_received: TokenAmount,
     ) -> Self {
+        #[allow(unused_mut)]
         let mut ret = DefaultKernel {
             call_manager: mgr,
             blocks: BlockRegistry::new(),

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -64,6 +64,13 @@ pub trait Kernel:
     ) -> Self
     where
         Self: Sized;
+
+    #[cfg(feature = "tracing")]
+    fn record_trace(
+        &self,
+        point: crate::gas::tracer::Point,
+        consumption: crate::gas::tracer::Consumption,
+    );
 }
 
 /// Network-related operations.

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -51,6 +51,7 @@ libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [features]
 vtune = ["wasmtime/vtune", "ittapi-rs"]
+tracing = ["fvm/tracing"]
 
 [dev-dependencies]
 pretty_env_logger = "0.4.0"

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -228,6 +228,16 @@ where
         self.0.finish()
     }
 
+    #[cfg(feature = "tracing")]
+    fn record_trace(
+        &self,
+        context: fvm::gas::tracer::Context,
+        point: fvm::gas::tracer::Point,
+        consumption: fvm::gas::tracer::Consumption,
+    ) {
+        self.0.record_trace(context, point, consumption)
+    }
+
     fn machine(&self) -> &Self::Machine {
         self.0.machine()
     }
@@ -326,6 +336,15 @@ where
             ),
             data,
         )
+    }
+
+    #[cfg(feature = "tracing")]
+    fn record_trace(
+        &self,
+        point: fvm::gas::tracer::Point,
+        consumption: fvm::gas::tracer::Consumption,
+    ) {
+        self.0.record_trace(point, consumption)
     }
 }
 


### PR DESCRIPTION
Introduces a new Cargo feature `tracing` that enables detailed gas tracing.

Traces are accumulated in the GasTracer, owned by the CallManager.

Gas traces specify the context, point of tracing, consumption stats, and timing stats.

We currently support these tracing points:

- {Pre,Post}Syscall
- {Pre,Post}Extern
- {Enter,Exit}Call
- Start (of the call stack)
- Finish (of the call stack)

Traces are currently serialized to JSON and printed directly on stdout.

There's a bit of duplication the syscall binding macros that I'm not happy about, and perhaps we could make the tracepoints in the CallManager a bit DRYer.

---

Example of a gas trace that this produces for a test vector: https://gist.github.com/raulk/f2207675000571e283bc2e20e43a5463