### PR TITLE
Implement ExitCode as u32 wrapper, and use new spec codes

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -323,7 +323,7 @@ where
                         .data()
                         .kernel
                         .block_get(return_block_id)
-                        .map_err(|e| Abort::from_error(ExitCode::SysErrIllegalActor, e))?;
+                        .map_err(|e| Abort::from_error(SystemExitCode::MISSING_RETURN, e))?;
                     debug_assert_eq!(code, DAG_CBOR);
                     RawBytes::new(ret)
                 } else {
@@ -350,14 +350,12 @@ where
                             (code, message, Ok(InvocationResult::Failure(code)))
                         }
                         Abort::OutOfGas => (
-                            ExitCode::SysErrOutOfGas,
+                            SystemExitCode::OUT_OF_GAS,
                             "out of gas".to_owned(),
                             Err(ExecutionError::OutOfGas),
                         ),
                         Abort::Fatal(err) => (
-                            // TODO: will be changed to a SysErrAssertionFailed when we
-                            // introduce the new exit codes.
-                            ExitCode::SysErrIllegalArgument,
+                            SystemExitCode::ASSERTION_FAILED,
                             "fatal error".to_owned(),
                             Err(ExecutionError::Fatal(err)),
                         ),

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -323,7 +323,7 @@ where
                         .data()
                         .kernel
                         .block_get(return_block_id)
