### PR TITLE
Make signature properties public

### DIFF
--- a/shared/src/crypto/signature.rs
+++ b/shared/src/crypto/signature.rs
@@ -35,8 +35,8 @@ pub enum SignatureType {
 /// A cryptographic signature, represented in bytes, of any key protocol.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Signature {
-    sig_type: SignatureType,
-    bytes: Vec<u8>,
+    pub sig_type: SignatureType,
+    pub bytes: Vec<u8>,
 }
 
 impl Cbor for Signature {}


### PR DESCRIPTION
In order to use `#[serde(remote = "Signature")]` it is required to have its fields defined as public.

I need to be able to define how to serialize/deserialize message in json and for that I use serde remote trick. The Signature is part of a SignedMessage struct that I want to serialize/deserialize.