### PR TITLE
fix: enforce max bitfield size on decode

### DIFF
--- a/ipld/bitfield/src/rleplus/mod.rs
+++ b/ipld/bitfield/src/rleplus/mod.rs
@@ -105,6 +105,12 @@ impl<'de> Deserialize<'de> for BitField {
         D: Deserializer<'de>,
     {
         let bytes: Cow<'de, [u8]> = serde_bytes::deserialize(deserializer)?;
+        if bytes.len() > MAX_ENCODED_SIZE {
+            return Err(serde::de::Error::custom(format!(
+                "encoded bitfield was too large {}",
+                bytes.len()
+            )));
+        }
         Self::from_bytes(&bytes).map_err(serde::de::Error::custom)
     }
 }


### PR DESCRIPTION
Honestly, we probably _don't_ need this in the FVM because:

1. Malicious inputs will burn gas for compute and won't be able to OOM the node.
2. Large bitfields will fail to serialize to state anyways.

However, I'd like relaxing this check to be an explicit step.

Fixes C1.