-                        .map_err(|e| Abort::from_error(SystemExitCode::MISSING_RETURN, e))?;
+                        .map_err(|e| Abort::from_error(ExitCode::SYS_MISSING_RETURN, e))?;
                     debug_assert_eq!(code, DAG_CBOR);
                     RawBytes::new(ret)
                 } else {
@@ -350,12 +350,12 @@ where
                             (code, message, Ok(InvocationResult::Failure(code)))
                         }
                         Abort::OutOfGas => (
-                            SystemExitCode::OUT_OF_GAS,
+                            ExitCode::SYS_OUT_OF_GAS,
                             "out of gas".to_owned(),
                             Err(ExecutionError::OutOfGas),
                         ),
                         Abort::Fatal(err) => (
-                            SystemExitCode::ASSERTION_FAILED,
+                            ExitCode::SYS_ASSERTION_FAILED,
                             "fatal error".to_owned(),
                             Err(ExecutionError::Fatal(err)),
                         ),

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -135,7 +135,7 @@ impl InvocationResult {
     /// from the [`Failure`](InvocationResult::Failure) variant otherwise.
     pub fn exit_code(&self) -> ExitCode {
         match self {
-            Self::Return(_) => ExitCode::Ok,
+            Self::Return(_) => ExitCode::OK,
             Self::Failure(e) => *e,
         }
     }

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -7,7 +7,7 @@ use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::{BigInt, Sign};
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::error::{ErrorNumber, ExitCode};
+use fvm_shared::error::{ErrorNumber, ExitCode, SystemExitCode};
 use fvm_shared::message::Message;
 use fvm_shared::receipt::Receipt;
 use fvm_shared::ActorID;
@@ -88,7 +88,7 @@ where
             Ok(InvocationResult::Return(return_data)) => {
                 backtrace.clear();
                 Receipt {
-                    exit_code: ExitCode::Ok,
+                    exit_code: ExitCode::OK,
                     return_data,
                     gas_used,
                 }
@@ -104,16 +104,16 @@ where
                 }
             }
             Err(ExecutionError::OutOfGas) => Receipt {
-                exit_code: ExitCode::SysErrOutOfGas,
+                exit_code: SystemExitCode::OUT_OF_GAS,
                 return_data: Default::default(),
                 gas_used,
             },
             Err(ExecutionError::Syscall(err)) => {
                 let exit_code = match err.1 {
-                    ErrorNumber::IllegalOperation => ExitCode::SysErrIllegalActor,
-                    ErrorNumber::AssertionFailed => ExitCode::SysErrIllegalArgument,
-                    ErrorNumber::InsufficientFunds => ExitCode::SysErrInsufficientFunds,
-                    ErrorNumber::NotFound => ExitCode::SysErrInvalidReceiver,
+                    ErrorNumber::IllegalOperation => SystemExitCode::ILLEGAL_ACTOR,
+                    ErrorNumber::AssertionFailed => SystemExitCode::ASSERTION_FAILED,
+                    ErrorNumber::InsufficientFunds => SystemExitCode::INSUFFICIENT_FUNDS,
+                    ErrorNumber::NotFound => SystemExitCode::INVALID_RECEIVER,
                     code => {
                         return Err(anyhow!(
                             "unexpected syscall error when processing message: {} ({})",
@@ -207,7 +207,7 @@ where
                 // Verify the cost of the message is not over the message gas limit.
                 if inclusion_total > msg.gas_limit {
                     return Ok(Err(ApplyRet::prevalidation_fail(
-                        ExitCode::SysErrOutOfGas,
+                        SystemExitCode::OUT_OF_GAS,
                         format!("Out of gas ({} > {})", inclusion_total, msg.gas_limit),
                         &self.context().base_fee * inclusion_total,
                     )));
@@ -227,7 +227,7 @@ where
             Some(id) => id,
             None => {
                 return Ok(Err(ApplyRet::prevalidation_fail(
-                    ExitCode::SysErrSenderInvalid,
+                    SystemExitCode::SENDER_INVALID,
                     "Sender invalid",
                     miner_penalty_amount,
                 )))
@@ -246,7 +246,7 @@ where
             Some(act) => act,
             None => {
                 return Ok(Err(ApplyRet::prevalidation_fail(
-                    ExitCode::SysErrSenderInvalid,
+                    SystemExitCode::SENDER_INVALID,
                     "Sender invalid",
                     miner_penalty_amount,
                 )))
@@ -262,7 +262,7 @@ where
 
         if !sender_is_account {
             return Ok(Err(ApplyRet::prevalidation_fail(
-                ExitCode::SysErrSenderInvalid,
+                SystemExitCode::SENDER_INVALID,
                 "Send not from account actor",
                 miner_penalty_amount,
             )));
@@ -271,7 +271,7 @@ where
         // Check sequence is correct
         if msg.sequence != sender.sequence {
             return Ok(Err(ApplyRet::prevalidation_fail(
-                ExitCode::SysErrSenderStateInvalid,
+                SystemExitCode::SENDER_STATE_INVALID,
                 format!(
                     "Actor sequence invalid: {} != {}",
                     msg.sequence, sender.sequence
@@ -284,7 +284,7 @@ where
         let gas_cost: TokenAmount = msg.gas_fee_cap.clone() * msg.gas_limit;
         if sender.balance < gas_cost {
             return Ok(Err(ApplyRet::prevalidation_fail(
-                ExitCode::SysErrSenderStateInvalid,
+                SystemExitCode::SENDER_STATE_INVALID,
                 format!(
                     "Actor balance less than needed: {} < {}",
                     sender.balance, gas_cost

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -2,7 +2,7 @@
 use std::sync::Mutex;
 
 use derive_more::Display;
-use fvm_shared::error::ExitCode;
+use fvm_shared::error::{ExitCode, SystemExitCode};
 use wasmtime::Trap;
 
 use crate::kernel::ExecutionError;
@@ -50,7 +50,7 @@ impl From<Trap> for Abort {
 
         // Actor panic/wasm error.
         if let Some(code) = t.trap_code() {
-            return Abort::Exit(ExitCode::SysErrActorPanic, code.to_string());
+            return Abort::Exit(SystemExitCode::ILLEGAL_INSTRUCTION, code.to_string());
         }
 
         // Try to get a smuggled error back.

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -2,7 +2,7 @@
 use std::sync::Mutex;
 
 use derive_more::Display;
-use fvm_shared::error::{ExitCode};
+use fvm_shared::error::ExitCode;
 use wasmtime::Trap;
 
 use crate::kernel::ExecutionError;

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -2,7 +2,7 @@
 use std::sync::Mutex;
 
 use derive_more::Display;
-use fvm_shared::error::{ExitCode, SystemExitCode};
+use fvm_shared::error::{ExitCode};
 use wasmtime::Trap;
 
 use crate::kernel::ExecutionError;
@@ -50,7 +50,7 @@ impl From<Trap> for Abort {
 
         // Actor panic/wasm error.
         if let Some(code) = t.trap_code() {
-            return Abort::Exit(SystemExitCode::ILLEGAL_INSTRUCTION, code.to_string());
+            return Abort::Exit(ExitCode::SYS_ILLEGAL_INSTRUCTION, code.to_string());
         }
 
         // Try to get a smuggled error back.

--- a/fvm/src/syscalls/send.rs
+++ b/fvm/src/syscalls/send.rs
@@ -11,10 +11,6 @@ use crate::Kernel;
 
 /// Send a message to another actor. The result is placed as a CBOR-encoded
 /// receipt in the block registry, and can be retrieved by the returned BlockId.
-///
-/// TODO result is a Receipt, but messages within a call stack don't
-///  actually produce receipts.
-///  See https://github.com/filecoin-project/fvm/issues/168.
 pub fn send(
     context: Context<'_, impl Kernel>,
     recipient_off: u32,
@@ -41,10 +37,10 @@ pub fn send(
             .send(&recipient, method, &params.into(), &value)?
         {
             InvocationResult::Return(value) => (
-                ExitCode::Ok as u32,
+                ExitCode::OK.value(),
                 context.kernel.block_create(DAG_CBOR, value.bytes())?,
             ),
-            InvocationResult::Failure(code) => (code as u32, 0),
+            InvocationResult::Failure(code) => (code.value(), 0),
         };
     Ok(sys::out::send::Send {
         exit_code,

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -18,12 +18,13 @@ pub fn abort(
     message_len: u32,
 ) -> Result<Never, Abort> {
     let code = ExitCode::new(code);
-    if code.is_system_error() {
-        return Err(Abort::Exit(
-            SystemExitCode::ILLEGAL_EXIT_CODE,
-            format!("actor aborted with code {}", code),
-        ));
-    }
+    // Uncomment to fix https://github.com/filecoin-project/ref-fvm/issues/253
+    // if code.is_system_error() {
+    //     return Err(Abort::Exit(
+    //         SystemExitCode::ILLEGAL_EXIT_CODE,
+    //         format!("actor aborted with code {}", code),
+    //     ));
+    // }
 
     let message = if message_len == 0 {
         "actor aborted".to_owned()

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -1,4 +1,4 @@
-use fvm_shared::error::{ExitCode};
+use fvm_shared::error::ExitCode;
 
 use super::error::Abort;
 use super::Context;

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -1,4 +1,4 @@
-use fvm_shared::error::{ExitCode, SystemExitCode};
+use fvm_shared::error::{ExitCode};
 
 use super::error::Abort;
 use super::Context;

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -1,4 +1,3 @@
-use fvm_ipld_encoding::{Cbor, DAG_CBOR};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::sys::{BlockId, Codec};
@@ -78,7 +77,7 @@ pub fn params_cbor<T: Cbor>(id: BlockId) -> SyscallResult<T> {
     match fvm_ipld_encoding::from_slice(raw.as_slice()) {
         Ok(v) => Ok(v),
         Err(e) => vm::abort(
-            ExitCode::ErrSerialization as u32,
+            StandardExitCode::SERIALIZATION.value(),
             Some(format!("could not deserialize parameters as cbor: {:?}", e).as_str()),
         ),
     }

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -1,9 +1,10 @@
-use fvm_shared::{ActorID, MethodNum};
 use fvm_shared::econ::TokenAmount;
+use fvm_shared::encoding::DAG_CBOR;
 use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::sys::{BlockId, Codec};
+use fvm_shared::{ActorID, MethodNum};
 
-use crate::{sys, SyscallResult, vm};
+use crate::{sys, SyscallResult};
 
 /// BlockID representing nil parameters or return data.
 pub const NO_DATA_BLOCK_ID: u32 = 0;
@@ -62,4 +63,3 @@ pub fn value_received() -> TokenAmount {
             .into()
     }
 }
-

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -1,9 +1,9 @@
+use fvm_shared::{ActorID, MethodNum};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::sys::{BlockId, Codec};
-use fvm_shared::{ActorID, MethodNum};
 
-use crate::{sys, vm, SyscallResult};
+use crate::{sys, SyscallResult, vm};
 
 /// BlockID representing nil parameters or return data.
 pub const NO_DATA_BLOCK_ID: u32 = 0;
@@ -63,22 +63,3 @@ pub fn value_received() -> TokenAmount {
     }
 }
 
-/// Fetches the input parameters as raw bytes, and decodes them locally
-/// into type T using cbor serde. Failing to decode will abort execution.
-///
-/// This function errors with ErrIllegalArgument when no parameters have been
-/// provided.
-pub fn params_cbor<T: Cbor>(id: BlockId) -> SyscallResult<T> {
-    if id == NO_DATA_BLOCK_ID {
-        return Err(ErrorNumber::IllegalArgument);
-    }
-    let (codec, raw) = params_raw(id)?;
-    debug_assert!(codec == DAG_CBOR, "parameters codec was not cbor");
-    match fvm_ipld_encoding::from_slice(raw.as_slice()) {
-        Ok(v) => Ok(v),
-        Err(e) => vm::abort(
-            StandardExitCode::SERIALIZATION.value(),
-            Some(format!("could not deserialize parameters as cbor: {:?}", e).as_str()),
-        ),
-    }
-}

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -1,6 +1,5 @@
+use fvm_ipld_encoding::DAG_CBOR;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::DAG_CBOR;
-use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::sys::{BlockId, Codec};
 use fvm_shared::{ActorID, MethodNum};
 

--- a/sdk/src/send.rs
+++ b/sdk/src/send.rs
@@ -6,7 +6,6 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::receipt::Receipt;
 use fvm_shared::MethodNum;
-use num_traits::FromPrimitive;
 
 use crate::message::NO_DATA_BLOCK_ID;
 use crate::{sys, SyscallResult};
@@ -47,9 +46,9 @@ pub fn send(
         )?;
 
         // Process the result.
-        let exit_code = ExitCode::from_u32(exit_code).unwrap_or(ExitCode::SysErrIllegalActor);
+        let exit_code = ExitCode::new(exit_code);
         let return_data = match exit_code {
-            ExitCode::Ok if return_id != NO_DATA_BLOCK_ID => {
+            ExitCode::OK if return_id != NO_DATA_BLOCK_ID => {
                 // Allocate a buffer to read the return data.
                 let fvm_shared::sys::out::ipld::IpldStat { size, .. } = sys::ipld::stat(return_id)?;
                 let mut bytes = vec![0; size as usize];

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -23,7 +23,7 @@ impl ExitCode {
     }
 
     pub fn value(self) -> u32 {
-        return self.value;
+        self.value
     }
 
     /// Returns true if the exit code indicates success.

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -2,11 +2,12 @@ use std::fmt::Formatter;
 
 use fvm_ipld_encoding::repr::*;
 use num_derive::FromPrimitive;
-use serde::{Deserializer, Serializer};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// ExitCode defines the exit code from the VM invocation.
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct ExitCode {
     value: u32,
 }
@@ -41,24 +42,6 @@ impl ExitCode {
 impl std::fmt::Display for ExitCode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.value)
-    }
-}
-
-impl serde::Serialize for ExitCode {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_u32(self.value)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for ExitCode {
-    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(ExitCode { value: 0 }) // FIXME figure this out
     }
 }
 

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -36,7 +36,7 @@ impl ExitCode {
 
 impl From<u32> for ExitCode {
     fn from(value: u32) -> Self {
-        ExitCode{ value }
+        ExitCode { value }
     }
 }
 

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -1,6 +1,5 @@
 use std::fmt::Formatter;
 
-use fvm_ipld_encoding::repr::*;
 use num_derive::FromPrimitive;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -1,100 +1,134 @@
-// Copyright 2019-2022 ChainSafe Systems
-// SPDX-License-Identifier: Apache-2.0, MIT
-
 use std::fmt::Formatter;
 
 use fvm_ipld_encoding::repr::*;
 use num_derive::FromPrimitive;
+use serde::{Deserializer, Serializer};
 use thiserror::Error;
 
-/// ExitCode defines the exit code from the VM execution.
-#[repr(u32)]
-#[derive(
-    PartialEq, Eq, Debug, Clone, Copy, FromPrimitive, Serialize_repr, Deserialize_repr, Error,
-)]
-pub enum ExitCode {
-    Ok = 0,
-
-    /// Indicates failure to find an actor in the state tree.
-    SysErrSenderInvalid = 1,
-
-    /// Indicates that the message sender was not in a valid state to send this message.
-    ///
-    /// Either:
-    /// - The sender's nonce nonce didn't match the message nonce.
-    /// - The sender didn't have the funds to cover the message gas.
-    SysErrSenderStateInvalid = 2,
-
-    /// Indicates failure to find a method in an actor.
-    SysErrInvalidMethod = 3,
-
-    /// Used for catching panics currently.
-    SysErrActorPanic = 4,
-
-    /// Indicates that the receiver of a message is not valid (and cannot be implicitly created).
-    SysErrInvalidReceiver = 5,
-
-    /// Indicates a message sender has insufficient funds for a message's execution.
-    SysErrInsufficientFunds = 6,
-
-    /// Indicates message execution (including subcalls) used more gas than the specified limit.
-    SysErrOutOfGas = 7,
-
-    /// Indicates a message execution is forbidden for the caller.
-    SysErrForbidden = 8,
-
-    /// Indicates actor code performed a disallowed operation. Disallowed operations include:
-    /// - mutating state outside of a state acquisition block
-    /// - failing to invoke caller validation
-    /// - aborting with a reserved exit code (including success or a system error).
-    SysErrIllegalActor = 9,
-
-    /// Indicates an invalid argument passed to a runtime method.
-    SysErrIllegalArgument = 10,
-
-    /// Reserved exit codes, do not use.
-    SysErrReserved2 = 11,
-    SysErrReserved3 = 12,
-    SysErrReserved4 = 13,
-    SysErrReserved5 = 14,
-    SysErrReserved6 = 15,
-
-    // -------Actor Error Codes-------
-    /// Indicates a method parameter is invalid.
-    ErrIllegalArgument = 16,
-    /// Indicates a requested resource does not exist.
-    ErrNotFound = 17,
-    /// Indicates an action is disallowed.
-    ErrForbidden = 18,
-    /// Indicates a balance of funds is insufficient.
-    ErrInsufficientFunds = 19,
-    /// Indicates an actor's internal state is invalid.
-    ErrIllegalState = 20,
-    /// Indicates de/serialization failure within actor code.
-    ErrSerialization = 21,
-    /// Power actor specific exit code.
-    // * remove this and support custom codes if there is overlap on actor specific codes in future
-    ErrTooManyProveCommits = 32,
-
-    ErrPlaceholder = 1000,
+/// ExitCode defines the exit code from the VM invocation.
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub struct ExitCode {
+    value: u32,
 }
 
 impl ExitCode {
-    /// Returns true if the exit code was a success
-    pub fn is_success(self) -> bool {
-        self == ExitCode::Ok
+    /// The code indicating successful execution.
+    pub const OK: ExitCode = ExitCode::new(0);
+
+    /// The lowest exit code that an actor may abort with.
+    pub const FIRST_UNRESERVED_EXIT_CODE: u32 = 16;
+
+    pub const fn new(value: u32) -> Self {
+        Self { value }
     }
 
-    /// Returns true if the error code is a system error.
+    pub fn value(self) -> u32 {
+        return self.value;
+    }
+
+    /// Returns true if the exit code indicates success.
+    pub fn is_success(self) -> bool {
+        self.value == 0
+    }
+
+    /// Returns true if the error code is in the range of exit codes reserved for the VM
+    /// (including Ok).
     pub fn is_system_error(self) -> bool {
-        (self as u32) < (ExitCode::ErrIllegalArgument as u32)
+        self.value < (Self::FIRST_UNRESERVED_EXIT_CODE)
     }
 }
 
 impl std::fmt::Display for ExitCode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "exit code: {}", *self as u32)
+        write!(f, "{}", self.value)
     }
+}
+
+impl serde::Serialize for ExitCode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u32(self.value)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ExitCode {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(ExitCode { value: 0 }) // FIXME figure this out
+    }
+}
+
+/// Enumerates exit codes which originate inside the VM.
+/// These values may not be used by actors when aborting.
+pub struct SystemExitCode {}
+
+impl SystemExitCode {
+    /// Indicates the message sender doesn't exist.
+    pub const SENDER_INVALID: ExitCode = ExitCode::new(1);
+    /// Indicates that the message sender was not in a valid state to send this message.
+    /// Either:
+    /// - The sender's nonce nonce didn't match the message nonce.
+    /// - The sender didn't have the funds to cover the message gas.
+    pub const SENDER_STATE_INVALID: ExitCode = ExitCode::new(2);
+    /// Indicates failure to find a method in an actor.
+    pub const INVALID_METHOD: ExitCode = ExitCode::new(3); // FIXME: reserved
+    /// Indicates the message receiver trapped (panicked).
+    pub const ILLEGAL_INSTRUCTION: ExitCode = ExitCode::new(4);
+    /// Indicates the message receiver doesn't exist and can't be automatically created
+    pub const INVALID_RECEIVER: ExitCode = ExitCode::new(5);
+    /// Indicates the message sender didn't have the requisite funds.
+    pub const INSUFFICIENT_FUNDS: ExitCode = ExitCode::new(6);
+    /// Indicates message execution (including subcalls) used more gas than the specified limit.
+    pub const OUT_OF_GAS: ExitCode = ExitCode::new(7);
+    // REVIEW: I restored this in order to map the syscall error number ErrorNumber::IllegalOperation
+    // Should it use ILLEGAL_INSTRUCTION instead?
+    pub const ILLEGAL_ACTOR: ExitCode = ExitCode::new(8);
+    /// Indicates the message receiver aborted with a reserved exit code.
+    pub const ILLEGAL_EXIT_CODE: ExitCode = ExitCode::new(9);
+    /// Indicates an internal VM assertion failed.
+    pub const ASSERTION_FAILED: ExitCode = ExitCode::new(10);
+    /// Indicates the actor returned a block handle that doesn't exist
+    pub const MISSING_RETURN: ExitCode = ExitCode::new(11);
+
+    pub const RESERVED_12: ExitCode = ExitCode::new(12);
+    pub const RESERVED_13: ExitCode = ExitCode::new(13);
+    pub const RESERVED_14: ExitCode = ExitCode::new(14);
+    pub const RESERVED_15: ExitCode = ExitCode::new(15);
+}
+
+/// Enumerates standard exit codes according to the built-in actors' calling convention.
+pub struct StandardExitCode {}
+
+impl StandardExitCode {
+    /// Indicates a method parameter is invalid.
+    pub const ILLEGAL_ARGUMENT: ExitCode = ExitCode::new(16);
+    /// Indicates a requested resource does not exist.
+    pub const NOT_FOUND: ExitCode = ExitCode::new(17);
+    /// Indicates an action is disallowed.
+    pub const FORBIDDEN: ExitCode = ExitCode::new(18);
+    /// Indicates a balance of funds is insufficient.
+    pub const INSUFFICIENT_FUNDS: ExitCode = ExitCode::new(19);
+    /// Indicates an actor's internal state is invalid.
+    pub const ILLEGAL_STATE: ExitCode = ExitCode::new(20);
+    /// Indicates de/serialization failure within actor code.
+    pub const SERIALIZATION: ExitCode = ExitCode::new(21);
+    /// Indicates the actor cannot handle this message.
+    pub const UNHANDLED_MESSAGE: ExitCode = ExitCode::new(22);
+    /// Indicates the actor failed with an unspecified error.
+    pub const UNSPECIFIED: ExitCode = ExitCode::new(23);
+
+    pub const RESERVED_24: ExitCode = ExitCode::new(24);
+    pub const RESERVED_25: ExitCode = ExitCode::new(25);
+    pub const RESERVED_26: ExitCode = ExitCode::new(26);
+    pub const RESERVED_27: ExitCode = ExitCode::new(27);
+    pub const RESERVED_28: ExitCode = ExitCode::new(28);
+    pub const RESERVED_29: ExitCode = ExitCode::new(29);
+    pub const RESERVED_30: ExitCode = ExitCode::new(30);
+    pub const RESERVED_31: ExitCode = ExitCode::new(31);
 }
 
 #[repr(u32)]


### PR DESCRIPTION
This is for discussion first, following initial discussion on Slack. I've implemented ExitCode as a wrapper over a u32, not an enum. It thus accepts any value. I've then added constants for the system and standard values, updating them to match the FVM [spec](https://github.com/filecoin-project/fvm-specs/blob/main/07-errors.md).

Possible changes:
- Some way to use ExitCode values as values of an enum, rather than as a bag of constants.
- Rename back to CamelCase and explicitly ignore Clippy

The worst bit of this change, IMO, is renaming to ALL_CAPS to follow Rust convention for constants that are not enum values. I did try leaving the SystemExitCode values as an enum of integers, with a `From` implementation, but that results in a bunch of `.into()` wherever they are used. I opted to use constant values of `ExitCode` type instead.

I considered using an enum as a discriminated union, with cases for ok, system code, standard code, and others, each containing a u32 value with explicit range checking on creation. I think that would be trying much to hard. There's no call to `match` over those, and not much call here for leaning on type safety for range bounds. In the built-in actors, we might not even use the ExitCode type. An enum of integers on that side could work well.

**Questions**

~The spec removed SysErrIllegalActor, but I've restored it as the code to which the syscall error number `IllegalOperation` maps. Please let me know if that should instead map to `SysErrIllegalInstruction` (i.e. panic) or something else. I didn't yet trace all the places that could generate it.~

The only use of the (non-system) StandardExitCode values in this repo is the `params_cbor` function, which is actually unused here or in builtin-actors, so could be removed (it's just sugar). We could then remove the StandardExitCode values entirely from this repo over to built-in actors, as part of the built-in actor calling convention. WDYT? They might still be useful here for user actors who call into the builtin ones (depending how we export their APIs).

I shortened the names, since they're always qualified. Happy to restore the prefixes on request.

Includes resolution of #253 if we update the conformance tests.
Fixes #430 plus some other TODOs

FYI @ZenGround0 