### PR TITLE
fix(shared): limit BigInt encoding and decoding sizes

### DIFF
--- a/shared/src/bigint/bigint_ser.rs
+++ b/shared/src/bigint/bigint_ser.rs
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn test_bigiint_max() {
-        let max_limbs = MAX_BIGINT_SIZE / 4; // u32 -> u8
+        let max_limbs = MAX_BIGINT_SIZE / 4; // 32bit limbs to bytes
         let good = BigInt::new(Sign::Plus, vec![u32::MAX; max_limbs - 1]);
         let good_neg = BigInt::new(Sign::Minus, vec![u32::MAX; max_limbs - 1]);
 
@@ -87,6 +87,7 @@ mod tests {
         let good_neg_back: BigIntDe = from_slice(&good_neg_bytes).unwrap();
         assert_eq!(good_neg_back.0, good_neg);
 
+        // max limbs will fail as the sign is prepended
         let bad1 = BigInt::new(Sign::Plus, vec![u32::MAX; max_limbs]);
         let bad1_neg = BigInt::new(Sign::Minus, vec![u32::MAX; max_limbs]);
         let bad2 = BigInt::new(Sign::Plus, vec![u32::MAX; max_limbs + 1]);

--- a/shared/src/bigint/bigint_ser.rs
+++ b/shared/src/bigint/bigint_ser.rs
@@ -6,13 +6,15 @@ use std::borrow::Cow;
 use num_bigint::{BigInt, Sign};
 use serde::{Deserialize, Serialize};
 
+use super::MAX_BIGINT_SIZE;
+
 /// Wrapper for serializing big ints to match filecoin spec. Serializes as bytes.
 #[derive(Serialize)]
 #[serde(transparent)]
 pub struct BigIntSer<'a>(#[serde(with = "self")] pub &'a BigInt);
 
 /// Wrapper for deserializing as BigInt from bytes.
-#[derive(Deserialize, Serialize, Clone, Default, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Default, PartialEq, Debug)]
 #[serde(transparent)]
 pub struct BigIntDe(#[serde(with = "self")] pub BigInt);
 
@@ -28,6 +30,10 @@ where
         Sign::Minus => bz.insert(0, 1),
         Sign::Plus => bz.insert(0, 0),
         Sign::NoSign => bz = Vec::new(),
+    }
+
+    if bz.len() > MAX_BIGINT_SIZE {
+        return Err(<S::Error as serde::ser::Error>::custom("BigInt too large"));
     }
 
     // Serialize as bytes
@@ -53,5 +59,58 @@ where
             ));
         }
     };
+
+    if bz.len() > MAX_BIGINT_SIZE {
+        return Err(<D::Error as serde::de::Error>::custom("BigInt too large"));
+    }
+
     Ok(BigInt::from_bytes_be(sign, &bz[1..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use fvm_ipld_encoding::{from_slice, to_vec};
+
+    use super::*;
+
+    #[test]
+    fn test_bigiint_max() {
+        let max_limbs = MAX_BIGINT_SIZE / 4; // u32 -> u8
+        let good = BigInt::new(Sign::Plus, vec![u32::MAX; max_limbs - 1]);
+        let good_neg = BigInt::new(Sign::Minus, vec![u32::MAX; max_limbs - 1]);
+
+        let good_bytes = to_vec(&BigIntSer(&good)).expect("should be good");
+        let good_back: BigIntDe = from_slice(&good_bytes).unwrap();
+        assert_eq!(good_back.0, good);
+
+        let good_neg_bytes = to_vec(&BigIntSer(&good_neg)).expect("should be good");
+        let good_neg_back: BigIntDe = from_slice(&good_neg_bytes).unwrap();
+        assert_eq!(good_neg_back.0, good_neg);
+
+        let bad1 = BigInt::new(Sign::Plus, vec![u32::MAX; max_limbs]);
+        let bad1_neg = BigInt::new(Sign::Minus, vec![u32::MAX; max_limbs]);
+        let bad2 = BigInt::new(Sign::Plus, vec![u32::MAX; max_limbs + 1]);
+        let bad2_neg = BigInt::new(Sign::Minus, vec![u32::MAX; max_limbs + 1]);
+
+        assert!(to_vec(&BigIntSer(&bad1)).is_err());
+        assert!(to_vec(&BigIntSer(&bad1_neg)).is_err());
+        assert!(to_vec(&BigIntSer(&bad2)).is_err());
+        assert!(to_vec(&BigIntSer(&bad2_neg)).is_err());
+
+        let bad_bytes = {
+            let (sign, mut source) = bad1.to_bytes_be();
+            match sign {
+                Sign::Minus => source.insert(0, 0),
+                _ => source.insert(0, 1),
+            }
+            to_vec(&serde_bytes::Bytes::new(&source)).unwrap()
+        };
+
+        let res: Result<BigIntDe, _> = from_slice(&bad_bytes);
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "Serialization error for Cbor protocol: BigInt too large"
+        );
+    }
 }

--- a/shared/src/bigint/biguint_ser.rs
+++ b/shared/src/bigint/biguint_ser.rs
@@ -69,13 +69,14 @@ mod tests {
 
     #[test]
     fn test_biguint_max() {
-        let max_limbs = MAX_BIGINT_SIZE / 4; // u32 -> u8
+        let max_limbs = MAX_BIGINT_SIZE / 4; // 32bit limbs to bytes
         let good = BigUint::new(vec![u32::MAX; max_limbs - 1]);
 
         let good_bytes = to_vec(&BigUintSer(&good)).expect("should be good");
         let good_back: BigUintDe = from_slice(&good_bytes).unwrap();
         assert_eq!(good_back.0, good);
 
+        // max limbs will fail as the sign is prepended
         let bad1 = BigUint::new(vec![u32::MAX; max_limbs]);
         let bad2 = BigUint::new(vec![u32::MAX; max_limbs + 1]);
 

--- a/shared/src/bigint/mod.rs
+++ b/shared/src/bigint/mod.rs
@@ -7,3 +7,6 @@ pub mod biguint_ser;
 pub use num_bigint::*;
 pub use num_integer::{self, Integer};
 pub use num_traits::Zero;
+
+/// The maximum number of bytes we accept to serialize/deserialize for a single BigInt.
+pub const MAX_BIGINT_SIZE: usize = 128;


### PR DESCRIPTION
The limit is taken from https://github.com/filecoin-project/go-state-types/blob/6027e22b77fd07693bf782401d10215057af9aad/big/int.go#L13