### PR TITLE
fix: don't leak underlying library error

### DIFF
--- a/ipld/car/src/error.rs
+++ b/ipld/car/src/error.rs
@@ -13,7 +13,7 @@ pub enum Error {
     #[error("Io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("Cbor encoding error: {0}")]
-    Cbor(#[from] fvm_shared::encoding::error::Error),
+    Cbor(#[from] fvm_shared::encoding::Error),
     #[error("CAR error: {0}")]
     Other(String),
 }

--- a/shared/src/encoding/cbor.rs
+++ b/shared/src/encoding/cbor.rs
@@ -17,7 +17,7 @@ pub const DAG_CBOR: u64 = 0x71;
 pub trait Cbor: ser::Serialize + de::DeserializeOwned {
     /// Marshalls cbor encodable object into cbor bytes
     fn marshal_cbor(&self) -> Result<Vec<u8>, Error> {
-        Ok(to_vec(&self)?)
+        to_vec(&self)
     }
 
     /// Unmarshals cbor encoded bytes to object

--- a/shared/src/encoding/mod.rs
+++ b/shared/src/encoding/mod.rs
@@ -9,7 +9,7 @@ mod vec;
 
 pub use serde::{de, ser};
 pub use serde_bytes;
-pub use serde_ipld_dagcbor::{error, from_reader, from_slice, to_writer};
+pub use serde_ipld_dagcbor::{from_reader, from_slice, to_writer};
 
 pub use self::bytes::*;
 pub use self::cbor::*;
@@ -32,7 +32,7 @@ pub mod repr {
 // TODO: upstream this. Upstream doesn't allow encoding unsized types (e.g., slices).
 
 /// Serializes a value to a vector.
-pub fn to_vec<T>(value: &T) -> serde_ipld_dagcbor::Result<Vec<u8>>
+pub fn to_vec<T>(value: &T) -> Result<Vec<u8>, Error>
 where
     T: ser::Serialize + ?Sized,
 {


### PR DESCRIPTION
The error of the underlying CBOR library is an implementation detail,
it shouldn't leak into the public API. Instead use the error that
wraps it into the one specified by the module.