### PR TITLE
Refactor consume/take

### DIFF
--- a/fvm/src/blockstore/buffered.rs
+++ b/fvm/src/blockstore/buffered.rs
@@ -33,7 +33,7 @@ where
         }
     }
 
-    pub fn consume(self) -> BS {
+    pub fn into_inner(self) -> BS {
         self.base
     }
 }

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -18,7 +18,7 @@ use crate::{account_actor, syscall_error};
 
 /// The default [`CallManager`] implementation.
 #[repr(transparent)]
-pub struct DefaultCallManager<M>(Option<InnerDefaultCallManager<M>>);
+pub struct DefaultCallManager<M>(Option<Box<InnerDefaultCallManager<M>>>);
 
 #[doc(hidden)]
 #[derive(Deref, DerefMut)]
@@ -64,7 +64,7 @@ where
     type Machine = M;
 
     fn new(machine: M, gas_limit: i64, origin: Address, nonce: u64) -> Self {
-        DefaultCallManager(Some(InnerDefaultCallManager {
+        DefaultCallManager(Some(Box::new(InnerDefaultCallManager {
             machine,
             gas_tracker: GasTracker::new(gas_limit, 0),
             origin,
@@ -72,7 +72,7 @@ where
             num_actors_created: 0,
             call_stack_depth: 0,
             backtrace: Backtrace::default(),
-        }))
+        })))
     }
 
     fn send<K>(

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -287,7 +287,7 @@ where
                 match kernel.block_create(DAG_CBOR, params) {
                     Ok(id) => id,
                     // This could fail if we pass some global memory limit.
-                    Err(err) => return (Err(err), kernel.take()),
+                    Err(err) => return (Err(err), kernel.into_call_manager()),
                 }
             } else {
                 super::NO_DATA_BLOCK_ID
@@ -303,7 +303,7 @@ where
                 .or_fatal()
             {
                 Ok(ret) => ret,
-                Err(err) => return (Err(err), store.into_data().kernel.take()),
+                Err(err) => return (Err(err), store.into_data().kernel.into_call_manager()),
             };
 
             // From this point on, there are no more syscall errors, only aborts.
@@ -335,7 +335,7 @@ where
 
             let invocation_data = store.into_data();
             let last_error = invocation_data.last_error;
-            let mut cm = invocation_data.kernel.take();
+            let mut cm = invocation_data.kernel.into_call_manager();
 
             // Process the result, updating the backtrace if necessary.
             let ret = match result {

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -181,7 +181,7 @@ where
 
     /// Consume consumes the executor and returns the Machine. If the Machine had
     /// been poisoned during execution, the Option will be None.
-    pub fn consume(self) -> Option<<K::CallManager as CallManager>::Machine> {
+    pub fn into_machine(self) -> Option<<K::CallManager as CallManager>::Machine> {
         self.0
     }
 

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -76,7 +76,7 @@ where
 {
     type CallManager = C;
 
-    fn take(self) -> Self::CallManager
+    fn into_call_manager(self) -> Self::CallManager
     where
         Self: Sized,
     {

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -45,7 +45,7 @@ pub trait Kernel:
     type CallManager: CallManager;
 
     /// Consume the [`Kernel`] and return the underlying [`CallManager`].
-    fn take(self) -> Self::CallManager
+    fn into_call_manager(self) -> Self::CallManager
     where
         Self: Sized;
 

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -113,7 +113,7 @@ mod test {
         let mut bs = MemoryBlockstore::default();
         let mut st = StateTree::new(bs, StateTreeVersion::V4).unwrap();
         let root = st.flush().unwrap();
-        bs = st.consume();
+        bs = st.into_store();
 
         // An empty built-in actors manifest.
         let manifest_cid = {

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -64,8 +64,8 @@ impl<M: Machine> Machine for Box<M> {
     }
 
     #[inline(always)]
-    fn consume(self) -> Self::Blockstore {
-        (*self).consume()
+    fn into_store(self) -> Self::Blockstore {
+        (*self).into_store()
     }
 
     #[inline(always)]

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -287,7 +287,7 @@ where
         Ok(())
     }
 
-    fn consume(self) -> Self::Blockstore {
-        self.state_tree.consume()
+    fn into_store(self) -> Self::Blockstore {
+        self.state_tree.into_store()
     }
 }

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -85,7 +85,7 @@ pub trait Machine: 'static {
     }
 
     /// Consumes the machine and returns the owned blockstore.
-    fn consume(self) -> Self::Blockstore;
+    fn into_store(self) -> Self::Blockstore;
 }
 
 /// Execution context supplied to the machine.

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -496,8 +496,8 @@ where
     }
 
     /// Consumes this StateTree and returns the Blockstore it owns via the HAMT.
-    pub fn consume(self) -> S {
-        self.hamt.consume()
+    pub fn into_store(self) -> S {
+        self.hamt.into_store()
     }
 
     pub fn for_each<F>(&self, mut f: F) -> anyhow::Result<()>

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -315,7 +315,7 @@ where
     }
 
     /// Consumes this HAMT and returns the Blockstore it owns.
-    pub fn consume(self) -> BS {
+    pub fn into_store(self) -> BS {
         self.store
     }
 }

--- a/testing/conformance/src/driver.rs
+++ b/testing/conformance/src/driver.rs
@@ -230,7 +230,7 @@ pub fn run_variant(
         }
     };
 
-    let machine = match exec.consume() {
+    let machine = match exec.into_machine() {
         Some(machine) => machine,
         None => {
             return Ok(VariantResult::Failed {
@@ -240,7 +240,7 @@ pub fn run_variant(
         }
     };
     if check_correctness {
-        let bs = machine.consume().consume();
+        let bs = machine.into_store().into_inner();
 
         if let Err(err) = compare_state_roots(&bs, &final_root, v) {
             return Ok(VariantResult::Failed {

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -167,8 +167,8 @@ where
         self.machine.transfer(from, to, value)
     }
 
-    fn consume(self) -> Self::Blockstore {
-        self.machine.consume()
+    fn into_store(self) -> Self::Blockstore {
+        self.machine.into_store()
     }
 
     fn flush(&mut self) -> Result<Cid> {
@@ -294,11 +294,11 @@ where
 {
     type CallManager = C;
 
-    fn take(self) -> Self::CallManager
+    fn into_call_manager(self) -> Self::CallManager
     where
         Self: Sized,
     {
-        self.0.take().0
+        self.0.into_call_manager().0
     }
 
     fn new(


### PR DESCRIPTION
This refactor makes two significant changes:

1. Renames consume/take into `into_*` less ambiguous `into_*` functions.
2. Boxes the "inner" call manager to reduce the amount of copying as we move up and down the callstack.