### PR TITLE
Implement execution traces for the FVM

### DIFF
--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -11,6 +11,7 @@ use fvm_shared::receipt::Receipt;
 use num_traits::Zero;
 
 use crate::call_manager::Backtrace;
+use crate::trace::ExecutionTrace;
 use crate::Kernel;
 
 /// An executor executes messages on the underlying machine/kernel. It's responsible for:
@@ -71,6 +72,8 @@ pub struct ApplyRet {
     pub miner_tip: BigInt,
     /// Additional failure information for debugging, if any.
     pub failure_info: Option<ApplyFailure>,
+    /// Execution trace information, for debugging.
+    pub exec_trace: ExecutionTrace,
 }
 
 impl ApplyRet {
@@ -89,6 +92,7 @@ impl ApplyRet {
             penalty: miner_penalty,
             failure_info: Some(ApplyFailure::PreValidation(message.into())),
             miner_tip: BigInt::zero(),
+            exec_trace: vec![],
         }
     }
 

--- a/fvm/src/kernel/error.rs
+++ b/fvm/src/kernel/error.rs
@@ -3,8 +3,6 @@ use std::fmt::Display;
 use derive_more::Display;
 use fvm_shared::error::ErrorNumber;
 
-use crate::kernel::ExecutionError::{Fatal, OutOfGas, Syscall};
-
 /// Execution result.
 pub type Result<T> = std::result::Result<T, ExecutionError>;
 
@@ -35,16 +33,6 @@ pub enum ExecutionError {
     OutOfGas,
     Syscall(SyscallError),
     Fatal(anyhow::Error),
-}
-
-impl Clone for ExecutionError {
-    fn clone(&self) -> Self {
-        match self {
-            OutOfGas => OutOfGas,
-            Syscall(v) => Syscall(v.clone()),
-            Fatal(v) => Fatal(anyhow::Error::msg(v.to_string())),
-        }
-    }
 }
 
 impl ExecutionError {

--- a/fvm/src/kernel/error.rs
+++ b/fvm/src/kernel/error.rs
@@ -3,6 +3,8 @@ use std::fmt::Display;
 use derive_more::Display;
 use fvm_shared::error::ErrorNumber;
 
+use crate::kernel::ExecutionError::{Fatal, OutOfGas, Syscall};
+
 /// Execution result.
 pub type Result<T> = std::result::Result<T, ExecutionError>;
 
@@ -26,13 +28,23 @@ macro_rules! syscall_error {
     };
 }
 
