### PR TITLE
ipld/encoding: switch to cbor4ii

### DIFF
--- a/fvm/src/syscalls/context.rs
+++ b/fvm/src/syscalls/context.rs
@@ -82,9 +82,11 @@ impl Memory {
 
 #[cfg(test)]
 mod test {
-    use cid::multihash::MultihashDigest;
-
     use super::*;
+
+    const RAW: u64 = 0x55;
+    const SHA2_256: u64 = 0x12;
+    const HASH: &[u8] = b"\x2C\x26\xB4\x6B\x68\xFF\xC6\x8F\xF9\x9B\x45\x3C\x1D\x30\x41\x34\x13\x42\x2D\x70\x64\x83\xBF\xA0\xF9\x8A\x5E\x88\x62\x66\xE7\xAE";
 
     // TODO: move this somewhere more useful.
     macro_rules! expect_syscall_err {
@@ -117,7 +119,8 @@ mod test {
 
     #[test]
     fn test_read_cid() {
-        let k = Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(b"foo"));
+        let hash = cid::multihash::Multihash::wrap(SHA2_256, HASH).unwrap();
+        let k = Cid::new_v1(RAW, hash);
         let mut k_bytes = k.to_bytes();
         let mem = Memory::new(&mut k_bytes);
         let k2 = mem.read_cid(0).expect("failed to read cid");
@@ -126,7 +129,8 @@ mod test {
 
     #[test]
     fn test_read_cid_truncated() {
-        let k = Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(b"foo"));
+        let hash = cid::multihash::Multihash::wrap(SHA2_256, HASH).unwrap();
+        let k = Cid::new_v1(RAW, hash);
         let mut k_bytes = k.to_bytes();
         let mem = Memory::new(&mut k_bytes[..20]);
         expect_syscall_err!(IllegalArgument, mem.read_cid(0));

--- a/ipld/blockstore/Cargo.toml
+++ b/ipld/blockstore/Cargo.toml
@@ -10,10 +10,9 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 [dependencies]
 cid = { version = "0.8.2", default-features = false, features = ["serde-codec", "std"] }
 anyhow = "1.0.51"
-
-
-[dev-dependencies]
-multihash = { version = "0.16.1", default-features = false, features = ["blake2b", "multihash-impl"] }
+# multihash is also re-exported by `cid`. Having `multihash` here as a
+# depdendency is needed to enable the features of the re-export.
+multihash = { version = "0.16.1", default-features = false, features = ["multihash-impl"] }
 
 [features]
 default = []

--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -10,14 +10,16 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
-# TODO remove fork in future (allowing non utf8 strings to be cbor deserialized)
-serde_ipld_dagcbor = "0.1.2"
+serde_ipld_dagcbor = "0.2.0"
 serde_tuple = "0.5"
 serde_repr = "0.1"
 cid = { version = "0.8.2", default-features = false, features = ["serde-codec", "std"] }
 thiserror = "1.0"
 anyhow = "1.0.56"
 fvm_ipld_blockstore = { version = "0.1", path = "../blockstore" }
+# multihash is also re-exported by `cid`. Having `multihash` here as a
+# depdendency is needed to enable the features of the re-export.
+multihash = { version = "0.16.1", default-features = false, features = ["blake2b", "multihash-impl"] }
 
 [features]
 default = []

--- a/ipld/encoding/src/errors.rs
+++ b/ipld/encoding/src/errors.rs
@@ -4,7 +4,7 @@
 use std::{fmt, io};
 
 use cid::Error as CidError;
-use serde_ipld_dagcbor::error::Error as CborError;
+use serde_ipld_dagcbor::{DecodeError, EncodeError};
 use thiserror::Error;
 
 /// Error type for encoding and decoding data through any Forest supported protocol.
@@ -18,8 +18,17 @@ pub struct Error {
     pub protocol: CodecProtocol,
 }
 
-impl From<CborError> for Error {
-    fn from(err: CborError) -> Error {
+impl<T: fmt::Debug> From<DecodeError<T>> for Error {
+    fn from(err: DecodeError<T>) -> Self {
+        Self {
+            description: err.to_string(),
+            protocol: CodecProtocol::Cbor,
+        }
+    }
+}
+
+impl<T: fmt::Debug> From<EncodeError<T>> for Error {
+    fn from(err: EncodeError<T>) -> Self {
         Self {
             description: err.to_string(),
             protocol: CodecProtocol::Cbor,

--- a/ipld/encoding/src/lib.rs
+++ b/ipld/encoding/src/lib.rs
@@ -34,16 +34,14 @@ pub fn to_vec<T>(value: &T) -> Result<Vec<u8>, Error>
 where
     T: ser::Serialize + ?Sized,
 {
-    let mut vec = Vec::new();
-    value.serialize(&mut serde_ipld_dagcbor::Serializer::new(&mut vec))?;
-    Ok(vec)
+    serde_ipld_dagcbor::to_vec(value).map_err(Into::into)
 }
 
 /// Decode a value from CBOR from the given reader.
 pub fn from_reader<T, R>(reader: R) -> Result<T, Error>
 where
     T: de::DeserializeOwned,
-    R: io::Read,
+    R: io::BufRead,
 {
     serde_ipld_dagcbor::from_reader(reader).map_err(Into::into)
 }
@@ -57,10 +55,10 @@ where
 }
 
 /// Encode a value as CBOR to the given writer.
-pub fn to_writer<W, T>(writer: W, value: &T) -> Result<(), Error>
+pub fn to_writer<W, T>(mut writer: W, value: &T) -> Result<(), Error>
 where
     W: io::Write,
     T: ser::Serialize,
 {
-    serde_ipld_dagcbor::to_writer(writer, value).map_err(Into::into)
+    serde_ipld_dagcbor::to_writer(&mut writer, value).map_err(Into::into)
 }

--- a/shared/src/bigint/bigint_ser.rs
+++ b/shared/src/bigint/bigint_ser.rs
@@ -109,9 +109,6 @@ mod tests {
 
         let res: Result<BigIntDe, _> = from_slice(&bad_bytes);
         assert!(res.is_err());
-        assert_eq!(
-            res.unwrap_err().to_string(),
-            "Serialization error for Cbor protocol: BigInt too large"
-        );
+        assert!(res.unwrap_err().to_string().contains("BigInt too large"));
     }
 }

--- a/shared/src/bigint/biguint_ser.rs
+++ b/shared/src/bigint/biguint_ser.rs
@@ -91,9 +91,6 @@ mod tests {
 
         let res: Result<BigUintDe, _> = from_slice(&bad_bytes);
         assert!(res.is_err());
-        assert_eq!(
-            res.unwrap_err().to_string(),
-            "Serialization error for Cbor protocol: BigInt too large"
-        );
+        assert!(res.unwrap_err().to_string().contains("BigInt too large"));
     }
 }

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -48,8 +48,7 @@ walkdir = "2.3"
 regex = { version = "1.0" }
 ittapi-rs = { version = "0.1.6", optional = true }
 actors-v6 = { version = "~6.2", package = "fil_builtin_actors_bundle" }
-#actors-v7 = { version = "~7.2", package = "fil_builtin_actors_bundle" }
-actors-v7 = { git = "https://github.com/filecoin-project/builtin-actors", branch = "cbor4ii", package = "fil_builtin_actors_bundle" }
+actors-v7 = { version = "~7.2", package = "fil_builtin_actors_bundle" }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [features]

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -48,7 +48,8 @@ walkdir = "2.3"
 regex = { version = "1.0" }
 ittapi-rs = { version = "0.1.6", optional = true }
 actors-v6 = { version = "~6.2", package = "fil_builtin_actors_bundle" }
-actors-v7 = { version = "~7.2", package = "fil_builtin_actors_bundle" }
+#actors-v7 = { version = "~7.2", package = "fil_builtin_actors_bundle" }
+actors-v7 = { git = "https://github.com/filecoin-project/builtin-actors", branch = "cbor4ii", package = "fil_builtin_actors_bundle" }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [features]


### PR DESCRIPTION
TODOs:

 - [x] Do not fork `cbor4ii`, but use it's core features and just have our own Serde implementation
 - [x] Integrate that work into `serde_ipld_dagcbor` and release it as 0.2.
