### PR TITLE
Clean up and simplify gas functionality

### DIFF
--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -136,6 +136,7 @@ lazy_static! {
 
         verify_consensus_fault: 495422,
         verify_replica_update: 36316136,
+        verify_seal_proof: 34721049,
         verify_post_lookup: [
             (
                 RegisteredPoStProof::StackedDRGWindow512MiBV1,
@@ -284,6 +285,7 @@ pub struct PriceList {
     pub(crate) verify_post_discount: bool,
     pub(crate) verify_consensus_fault: i64,
     pub(crate) verify_replica_update: i64,
+    pub(crate) verify_seal_proof: i64,
 }
 
 impl PriceList {
@@ -450,6 +452,11 @@ impl PriceList {
     #[inline]
     pub fn on_verify_consensus_fault(&self) -> GasCharge<'static> {
         GasCharge::new("OnVerifyConsensusFault", self.verify_consensus_fault, 0)
+    }
+    /// Returns gas required for submitting a seal proof.
+    #[inline]
+    pub fn on_submit_verify_seal(&self) -> GasCharge<'static> {
+        GasCharge::new("OnSubmitVerifySeal", self.verify_seal_proof, 0)
     }
 }
 

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -7,7 +7,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredPoStProof, RegisteredSealProof, ReplicaUpdateInfo,
-    SealVerifyInfo, WindowPoStVerifyInfo,
+    WindowPoStVerifyInfo,
 };
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{MethodNum, METHOD_SEND};
@@ -45,51 +45,92 @@ lazy_static! {
 
         hashing_base: 31355,
         compute_unsealed_sector_cid_base: 98647,
-        verify_seal_base: 2000, // TODO revisit potential removal of this
 
         verify_aggregate_seal_base: 0,
         verify_aggregate_seal_per: [
-            (
-                RegisteredSealProof::StackedDRG32GiBV1P1,
-                449900
-            ),
-            (
-                RegisteredSealProof::StackedDRG64GiBV1P1,
-                359272
-            )
-        ].iter().copied().collect(),
+            (RegisteredSealProof::StackedDRG32GiBV1P1, 449900),
+            (RegisteredSealProof::StackedDRG64GiBV1P1, 359272)
+        ]
+        .iter()
+        .copied()
+        .collect(),
         verify_aggregate_seal_steps: [
             (
                 RegisteredSealProof::StackedDRG32GiBV1P1,
-                StepCost (
-                    vec![
-                        Step{start: 4, cost: 103994170},
-                        Step{start: 7, cost: 112356810},
-                        Step{start: 13, cost: 122912610},
-                        Step{start: 26, cost: 137559930},
-                        Step{start: 52, cost: 162039100},
-                        Step{start: 103, cost: 210960780},
-                        Step{start: 205, cost: 318351180},
-                        Step{start: 410, cost: 528274980},
-                    ]
-                )
+                StepCost(vec![
+                    Step {
+                        start: 4,
+                        cost: 103994170
+                    },
+                    Step {
+                        start: 7,
+                        cost: 112356810
+                    },
+                    Step {
+                        start: 13,
+                        cost: 122912610
+                    },
+                    Step {
+                        start: 26,
+                        cost: 137559930
+                    },
+                    Step {
+                        start: 52,
+                        cost: 162039100
+                    },
+                    Step {
+                        start: 103,
+                        cost: 210960780
+                    },
+                    Step {
+                        start: 205,
+                        cost: 318351180
+                    },
+                    Step {
+                        start: 410,
+                        cost: 528274980
+                    },
+                ])
             ),
             (
                 RegisteredSealProof::StackedDRG64GiBV1P1,
-                StepCost (
-                    vec![
-                        Step{start: 4, cost: 102581240},
-                        Step{start: 7, cost: 110803030},
-                        Step{start: 13, cost: 120803700},
-                        Step{start: 26, cost: 134642130},
-                        Step{start: 52, cost: 157357890},
-                        Step{start: 103, cost: 203017690},
-                        Step{start: 205, cost: 304253590},
-                        Step{start: 410, cost: 509880640},
-                    ]
-                )
+                StepCost(vec![
+                    Step {
+                        start: 4,
+                        cost: 102581240
+                    },
+                    Step {
+                        start: 7,
+                        cost: 110803030
+                    },
+                    Step {
+                        start: 13,
+                        cost: 120803700
+                    },
+                    Step {
+                        start: 26,
+                        cost: 134642130
+                    },
+                    Step {
+                        start: 52,
+                        cost: 157357890
+                    },
+                    Step {
+                        start: 103,
+                        cost: 203017690
+                    },
+                    Step {
+                        start: 205,
+                        cost: 304253590
+                    },
+                    Step {
+                        start: 410,
+                        cost: 509880640
+                    },
+                ])
             )
-        ].iter()
+        ]
+        .iter()
         .cloned()
         .collect(),
 
