### PR TITLE
chore: release fvm_shared 0.3.0

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -20,7 +20,7 @@ ahash = "0.7"
 num-derive = "0.3.3"
 cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.1", default-features = false }
-fvm_shared = { version = "0.2.2", path = "../shared", features = ["crypto"] }
+fvm_shared = { version = "0.3.0", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.2.0", path = "../ipld/hamt"}
 fvm_ipld_amt = { version = "0.2.0", path = "../ipld/amt"}
 serde = { version = "1.0", features = ["derive"] }

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -14,7 +14,7 @@ thiserror = "1.0"
 once_cell = "1.5"
 ahash = { version = "0.7", optional = true }
 itertools = "0.10"
-fvm_shared = { version = "0.2.0", path = "../../shared" }
+fvm_shared = { version = "0.3.0", path = "../../shared" }
 anyhow = "1.0.51"
 
 [features]

--- a/ipld/bitfield/Cargo.toml
+++ b/ipld/bitfield/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 unsigned-varint = "0.7.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
-fvm_shared = { version = "0.2.0", path = "../../shared" }
+fvm_shared = { version = "0.3.0", path = "../../shared" }
 
 [dev-dependencies]
 rand_xorshift = "0.2.0"

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 futures = "0.3.5"
 integer-encoding = { version = "3.0", features = ["futures_async"] }
-fvm_shared = { version = "0.2.0", path = "../../shared" }
+fvm_shared = { version = "0.3.0", path = "../../shared" }
 
 [dev-dependencies]
 async-std = { version = "1.9", features = ["attributes"] }

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1.0"
 sha2 = "0.10"
 once_cell = "1.5"
 forest_hash_utils = "0.1"
-fvm_shared = { version = "0.2.0", path = "../../shared" }
+fvm_shared = { version = "0.3.0", path = "../../shared" }
 anyhow = "1.0.51"
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { version = "0.8.2", default-features = false }
-fvm_shared = { version = "0.2.2", path = "../shared" }
+fvm_shared = { version = "0.3.0", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = "1.4.0"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
 fvm = { version = "0.3.0", path = "../../fvm", default-features = false }
-fvm_shared = { version = "0.2.0", path = "../../shared" }
+fvm_shared = { version = "0.3.0", path = "../../shared" }
 fvm_ipld_hamt = { version = "0.2.0", path = "../../ipld/hamt"}
 fvm_ipld_amt = { version = "0.2.0", path = "../../ipld/amt"}
 fvm_ipld_car = { version = "0.2.0", path = "../../ipld/car" }


### PR DESCRIPTION
It's a minor release because it removes something that shouldn't have
been exported in the first place (breaking change).