### PR TITLE
Release shared 0.5.0

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -20,7 +20,7 @@ ahash = "0.7"
 num-derive = "0.3.3"
 cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.1", default-features = false }
-fvm_shared = { version = "0.4.1", path = "../shared", features = ["crypto"] }
+fvm_shared = { version = "0.5.0", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.4.0", path = "../ipld/hamt"}
 fvm_ipld_amt = { version = "0.4.0", path = "../ipld/amt"}
 fvm_ipld_blockstore = { version = "0.1.0", path = "../ipld/blockstore" }

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.5.0 - 2022-04-11
+
+Upgrades the SDK to fvm_shared 0.5.0. This release includes a significant breaking change to exit codes.

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "0.4.0"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { version = "0.8.2", default-features = false }
-fvm_shared = { version = "0.4.1", path = "../shared" }
+fvm_shared = { version = "0.5.0", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = "1.4.0"

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 0.5.0 - 2022-04-11
+
+- Enforce maximum big-int size to match lotus.
+- Make signature properties public.
+- Major error type refactor.
+
+The largest change here is a major error type refactor.
+
+1. It's now a u32 with a set of pre-defined values instead of an enum.
+2. The error codes have been reworked according to the FVM spec.
+
+Both of these changes were made to better support user-defined actors.

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
 fvm = { version = "0.5.1", path = "../../fvm", default-features = false }
-fvm_shared = { version = "0.4.1", path = "../../shared" }
+fvm_shared = { version = "0.5.0", path = "../../shared" }
 fvm_ipld_hamt = { version = "0.4.0", path = "../../ipld/hamt"}
 fvm_ipld_amt = { version = "0.4.0", path = "../../ipld/amt"}
 fvm_ipld_car = { version = "0.4.0", path = "../../ipld/car" }


### PR DESCRIPTION
Major breaking change: refactored error codes.

TODO: backport this chnage to prior actor releases?

Blocks https://github.com/filecoin-project/builtin-actors/pull/200