@@ -234,7 +275,6 @@ pub struct PriceList {
     pub(crate) hashing_base: i64,
 
     pub(crate) compute_unsealed_sector_cid_base: i64,
-    pub(crate) verify_seal_base: i64,
     #[allow(unused)]
     pub(crate) verify_aggregate_seal_base: i64,
     pub(crate) verify_aggregate_seal_per: AHashMap<RegisteredSealProof, i64>,
@@ -344,11 +384,6 @@ impl PriceList {
             self.compute_unsealed_sector_cid_base,
             0,
         )
-    }
-    /// Returns gas required for seal verification.
-    #[inline]
-    pub fn on_verify_seal(&self, _info: &SealVerifyInfo) -> GasCharge<'static> {
-        GasCharge::new("OnVerifySeal", self.verify_seal_base, 0)
     }
     #[inline]
     pub fn on_verify_aggregate_seals(

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -504,13 +504,6 @@ where
         data_commitment_v1_to_cid(&comm_d).or_illegal_argument()
     }
 
-    /// Verify seal proof for sectors. This proof verifies that a sector was sealed by the miner.
-    fn verify_seal(&mut self, vi: &SealVerifyInfo) -> Result<bool> {
-        self.call_manager
-            .charge_gas(self.call_manager.price_list().on_verify_seal(vi))?;
-        verify_seal(vi)
-    }
-
     fn verify_post(&mut self, verify_info: &WindowPoStVerifyInfo) -> Result<bool> {
         self.call_manager
             .charge_gas(self.call_manager.price_list().on_verify_post(verify_info))?;

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -704,6 +704,11 @@ where
         let charge = GasCharge::new(name, compute, 0);
         self.call_manager.charge_gas(charge)
     }
+
+    fn on_submit_verify_seal(&mut self) -> Result<()> {
+        self.call_manager
+            .charge_gas(self.call_manager.price_list().on_submit_verify_seal())
+    }
 }
 
 impl<C> NetworkOps for DefaultKernel<C>

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -212,15 +212,17 @@ pub trait CircSupplyOps {
 }
 
 /// Operations for explicit gas charging.
-///
-/// TODO this is unsafe; most gas charges should occur as part of syscalls, but
-///  some built-in actors currently charge gas explicitly for concrete actions.
-///  In the future (Phase 1), this should disappear and be replaced by gas instrumentation
-///  at the WASM level.
 pub trait GasOps {
+    /// TODO this is unsafe; most gas charges should occur as part of syscalls, but
+    ///  some built-in actors currently charge gas explicitly for concrete actions.
+    ///  In the future (Phase 1), this should disappear and be replaced by gas instrumentation
+    ///  at the WASM level
     /// ChargeGas charges specified amount of `gas` for execution.
     /// `name` provides information about gas charging point
     fn charge_gas(&mut self, name: &str, compute: i64) -> Result<()>;
+
+    /// Charges the gas associated with submitting a seal proof for future bulk verification
+    fn on_submit_verify_seal(&mut self) -> Result<()>;
 }
 
 /// Cryptographic primitives provided by the kernel.

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -243,9 +243,6 @@ pub trait CryptoOps {
         pieces: &[PieceInfo],
     ) -> Result<Cid>;
 
-    /// Verifies a sector seal proof.
-    fn verify_seal(&mut self, vi: &SealVerifyInfo) -> Result<bool>;
-
     /// Verifies a window proof of spacetime.
     fn verify_post(&mut self, verify_info: &WindowPoStVerifyInfo) -> Result<bool>;
 

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -92,25 +92,6 @@ pub fn compute_unsealed_sector_cid(
     Ok(bytes.len() as u32)
 }
 
-/// Verifies a sector seal proof.
-///
-/// The return i32 indicates the status code of the verification:
-///  - 0: verification ok.
-///  - -1: verification failed.
-pub fn verify_seal(
-    mut context: Context<'_, impl Kernel>,
-    info_off: u32, // SealVerifyInfo
-    info_len: u32,
-) -> Result<i32> {
-    let info = context
-        .memory
-        .read_cbor::<SealVerifyInfo>(info_off, info_len)?;
-    context
-        .kernel
-        .verify_seal(&info)
-        .map(|v| if v { 0 } else { -1 })
-}
-
 /// Verifies a window proof of spacetime.
 ///
 /// The return i32 indicates the status code of the verification:

--- a/fvm/src/syscalls/gas.rs
+++ b/fvm/src/syscalls/gas.rs
@@ -1,16 +1,7 @@
-use std::str;
-
 use super::Context;
-use crate::kernel::{ClassifyResult, Result};
+use crate::kernel::Result;
 use crate::Kernel;
 
