### PR TITLE
Derive Debug for PieceInfo

### DIFF
--- a/shared/src/piece/mod.rs
+++ b/shared/src/piece/mod.rs
@@ -62,7 +62,7 @@ impl PaddedPieceSize {
 }
 
 /// Piece information for part or a whole file.
-#[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Clone)]
+#[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Clone, Debug)]
 pub struct PieceInfo {
     /// Size in nodes. For BLS12-381 (capacity 254 bits), must be >= 16. (16 * 8 = 128).
     pub size: PaddedPieceSize,


### PR DESCRIPTION
This is wanted for the built-in actors mock runtime.