-// NOTE: this intentionally does not implemnent error so we can make the context impl work out
+// NOTE: this intentionally does not implement error so we can make the context impl work out
 // below.
 #[derive(Display, Debug)]
 pub enum ExecutionError {
     OutOfGas,
     Syscall(SyscallError),
     Fatal(anyhow::Error),
+}
+
+impl Clone for ExecutionError {
+    fn clone(&self) -> Self {
+        match self {
+            OutOfGas => OutOfGas,
+            Syscall(v) => Syscall(v.clone()),
+            Fatal(v) => Fatal(anyhow::Error::msg(v.to_string())),
+        }
+    }
 }
 
 impl ExecutionError {

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -30,6 +30,8 @@ mod power_actor;
 mod reward_actor;
 mod system_actor;
 
+pub mod trace;
+
 use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
 use fvm_ipld_encoding::{to_vec, DAG_CBOR};

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -129,8 +129,8 @@ impl NetworkConfig {
 
     /// Enable actor debugging. This is a consensus-critical option (affects gas usage) so it should
     /// only be enabled for local testing or as a network-wide parameter.
-    pub fn enable_actor_debugging(&mut self, enabled: bool) -> &mut Self {
-        self.actor_debugging = enabled;
+    pub fn enable_actor_debugging(&mut self) -> &mut Self {
+        self.actor_debugging = true;
         self
     }
 
@@ -180,6 +180,8 @@ pub struct MachineContext {
     /// DEFAULT: Total FIL supply (likely not what you want).
     pub circ_supply: TokenAmount,
 
+    /// Whether or not to produce execution traces in the returned result.
+    /// Not consensus-critical, but has a performance impact.
     pub tracing: bool,
 }
 
@@ -196,7 +198,7 @@ impl MachineContext {
         self
     }
 
-    /// Set [`MachineContext::tracing`].
+    /// Enable execution traces. [`MachineContext::tracing`].
     pub fn enable_tracing(&mut self) -> &mut Self {
         self.tracing = true;
         self

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -149,6 +149,7 @@ impl NetworkConfig {
             initial_state_root: initial_state,
             base_fee: TokenAmount::zero(),
             circ_supply: fvm_shared::TOTAL_FILECOIN.clone(),
+            tracing: false,
         }
     }
 }
@@ -178,18 +179,26 @@ pub struct MachineContext {
     ///
     /// DEFAULT: Total FIL supply (likely not what you want).
     pub circ_supply: TokenAmount,
+
+    pub tracing: bool,
 }
 
 impl MachineContext {
-    /// Sets [`EpochContext::base_fee`].
+    /// Sets [`MachineContext::base_fee`].
     pub fn set_base_fee(&mut self, amt: TokenAmount) -> &mut Self {
         self.base_fee = amt;
         self
     }
 
-    /// Set [`EpochContext::circ_supply`].
+    /// Set [`MachineContext::circ_supply`].
     pub fn set_circulating_supply(&mut self, amt: TokenAmount) -> &mut Self {
         self.circ_supply = amt;
+        self
+    }
+
+    /// Set [`MachineContext::tracing`].
+    pub fn enable_tracing(&mut self) -> &mut Self {
+        self.tracing = true;
         self
     }
 }

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -4,7 +4,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::{ActorID, MethodNum};
 
 use crate::call_manager::InvocationResult;
-use crate::kernel::Result;
+use crate::kernel::SyscallError;
 
 /// Execution Trace, only for informational and debugging purposes.
 pub type ExecutionTrace = Vec<ExecutionEvent>;
@@ -12,7 +12,7 @@ pub type ExecutionTrace = Vec<ExecutionEvent>;
 #[derive(Clone, Debug)]
 pub enum ExecutionEvent {
     Call(SendParams),
-    Return(Result<InvocationResult>),
+    Return(Result<InvocationResult, SyscallError>),
 }
 
 #[derive(Clone, Debug)]

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -1,0 +1,25 @@
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::Address;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::{ActorID, MethodNum};
+
+use crate::call_manager::InvocationResult;
+use crate::kernel::Result;
+
+/// Execution Trace, only for informational and debugging purposes.
+pub type ExecutionTrace = Vec<ExecutionEvent>;
+
+#[derive(Clone, Debug)]
+pub enum ExecutionEvent {
+    Call(SendParams),
+    Return(Result<InvocationResult>),
+}
+
+#[derive(Clone, Debug)]
+pub struct SendParams {
+    pub from: ActorID,
+    pub to: Address,
+    pub method: MethodNum,
+    pub params: RawBytes,
+    pub value: TokenAmount,
+}

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 
 use cid::Cid;
 use futures::executor::block_on;
-use fvm::call_manager::{Backtrace, CallManager, DefaultCallManager, InvocationResult};
+use fvm::call_manager::{CallManager, DefaultCallManager, FinishRet, InvocationResult};
 use fvm::gas::{GasTracker, PriceList};
 use fvm::kernel::*;
 use fvm::machine::{DefaultMachine, Engine, Machine, MachineContext, NetworkConfig};
@@ -211,7 +211,7 @@ where
         })
     }
 
-    fn finish(self) -> (i64, Backtrace, Self::Machine) {
+    fn finish(self) -> (FinishRet, Self::Machine) {
         self.0.finish()
     }
 


### PR DESCRIPTION
Resolves #318 

This gets us most of the way to matching Lotus execution traces -- fine gas tracing isn't implemented yet, but it will be impossible to meet that level of detail in M1 anyway.

The ExecutionTrace is created and populated by the call manager, which returns it on `finish`. 