### PR TITLE
Reject system exit codes from abort

### DIFF
--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -1,4 +1,5 @@
 use fvm_shared::error::ExitCode;
+use fvm_shared::version::NetworkVersion;
 
 use super::error::Abort;
 use super::Context;
@@ -18,13 +19,12 @@ pub fn abort(
     message_len: u32,
 ) -> Result<Never, Abort> {
     let code = ExitCode::new(code);
-    // Uncomment to fix https://github.com/filecoin-project/ref-fvm/issues/253
-    // if code.is_system_error() {
-    //     return Err(Abort::Exit(
-    //         SystemExitCode::ILLEGAL_EXIT_CODE,
-    //         format!("actor aborted with code {}", code),
-    //     ));
-    // }
+    if context.kernel.network_version() >= NetworkVersion::V16 && code.is_system_error() {
+        return Err(Abort::Exit(
+            ExitCode::SYS_ILLEGAL_EXIT_CODE,
+            format!("actor aborted with code {}", code),
+        ));
+    }
 
     let message = if message_len == 0 {
         "actor aborted".to_owned()


### PR DESCRIPTION
Fixes #253.

I'm a little confused why I need a network version check here (to have conformance tests pass). I thought the master branch was for nv16 already. Should I instead update the conformance tests? How do I do that?