### PR TITLE
feat: add a feature to statically disable debugging in the sdk

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -15,7 +15,11 @@ cid = { version = "0.8.2", default-features = false }
 fvm_shared = { version = "0.5.1", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
-lazy_static = "1.4.0"
+lazy_static = { version = "1.4.0", optional = true }
 log = "0.4.14"
 thiserror = "1.0.30"
 fvm_ipld_encoding = { version = "0.1", path = "../ipld/encoding" }
+
+[features]
+default = ["debug"]
+debug = ["lazy_static"]

--- a/sdk/src/sys/mod.rs
+++ b/sdk/src/sys/mod.rs
@@ -4,7 +4,7 @@ pub use fvm_shared::sys::TokenAmount;
 
 pub mod actor;
 pub mod crypto;
-//#[cfg(feature = "debug")]
+#[cfg(feature = "debug")]
 pub mod debug;
 pub mod gas;
 pub mod ipld;


### PR DESCRIPTION
When the debug feature is disabled, most actor debugging logic should get statically compiled out.

I've left it enabled by default for now, but we should consider disabling it by default for the final release. But if we do that, we need _some_ way to re-execute actors with debugging enabled.