### PR TITLE
fix: mark NetworkVersion as non-exhaustive

### DIFF
--- a/shared/src/version/mod.rs
+++ b/shared/src/version/mod.rs
@@ -8,6 +8,7 @@ use fvm_ipld_encoding::repr::Serialize_repr;
 /// Specifies the network version
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd, Serialize_repr)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum NetworkVersion {
     /// genesis (specs-actors v0.9.3)
     V0 = 0,


### PR DESCRIPTION
That way changing this isn't a breaking change.