### PR TITLE
chore: release fvm_ipld_bitfield 0.4.0

### DIFF
--- a/ipld/bitfield/Cargo.toml
+++ b/ipld/bitfield/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_bitfield"
 description = "Bitfield logic for use in Filecoin actors"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"


### PR DESCRIPTION
This version is incompatible with previous versions due to a few changed
function signatures, and stricter validation. Continue using 0.3.0 to
validate networks before nv16.