### PR TITLE
feat: switch to the new versioned manifest.

### DIFF
--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -127,6 +127,8 @@ mod test {
             bs.put_cbor(&manifest, Code::Blake2b256).unwrap()
         };
 
+        let actors_cid = bs.put_cbor(&(0, manifest_cid), Code::Blake2b256).unwrap();
+
         let machine = DefaultMachine::new(
             Config::default(),
             Engine::default(),
@@ -135,7 +137,7 @@ mod test {
             Zero::zero(),
             fvm_shared::version::NetworkVersion::V14,
             root,
-            Some(manifest_cid),
+            Some(actors_cid),
             bs,
             DummyExterns,
         )

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -135,7 +135,7 @@ mod test {
             Zero::zero(),
             fvm_shared::version::NetworkVersion::V14,
             root,
-            (0, Some(manifest_cid)),
+            Some(manifest_cid),
             bs,
             DummyExterns,
         )

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context as _};
 use cid::Cid;
 use fvm_shared::actor::builtin::{load_manifest, Manifest};
 use fvm_shared::address::Address;
-use fvm_shared::blockstore::{Blockstore, Buffered};
+use fvm_shared::blockstore::{Blockstore, Buffered, CborStore};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
@@ -57,7 +57,7 @@ where
         circ_supply: TokenAmount,
         network_version: NetworkVersion,
         state_root: Cid,
-        builtin_actors: (u32, Option<Cid>),
+        builtin_actors: Option<Cid>,
         blockstore: B,
         externs: E,
     ) -> anyhow::Result<Self> {
@@ -102,15 +102,21 @@ where
 
         // Load the built-in actors manifest.
         // TODO: Check that the actor bundle is sane for the network version.
-        let builtin_actors_cid = match builtin_actors.1 {
-            Some(cid) => cid,
+        let (builtin_actors_cid, manifest_version) = match builtin_actors {
+            Some(manifest_cid) => {
+                let (version, cid): (u32, Cid) = state_tree
+                    .store()
+                    .get_cbor(&manifest_cid)?
+                    .context("failed to load actor manifest")?;
+                (cid, version)
+            }
             None => {
                 let (state, _) = SystemActorState::load(&state_tree)?;
-                state.builtin_actors
+                (state.builtin_actors, 1)
             }
         };
         let builtin_actors =
-            load_manifest(state_tree.store(), &builtin_actors_cid, builtin_actors.0)?;
+            load_manifest(state_tree.store(), &builtin_actors_cid, manifest_version)?;
 
         // Preload any uncached modules.
         // This interface works for now because we know all actor CIDs

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -45,8 +45,8 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 walkdir = "2.3"
 regex = { version = "1.0" }
 ittapi-rs = { version = "0.1.6", optional = true }
-actors-v6 = { version = "6.0.5", package = "fil_builtin_actors_bundle" }
-actors-v7 = { version = "7.0.4", package = "fil_builtin_actors_bundle" }
+actors-v6 = { version = "6.0.6", package = "fil_builtin_actors_bundle" }
+actors-v7 = { version = "7.0.7", package = "fil_builtin_actors_bundle" }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [features]

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -45,8 +45,8 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 walkdir = "2.3"
 regex = { version = "1.0" }
 ittapi-rs = { version = "0.1.6", optional = true }
-actors-v6 = { version = "6.0.6", package = "fil_builtin_actors_bundle" }
-actors-v7 = { version = "7.0.7", package = "fil_builtin_actors_bundle" }
+actors-v6 = { version = "6.1.0", package = "fil_builtin_actors_bundle" }
+actors-v7 = { version = "7.1.0", package = "fil_builtin_actors_bundle" }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [features]

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -85,7 +85,7 @@ impl TestMachine<Box<DefaultMachine<MemoryBlockstore, TestExterns>>> {
             BigInt::zero(),
             network_version,
             state_root,
-            (0, Some(builtin_actors)),
+            Some(builtin_actors),
             blockstore,
             externs,
         )


### PR DESCRIPTION
1. If no manifest CID is passed, load the manifest from the system actor and assume "v1" for now. In the future, we'll likely use the network version to infer the manifest version.
2. If a manifest CID _is_ passed, assume it's a versioned manifest and use the specified version.

replaces #404