### PR TITLE
fix: remove cbor serde error from everywhere

### DIFF
--- a/shared/src/encoding/cbor.rs
+++ b/shared/src/encoding/cbor.rs
@@ -22,7 +22,7 @@ pub trait Cbor: ser::Serialize + de::DeserializeOwned {
 
     /// Unmarshals cbor encoded bytes to object
     fn unmarshal_cbor(bz: &[u8]) -> Result<Self, Error> {
-        Ok(from_slice(bz)?)
+        from_slice(bz)
     }
 
     /// Returns the content identifier of the raw block of data
@@ -101,6 +101,6 @@ impl RawBytes {
 
     /// Deserializes the serialized bytes into a defined type.
     pub fn deserialize<O: de::DeserializeOwned>(&self) -> Result<O, Error> {
-        Ok(from_slice(&self.bytes)?)
+        from_slice(&self.bytes)
     }
 }

--- a/shared/src/encoding/mod.rs
+++ b/shared/src/encoding/mod.rs
@@ -7,9 +7,10 @@ mod errors;
 mod hash;
 mod vec;
 
+use std::io;
+
 pub use serde::{de, ser};
 pub use serde_bytes;
-pub use serde_ipld_dagcbor::{from_reader, from_slice, to_writer};
 
 pub use self::bytes::*;
 pub use self::cbor::*;
@@ -29,8 +30,6 @@ pub mod repr {
     pub use serde_repr::{Deserialize_repr, Serialize_repr};
 }
 
-// TODO: upstream this. Upstream doesn't allow encoding unsized types (e.g., slices).
-
 /// Serializes a value to a vector.
 pub fn to_vec<T>(value: &T) -> Result<Vec<u8>, Error>
 where
@@ -39,4 +38,30 @@ where
     let mut vec = Vec::new();
     value.serialize(&mut serde_ipld_dagcbor::Serializer::new(&mut vec))?;
     Ok(vec)
+}
+
+/// Decode a value from CBOR from the given reader.
+pub fn from_reader<T, R>(reader: R) -> Result<T, Error>
+where
+    T: de::DeserializeOwned,
+    R: io::Read,
+{
+    serde_ipld_dagcbor::from_reader(reader).map_err(Into::into)
+}
+
+/// Decode a value from CBOR from the given slice.
+pub fn from_slice<'a, T>(slice: &'a [u8]) -> Result<T, Error>
+where
+    T: de::Deserialize<'a>,
+{
+    serde_ipld_dagcbor::from_slice(slice).map_err(Into::into)
+}
+
+/// Encode a value as CBOR to the given writer.
+pub fn to_writer<W, T>(writer: W, value: &T) -> Result<(), Error>
+where
+    W: io::Write,
+    T: ser::Serialize,
+{
+    serde_ipld_dagcbor::to_writer(writer, value).map_err(Into::into)
 }


### PR DESCRIPTION
The previous patch only removed it from to_vec, but we need to do this everywhere.