### PR TITLE
fix(shared): impl IntoIterator for Address

### DIFF
--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -70,6 +70,15 @@ pub struct Address {
     payload: Payload,
 }
 
+impl<'a> IntoIterator for &'a Address {
+    type Item = &'a Address;
+    type IntoIter = std::array::IntoIter<&'a Address, 1>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        [self].into_iter()
+    }
+}
+
 impl Cbor for Address {}
 
 impl Address {


### PR DESCRIPTION
This allows writing `rt.validate_immediate_caller_is(&*ACTOR_ADDR)`, without having to
manually wrap them.