### PR TITLE
doc: document syscalls & errors

### DIFF
--- a/sdk/src/sys/actor.rs
+++ b/sdk/src/sys/actor.rs
@@ -1,25 +1,40 @@
+//! Syscalls for creating and resolving actors.
+
+#[doc(inline)]
+pub use fvm_shared::sys::out::actor::*;
+
 super::fvm_syscalls! {
     module = "actor";
 
     /// Resolves the ID address of an actor.
-    pub fn resolve_address(addr_off: *const u8, addr_len: u32) -> Result<fvm_shared::sys::out::actor::ResolveAddress>;
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                                                    |
+    /// |-------------------|-----------------------------------------------------------|
+    /// | `NotFound`        | target actor doesn't exist                                |
+    /// | `IllegalArgument` | if the passed address buffer isn't valid, in memory, etc. |
+    pub fn resolve_address(
+        addr_off: *const u8,
+        addr_len: u32,
+    ) -> Result<ResolveAddress>;
 
     /// Gets the CodeCID of an actor by address.
+    ///
+    /// Returns the
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                                                    |
+    /// |-------------------|-----------------------------------------------------------|
+    /// | `NotFound`        | target actor doesn't exist                                |
+    /// | `IllegalArgument` | if the passed address buffer isn't valid, in memory, etc. |
     pub fn get_actor_code_cid(
         addr_off: *const u8,
         addr_len: u32,
         obuf_off: *mut u8,
         obuf_len: u32,
     ) -> Result<i32>;
-
-    /// Generates a new actor address for an actor deployed
-    /// by the calling actor.
-    pub fn new_actor_address(obuf_off: *mut u8, obuf_len: u32) -> Result<u32>;
-
-    /// Creates a new actor of the specified type in the state tree, under
-    /// the provided address.
-    /// TODO this syscall will change to calculate the address internally.
-    pub fn create_actor(actor_id: u64, typ_off: *const u8) -> Result<()>;
 
     /// Determines whether the specified CodeCID belongs to that of a builtin
     /// actor and which. Returns 0 if unrecognized. Can only fail due to
@@ -31,4 +46,18 @@ super::fvm_syscalls! {
      /// length of the written CID written to the output buffer. Can only
      /// return a failure due to internal errors.
     pub fn get_code_cid_for_type(typ: i32, obuf_off: *mut u8, obuf_len: u32) -> Result<i32>;
+
+    /// Generates a new actor address for an actor deployed
+    /// by the calling actor.
+    ///
+    /// **Privledged:** May only be called by the init actor.
+    #[doc(hidden)]
+    pub fn new_actor_address(obuf_off: *mut u8, obuf_len: u32) -> Result<u32>;
+
+    /// Creates a new actor of the specified type in the state tree, under
+    /// the provided address.
+    ///
+    /// **Privledged:** May only be called by the init actor.
+    #[doc(hidden)]
+    pub fn create_actor(actor_id: u64, typ_off: *const u8) -> Result<()>;
 }

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -1,7 +1,20 @@
+//! Syscalls for cryptographic operations.
+
+#[doc(inline)]
+pub use fvm_shared::sys::out::crypto::*;
+
 super::fvm_syscalls! {
     module = "crypto";
 
     /// Verifies that a signature is valid for an address and plaintext.
+    ///
+    /// Returns 0 on success, or -1 if the signature fails to validate.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                                               |
+    /// |-------------------|------------------------------------------------------|
+    /// | `IllegalArgument` | signature, address, or plaintext buffers are invalid |
     pub fn verify_signature(
         sig_off: *const u8,
         sig_len: u32,
@@ -14,6 +27,12 @@ super::fvm_syscalls! {
     /// Hashes input data using blake2b with 256 bit output.
     ///
     /// The output buffer must be sized to a minimum of 32 bytes.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                                          |
+    /// |-------------------|-------------------------------------------------|
+    /// | `IllegalArgument` | the input buffer does not point to valid memory |
     pub fn hash_blake2b(
         data_off: *const u8,
         data_len: u32,
@@ -24,6 +43,12 @@ super::fvm_syscalls! {
     ///
     /// Writes the CID in the provided output buffer, and returns the length of
     /// the written CID.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                   |
+    /// |-------------------|--------------------------|
+    /// | `IllegalArgument` | an argument is malformed |
     pub fn compute_unsealed_sector_cid(
         proof_type: i64,
         pieces_off: *const u8,
@@ -33,9 +58,25 @@ super::fvm_syscalls! {
     ) -> Result<u32>;
 
     /// Verifies a sector seal proof.
+    ///
+    /// Returns 0 to indicate that the proof was valid, -1 otherwise.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                   |
+    /// |-------------------|--------------------------|
+    /// | `IllegalArgument` | an argument is malformed |
     pub fn verify_seal(info_off: *const u8, info_len: u32) -> Result<i32>;
 
     /// Verifies a window proof of spacetime.
+    ///
+    /// Returns 0 to indicate that the proof was valid, -1 otherwise.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                   |
+    /// |-------------------|--------------------------|
+    /// | `IllegalArgument` | an argument is malformed |
     pub fn verify_post(info_off: *const u8, info_len: u32) -> Result<i32>;
 
     /// Verifies that two block headers provide proof of a consensus fault.
@@ -43,6 +84,13 @@ super::fvm_syscalls! {
     /// Returns a 0 status if a consensus fault was recognized, along with the
     /// BlockId containing the fault details. Otherwise, a -1 status is returned,
     /// and the second result parameter must be ignored.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                                |
+    /// |-------------------|---------------------------------------|
+    /// | `LimitExceeded`   | exceeded lookback limit finding block |
+    /// | `IllegalArgument` | an argument is malformed              |
     pub fn verify_consensus_fault(
         h1_off: *const u8,
         h1_len: u32,
@@ -50,14 +98,38 @@ super::fvm_syscalls! {
         h2_len: u32,
         extra_off: *const u8,
         extra_len: u32,
-    ) -> Result<fvm_shared::sys::out::crypto::VerifyConsensusFault>;
+    ) -> Result<VerifyConsensusFault>;
 
     /// Verifies an aggregated batch of sector seal proofs.
+    ///
+    /// Returns 0 to indicate that the proof was valid, -1 otherwise.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                         |
+    /// |-------------------|--------------------------------|
+    /// | `LimitExceeded`   | exceeds seal aggregation limit |
+    /// | `IllegalArgument` | an argument is malformed       |
     pub fn verify_aggregate_seals(agg_off: *const u8, agg_len: u32) -> Result<i32>;
 
     /// Verifies a replica update proof.
+    ///
+    /// Returns 0 to indicate that the proof was valid, -1 otherwise.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                        |
+    /// |-------------------|-------------------------------|
+    /// | `LimitExceeded`   | exceeds replica update limit  |
+    /// | `IllegalArgument` | an argument is malformed      |
     pub fn verify_replica_update(rep_off: *const u8, rep_len: u32) -> Result<i32>;
 
     /// Verifies an aggregated batch of sector seal proofs.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                   |
+    /// |-------------------|--------------------------|
+    /// | `IllegalArgument` | an argument is malformed |
     pub fn batch_verify_seals(batch_off: *const u8, batch_len: u32, result_off: *const u8) -> Result<()>;
 }

--- a/sdk/src/sys/debug.rs
+++ b/sdk/src/sys/debug.rs
@@ -1,3 +1,5 @@
+//! Syscalls for debugging.
+
 super::fvm_syscalls! {
     module = "debug";
 

--- a/sdk/src/sys/gas.rs
+++ b/sdk/src/sys/gas.rs
@@ -1,3 +1,5 @@
+//! Syscalls for working with gas.
+
 super::fvm_syscalls! {
     module = "gas";
 
@@ -5,6 +7,12 @@ super::fvm_syscalls! {
     // We could also _not_ feed that through to the outside?
 
     /// Charge gas.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason               |
+    /// |-------------------|----------------------|
+    /// | `IllegalArgument` | invalid name buffer. |
     pub fn charge(name_off: *const u8, name_len: u32, amount: u64) -> Result<()>;
 
     // Returns the amount of gas remaining.

--- a/sdk/src/sys/ipld.rs
+++ b/sdk/src/sys/ipld.rs
@@ -1,26 +1,10 @@
-// Q: Charge the first time? Or every time? We have several idempotent operations here.
-// A: TODO
+//! Syscalls for manipulating IPLD state.
 
-// Q: How to allocate?
-// A: Let the user do it, and reference blocks with "handles".
-
-// Q: Ids or CIDs in set/get root?
-// A: CIDs.
-//   - Forces the user to explicitly call "load" if they actually want the data.
-//   - Gives the user access to the CID without forcing them to recompute it.
-//   - Makes the user explicitly compute the CID.
-
-// Q: We have open, do we have close?
-// A: We'd need reference counting at runtime. Not terrible, but somewhat complicated. Do we need
-//    it? We probably want it in the future, but maybe not yet.
-//    Idea: Use WASM "reftypes". Maybe someday.
-
-// Q: Do we really need `stat`?
-// A: No, we don't. We can punt on that if we want to.
-
-// TODO: Implement this!
 /// The ID of the "unit" block (or void for C programmers).
 pub const UNIT: u32 = 0;
+
+#[doc(inline)]
+pub use fvm_shared::sys::out::ipld::*;
 
 super::fvm_syscalls! {
     module = "ipld";
@@ -31,26 +15,65 @@ super::fvm_syscalls! {
     /// - The reachable set is initialized to the root.
     /// - The reachable set is extended to include the direct children of loaded blocks until the
     ///   end of the invocation.
-    pub fn open(cid: *const u8) -> Result<fvm_shared::sys::out::ipld::IpldOpen>;
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                                      |
+    /// |-------------------|---------------------------------------------|
+    /// | `NotFound`        | the target block isn't in the reachable set |
+    /// | `IllegalArgument` | there's something wrong with the CID        |
+    pub fn open(cid: *const u8) -> Result<IpldOpen>;
 
     /// Creates a new block, returning the block's ID. The block's children must be in the reachable
     /// set. The new block isn't added to the reachable set until the CID is computed.
+    ///
+    /// | Error             | Reason                                                  |
+    /// |-------------------|---------------------------------------------------------|
+    /// | `LimitExceeded`   | the block is too big                                    |
+    /// | `NotFound`        | one of the blocks's children isn't in the reachable set |
+    /// | `IllegalCodec`    | the passed codec isn't supported                        |
+    /// | `Serialization`   | the passed block doesn't match the passed codec         |
+    /// | `IllegalArgument` | the block isn't in memory, etc.                         |
     pub fn create(codec: u64, data: *const u8, len: u32) -> Result<u32>;
 
-    /// Reads the identified block into obuf, starting at offset, reading _at most_ len bytes.
+    /// Reads the block identified by `id` into `obuf`, starting at `offset`, reading _at most_
+    /// `max_len` bytes.
+    ///
     /// Returns the number of bytes read.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                                            |
+    /// |-------------------|---------------------------------------------------|
+    /// | `InvalidHandle`   | if the handle isn't known.                        |
+    /// | `IllegalArgument` | if the passed buffer isn't valid, in memory, etc. |
     pub fn read(id: u32, offset: u32, obuf: *mut u8, max_len: u32) -> Result<u32>;
 
     /// Returns the codec and size of the specified block.
-    pub fn stat(id: u32) -> Result<fvm_shared::sys::out::ipld::IpldStat>;
+    ///
+    /// # Errors
+    ///
+    /// | Error           | Reason                     |
+    /// |-----------------|----------------------------|
+    /// | `InvalidHandle` | if the handle isn't known. |
+    pub fn stat(id: u32) -> Result<IpldStat>;
 
     // TODO: CID versions?
 
-    /// Computes the given block's CID, returning the actual size of the CID.
+    /// Computes the given block's CID, writing the resulting CID into `cid`, returning the actual
+    /// size of the CID.
     ///
-    /// If the CID is longer than cid_max_len, no data is written and the actual size is returned.
+    /// If the CID is longer than `cid_max_len`, no data is written and the actual size is returned.
     ///
     /// The returned CID is added to the reachable set.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                                            |
+    /// |-------------------|---------------------------------------------------|
+    /// | `InvalidHandle`   | if the handle isn't known.                        |
+    /// | `IllegalCid`      | hash code and/or hash length aren't supported.    |
+    /// | `IllegalArgument` | if the passed buffer isn't valid, in memory, etc. |
     pub fn cid(
         id: u32,
         hash_fun: u64,

--- a/sdk/src/sys/message.rs
+++ b/sdk/src/sys/message.rs
@@ -1,16 +1,33 @@
+//! Syscalls for reading message metadata.
+
 super::fvm_syscalls! {
     module = "message";
 
     /// Returns the caller's actor ID.
+    ///
+    /// # Errors
+    ///
+    /// None
     pub fn caller() -> Result<u64>;
 
     /// Returns the receiver's actor ID (i.e. ourselves).
+    ///
+    /// # Errors
+    ///
+    /// None
     pub fn receiver() -> Result<u64>;
 
     /// Returns the method number from the message.
+    ///
+    /// # Errors
+    ///
+    /// None
     pub fn method_number() -> Result<u64>;
 
-    /// Returns the value that was received, as little-Endian
-    /// tuple of u64 values to be concatenated in a u128.
-    pub fn value_received() -> Result<fvm_shared::sys::TokenAmount>;
+    /// Returns the value that was received.
+    ///
+    /// # Errors
+    ///
+    /// None
+    pub fn value_received() -> Result<super::TokenAmount>;
 }

--- a/sdk/src/sys/mod.rs
+++ b/sdk/src/sys/mod.rs
@@ -1,3 +1,7 @@
+//! This module defines the low-level syscall FFI "shims".
+#[doc(inline)]
+pub use fvm_shared::sys::TokenAmount;
+
 pub mod actor;
 pub mod crypto;
 //#[cfg(feature = "debug")]

--- a/sdk/src/sys/network.rs
+++ b/sdk/src/sys/network.rs
@@ -1,18 +1,33 @@
+//! Syscalls for network metadata.
+
 super::fvm_syscalls! {
     module = "network";
 
     /// Gets the current epoch.
+    ///
+    /// # Errors
+    ///
+    /// None
     pub fn curr_epoch() -> Result<i64>;
 
     /// Gets the network version.
+    ///
+    /// # Errors
+    ///
+    /// None
     pub fn version() -> Result<u32>;
 
-    /// Gets the base fee for the epoch as little-Endian
-    /// tuple of u64 values to be concatenated in a u128.
-    pub fn base_fee() -> Result<fvm_shared::sys::TokenAmount>;
+    /// Gets the base fee for the current epoch.
+    ///
+    /// # Errors
+    ///
+    /// None
+    pub fn base_fee() -> Result<super::TokenAmount>;
 
-    /// Gets the circulating supply as little-Endian
-    /// tuple of u64 values to be concatenated in a u128.
-    /// Note that how this value is calculated is expected to change in nv15
-    pub fn total_fil_circ_supply() -> Result<fvm_shared::sys::TokenAmount>;
+    /// Gets the circulating supply.
+    ///
+    /// # Errors
+    ///
+    /// None
+    pub fn total_fil_circ_supply() -> Result<super::TokenAmount>;
 }

--- a/sdk/src/sys/rand.rs
+++ b/sdk/src/sys/rand.rs
@@ -1,3 +1,5 @@
+//! Syscalls for getting randomness.
+
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
 
 super::fvm_syscalls! {
@@ -7,6 +9,13 @@ super::fvm_syscalls! {
     /// The supplied output buffer must have at least 32 bytes of capacity.
     /// If this syscall succeeds, exactly 32 bytes will be written starting at the
     /// supplied offset.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                  |
+    /// |-------------------|-------------------------|
+    /// | `LimitExceeded`   | lookback exceeds limit. |
+    /// | `IllegalArgument` | invalid buffer, etc.    |
     pub fn get_chain_randomness(
         dst: i64,
         round: i64,
@@ -18,6 +27,13 @@ super::fvm_syscalls! {
     /// The supplied output buffer must have at least 32 bytes of capacity.
     /// If this syscall succeeds, exactly 32 bytes will be written starting at the
     /// supplied offset.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                  |
+    /// |-------------------|-------------------------|
+    /// | `LimitExceeded`   | lookback exceeds limit. |
+    /// | `IllegalArgument` | invalid buffer, etc.    |
     pub fn get_beacon_randomness(
         dst: i64,
         round: i64,

--- a/sdk/src/sys/send.rs
+++ b/sdk/src/sys/send.rs
@@ -1,8 +1,27 @@
+//! Syscalls for sending messages to other actors.
+
+#[doc(inline)]
+pub use fvm_shared::sys::out::send::*;
+
 super::fvm_syscalls! {
     module = "send";
 
     /// Sends a message to another actor, and returns the exit code and block ID of the return
     /// result.
+    ///
+    /// # Errors
+    ///
+    /// A syscall error in [`send`] means the _caller_ did something wrong. If the _callee_ panics,
+    /// exceeds some limit, aborts, aborts with an invalid code, etc., the syscall will _succeed_
+    /// and the failure will be reflected in the exit code contained in the return value.
+    ///
+    /// | Error               | Reason                                               |
+    /// |---------------------|------------------------------------------------------|
+    /// | `NotFound`          | target actor does not exist and cannot be created.   |
+    /// | `InsufficientFunds` | tried to send more FIL than available.               |
+    /// | `InvalidHandle`     | parameters block not found.                          |
+    /// | `LimitExceeded`     | recursion limit reached.                             |
+    /// | `IllegalArgument`   | invalid recipient address buffer.                    |
     pub fn send(
         recipient_off: *const u8,
         recipient_len: u32,
@@ -10,5 +29,5 @@ super::fvm_syscalls! {
         params: u32,
         value_hi: u64,
         value_lo: u64,
-    ) -> Result<fvm_shared::sys::out::send::Send>;
+    ) -> Result<Send>;
 }

--- a/sdk/src/sys/sself.rs
+++ b/sdk/src/sys/sself.rs
@@ -1,3 +1,5 @@
+//! Syscalls for querying and modifying the current actor.
+
 super::fvm_syscalls! {
     module = "self";
 
@@ -5,15 +7,41 @@ super::fvm_syscalls! {
     ///
     /// If the CID doesn't fit in the specified maximum length (and/or the length is 0), this
     /// function returns the required size and does not update the cid buffer.
+    ///
+    /// # Errors
+    ///
+    /// | Error              | Reason                                             |
+    /// |--------------------|----------------------------------------------------|
+    /// | `IllegalOperation` | actor hasn't set the root yet, or has been deleted |
+    /// | `IllegalArgument`  | if the passed buffer isn't valid, in memory, etc.  |
     pub fn root(cid: *mut u8, cid_max_len: u32) -> Result<u32>;
 
     /// Sets the root CID for the calling actor. The new root must be in the reachable set.
+    ///
+    /// # Errors
+    ///
+    /// | Error              | Reason                                         |
+    /// |--------------------|------------------------------------------------|
+    /// | `IllegalOperation` | actor has been deleted                         |
+    /// | `NotFound`         | specified root CID is not in the reachable set |
     pub fn set_root(cid: *const u8) -> Result<()>;
 
     /// Gets the current balance for the calling actor.
-    pub fn current_balance() -> Result<fvm_shared::sys::TokenAmount>;
+    ///
+    /// # Errors
+    ///
+    /// None.
+    pub fn current_balance() -> Result<super::TokenAmount>;
 
     /// Destroys the calling actor, sending its current balance
     /// to the supplied address, which cannot be itself.
+    ///
+    /// # Errors
+    ///
+    /// | Error             | Reason                                                         |
+    /// |-------------------|----------------------------------------------------------------|
+    /// | `NotFound`        | beneficiary isn't found                                        |
+    /// | `Forbidden`       | beneficiary is not allowed (usually means beneficiary is self) |
+    /// | `IllegalArgument` | if the passed address buffer isn't valid, in memory, etc.      |
     pub fn self_destruct(addr_off: *const u8, addr_len: u32) -> Result<()>;
 }

--- a/sdk/src/sys/vm.rs
+++ b/sdk/src/sys/vm.rs
@@ -1,7 +1,13 @@
+//! Syscalls for interacting with the VM.
+
 super::fvm_syscalls! {
     module = "vm";
 
     /// Abort execution with the given code and message. The code is recorded in the receipt, the
     /// message is for debugging only.
+    ///
+    /// # Errors
+    ///
+    /// None. This function doesn't return.
     pub fn abort(code: u32, message: *const u8, message_len: u32) -> !;
 }

--- a/shared/src/sys/mod.rs
+++ b/shared/src/sys/mod.rs
@@ -6,6 +6,11 @@ pub mod out;
 pub type BlockId = u32;
 pub type Codec = u64;
 
+/// The token amount type used in syscalls. It can represent any token amount (in atto-FIL) from 0
+/// to `2^128-1` attoFIL. Or 0 to about 340 exaFIL.
+///
+/// Internally, this type is a tuple of `u64`s storing the "low" and "high" bits of a little-endian
+/// u128.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TokenAmount {


### PR DESCRIPTION
I've decided to document these in the SDK because this is the cleanest, low-level API definition we have. My plan is to link to the documentation from the spec instead of duplicating the syscall definitions in both places.

Rendered: https://bafybeif5utc6rkqubx3iiikkpn6ubompnd7xdowliznndocyaqgozy2uni.ipfs.dweb.link/fvm_sdk/sys/index.html