### PR TITLE
Use repr(packed, C) for syscall types

### DIFF
--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 Changes to the reference FVM implementation.
 
-## [Unreleased]
+## 0.7.0 [UNRELEASED]
+
+This release contains exactly one (breaking) change.
+
+BREAKING: Updates the FVM to the latest syscall struct alignment
+(https://github.com/filecoin-project/fvm-specs/issues/63).
 
 ## 0.6.0 [2022-04-13]
 

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -20,7 +20,7 @@ ahash = "0.7"
 num-derive = "0.3.3"
 cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.1", default-features = false }
-fvm_shared = { version = "0.5.1", path = "../shared", features = ["crypto"] }
+fvm_shared = { version = "0.6.0", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.5.0", path = "../ipld/hamt"}
 fvm_ipld_amt = { version = "0.4.0", path = "../ipld/amt"}
 fvm_ipld_blockstore = { version = "0.1.0", path = "../ipld/blockstore" }

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -1,5 +1,7 @@
 use fvm_shared::error::ExitCode;
+use fvm_shared::sys::SyscallSafe;
 use fvm_shared::version::NetworkVersion;
+use num_traits::FromPrimitive;
 
 use super::error::Abort;
 use super::Context;
@@ -10,6 +12,8 @@ use crate::Kernel;
 /// returning an error.
 #[derive(Copy, Clone)]
 pub enum Never {}
+
+unsafe impl SyscallSafe for Never {}
 
 // NOTE: this won't clobber the last syscall error because it directly returns a "trap".
 pub fn abort(

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -1,7 +1,6 @@
 use fvm_shared::error::ExitCode;
 use fvm_shared::sys::SyscallSafe;
 use fvm_shared::version::NetworkVersion;
-use num_traits::FromPrimitive;
 
 use super::error::Abort;
 use super::Context;

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## 0.6.0 [2022-04-14]
+
+BREAKING: Upgrades to fvm_shared 0.6.0, and the new syscall struct alignment.
+https://github.com/filecoin-project/fvm-specs/issues/63
+
 ## 0.5.0 [2022-04-11]
 
 Upgrades the SDK to fvm_shared 0.5.0. This release includes a significant breaking change to exit codes.

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "0.5.0"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { version = "0.8.2", default-features = false }
-fvm_shared = { version = "0.5.1", path = "../shared" }
+fvm_shared = { version = "0.6.0", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = { version = "1.4.0", optional = true }

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## 0.6.0 [2022-04-14]
+
+BREAKING: Switch syscall struct alignment: https://github.com/filecoin-project/fvm-specs/issues/63
+
+Actors built against this new version of fvm_shared will be incompatible with prior FVM versions,
+and vice-versa.
 
 ## 0.5.1  [2022-04-11]
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/shared/src/sys/mod.rs
+++ b/shared/src/sys/mod.rs
@@ -11,8 +11,8 @@ pub type Codec = u64;
 ///
 /// Internally, this type is a tuple of `u64`s storing the "low" and "high" bits of a little-endian
 /// u128.
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[repr(packed, C)]
 pub struct TokenAmount {
     pub lo: u64,
     pub hi: u64,

--- a/shared/src/sys/out.rs
+++ b/shared/src/sys/out.rs
@@ -11,8 +11,8 @@ pub mod actor {
     #[derive(Debug, Copy, Clone)]
     #[repr(packed, C)]
     pub struct ResolveAddress {
-        pub resolved: i32,
         pub value: u64,
+        pub resolved: i32,
     }
 }
 

--- a/shared/src/sys/out.rs
+++ b/shared/src/sys/out.rs
@@ -7,6 +7,13 @@
 //!
 //! Read more at https://github.com/rust-lang/rust/issues/73755.
 
+// NOTE: When possible, pack fields such that loads will be power-of-two aligned. Un-aligned loads
+// _can_ be done (LLVM will generate the appropriate code) but are slower.
+//
+// Read up on https://doc.rust-lang.org/reference/type-layout.html for more information.
+//
+// Also, please also read the docs on super::SyscallSafe before modifying any of these types.
+
 pub mod actor {
     #[derive(Debug, Copy, Clone)]
     #[repr(packed, C)]

--- a/shared/src/sys/out.rs
+++ b/shared/src/sys/out.rs
@@ -8,8 +8,8 @@
 //! Read more at https://github.com/rust-lang/rust/issues/73755.
 
 pub mod actor {
-    #[repr(C)]
     #[derive(Debug, Copy, Clone)]
+    #[repr(packed, C)]
     pub struct ResolveAddress {
         pub resolved: i32,
         pub value: u64,
@@ -17,17 +17,16 @@ pub mod actor {
 }
 
 pub mod ipld {
-    #[repr(C)]
     #[derive(Debug, Copy, Clone)]
+    #[repr(packed, C)]
     pub struct IpldOpen {
-        /// TODO could be more efficient to align id, size, codec, depending on padding.
-        pub id: u32,
         pub codec: u64,
+        pub id: u32,
         pub size: u32,
     }
 
-    #[repr(C)]
     #[derive(Debug, Copy, Clone)]
+    #[repr(packed, C)]
     pub struct IpldStat {
         pub codec: u64,
         pub size: u32,
@@ -37,8 +36,8 @@ pub mod ipld {
 pub mod send {
     use crate::sys::BlockId;
 
-    #[repr(C)]
     #[derive(Debug, Copy, Clone)]
+    #[repr(packed, C)]
     pub struct Send {
         pub exit_code: u32,
         pub return_id: BlockId,
@@ -48,11 +47,11 @@ pub mod send {
 pub mod crypto {
     use crate::{ActorID, ChainEpoch};
 
-    #[repr(C)]
     #[derive(Debug, Copy, Clone)]
+    #[repr(packed, C)]
     pub struct VerifyConsensusFault {
-        pub fault: u32,
         pub epoch: ChainEpoch,
         pub target: ActorID,
+        pub fault: u32,
     }
 }

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
 fvm = { version = "0.6.0", path = "../../fvm", default-features = false }
-fvm_shared = { version = "0.5.1", path = "../../shared" }
+fvm_shared = { version = "0.6.0", path = "../../shared" }
 fvm_ipld_hamt = { version = "0.5.0", path = "../../ipld/hamt"}
 fvm_ipld_amt = { version = "0.4.0", path = "../../ipld/amt"}
 fvm_ipld_car = { version = "0.4.0", path = "../../ipld/car" }


### PR DESCRIPTION
I was hoping to _not_ do this as it might have a perf implication, but:

- Padding is undefined so we could end up leaking rust memory (and causing non-determinism at runtime).
- Requiring that everything be "packed" simplifies the spec. We don't need to explain alignment, just:
    - little endian byte order
    - packed
- In practice, there should be no performance issues (with existing syscalls). Specifically, we can re-order fields to avoid unaligned loads. This PR takes care of that.

Part of https://github.com/filecoin-project/fvm-specs/issues/63.