-pub fn charge_gas(
-    context: Context<'_, impl Kernel>,
-    name_off: u32,
-    name_len: u32,
-    compute: i64,
-) -> Result<()> {
-    let name =
-        str::from_utf8(context.memory.try_slice(name_off, name_len)?).or_illegal_argument()?;
-    context.kernel.charge_gas(name, compute)
+pub fn on_submit_verify_seal(context: Context<'_, impl Kernel>) -> Result<()> {
+    context.kernel.on_submit_verify_seal()
 }

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -123,7 +123,7 @@ pub fn bind_syscalls(
     linker.bind("rand", "get_chain_randomness", rand::get_chain_randomness)?;
     linker.bind("rand", "get_beacon_randomness", rand::get_beacon_randomness)?;
 
-    linker.bind("gas", "charge", gas::charge_gas)?;
+    linker.bind("gas", "on_submit_verify_seal", gas::on_submit_verify_seal)?;
 
     // Ok, this singled-out syscall should probably be in another category.
     linker.bind("send", "send", send::send)?;

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -97,7 +97,6 @@ pub fn bind_syscalls(
 
     linker.bind("crypto", "verify_signature", crypto::verify_signature)?;
     linker.bind("crypto", "hash_blake2b", crypto::hash_blake2b)?;
-    linker.bind("crypto", "verify_seal", crypto::verify_seal)?;
     linker.bind("crypto", "verify_post", crypto::verify_post)?;
     linker.bind(
         "crypto",

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -71,15 +71,6 @@ pub fn compute_unsealed_sector_cid(
     }
 }
 
-/// Verifies a sector seal proof.
-#[allow(unused)]
-pub fn verify_seal(info: &SealVerifyInfo) -> SyscallResult<bool> {
-    let info = info
-        .marshal_cbor()
-        .expect("failed to marshal seal verification input");
-    unsafe { sys::crypto::verify_seal(info.as_ptr(), info.len() as u32).map(status_code_to_bool) }
-}
-
 /// Verifies a window proof of spacetime.
 #[allow(unused)]
 pub fn verify_post(info: &WindowPoStVerifyInfo) -> SyscallResult<bool> {

--- a/sdk/src/gas.rs
+++ b/sdk/src/gas.rs
@@ -1,8 +1,6 @@
 use crate::sys;
 
 /// Charge gas for the operation identified by name.
-pub fn charge(name: &str, compute: u64) {
-    unsafe { sys::gas::charge(name.as_ptr(), name.len() as u32, compute) }
-        // can only happen if name isn't utf8, memory corruption, etc.
-        .expect("failed to charge gas")
+pub fn on_submit_verify_seal() {
+    unsafe { sys::gas::on_submit_verify_seal() }.expect("failed to charge gas for bulk verify")
 }

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -32,9 +32,6 @@ super::fvm_syscalls! {
         cid_len: u32,
     ) -> Result<u32>;
 
-    /// Verifies a sector seal proof.
-    pub fn verify_seal(info_off: *const u8, info_len: u32) -> Result<i32>;
-
     /// Verifies a window proof of spacetime.
     pub fn verify_post(info_off: *const u8, info_len: u32) -> Result<i32>;
 

--- a/sdk/src/sys/gas.rs
+++ b/sdk/src/sys/gas.rs
@@ -1,13 +1,6 @@
 super::fvm_syscalls! {
     module = "gas";
 
-    // TODO: name for debugging & tracing?
-    // We could also _not_ feed that through to the outside?
-
-    /// Charge gas.
-    pub fn charge(name_off: *const u8, name_len: u32, amount: u64) -> Result<()>;
-
-    // Returns the amount of gas remaining.
-    // TODO not implemented.
-    // pub fn remaining() -> Result<u64>;
+    /// Charge gas for submitting a seal proof for bulk verify.
+    pub fn on_submit_verify_seal() -> Result<()>;
 }

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -495,6 +495,10 @@ where
     fn charge_gas(&mut self, name: &str, compute: i64) -> Result<()> {
         self.0.charge_gas(name, compute)
     }
+
+    fn on_submit_verify_seal(&mut self) -> Result<()> {
+        self.0.on_submit_verify_seal()
+    }
 }
 
 impl<M, C, K> MessageOps for TestKernel<K>

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -437,13 +437,6 @@ where
     }
 
     // NOT forwarded
-    fn verify_seal(&mut self, vi: &SealVerifyInfo) -> Result<bool> {
-        let charge = self.1.price_list.on_verify_seal(vi);
-        self.0.charge_gas(charge.name, charge.total())?;
-        Ok(true)
-    }
-
-    // NOT forwarded
     fn verify_post(&mut self, vi: &WindowPoStVerifyInfo) -> Result<bool> {
         let charge = self.1.price_list.on_verify_post(vi);
         self.0.charge_gas(charge.name, charge.total())?;


### PR DESCRIPTION
- Remove `verify_seal`, pretty sure this has been unused since pre-mainnet
- Replace the `charge_gas` syscall with a specialized `on_submit_verify_seal` call (better name welcome). This was the only use of the syscall in actors code, and I really don't like the idea of actors code asking the VM to charge arbitrary amounts of gas on a whim.