### PR TITLE
chore: release 0.5.1

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "0.5.0", path = "../../fvm", default-features = false }
+fvm = { version = "0.5.1", path = "../../fvm", default-features = false }
 fvm_shared = { version = "0.4.1", path = "../../shared" }
 fvm_ipld_hamt = { version = "0.4.0", path = "../../ipld/hamt"}
 fvm_ipld_amt = { version = "0.4.0", path = "../../ipld/amt"}


### PR DESCRIPTION
This release _just_ bumps wasmtime to a version that builds on aarch64.