### PR TITLE
add nv16 to supported network versions

### DIFF
--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -63,7 +63,7 @@ where
         externs: E,
     ) -> anyhow::Result<Self> {
         const SUPPORTED_VERSIONS: RangeInclusive<NetworkVersion> =
-            NetworkVersion::V14..=NetworkVersion::V15;
+            NetworkVersion::V14..=NetworkVersion::V16;
 
         debug!(
             "initializing a new machine, epoch={}, base_fee={}, nv={:?}, root={}",


### PR DESCRIPTION
needed to instantiate the machine for nv16 in lotus.

We'll also need to bubble up a new release to filecoin-ffi, but for now I should be able to make do with patch.