### PR TITLE
Invalidate SSCACHE on github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       with:
         version: v0.2.15
         # change this to invalidate sccache for this job
-        shared-key: v0
+        shared-key: v1
     - name: Runing ${{ matrix.command }}
       uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:


### PR DESCRIPTION
Current SSCACHE is stuck due to: https://github.com/actions/toolkit/issues/658
as seen within https://github.com/filecoin-project/ref-fvm/runs/5711220587?check_suite_focus=true in `Post Setting up cache`
The simplest solution is to invalidate it by switching the start of the cache key to v1.