### PR TITLE
chore: sector: Cleanup registered_proof

### DIFF
--- a/shared/src/sector/registered_proof.rs
+++ b/shared/src/sector/registered_proof.rs
@@ -14,14 +14,14 @@ use crate::version::NetworkVersion;
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 pub enum RegisteredSealProof {
     StackedDRG2KiBV1,
-    StackedDRG512MiBV1,
     StackedDRG8MiBV1,
+    StackedDRG512MiBV1,
     StackedDRG32GiBV1,
     StackedDRG64GiBV1,
 
     StackedDRG2KiBV1P1,
-    StackedDRG512MiBV1P1,
     StackedDRG8MiBV1P1,
+    StackedDRG512MiBV1P1,
     StackedDRG32GiBV1P1,
     StackedDRG64GiBV1P1,
     // TODO: get rid of this option once we no longer need go compat.
@@ -119,30 +119,6 @@ impl RegisteredPoStProof {
             StackedDRGWindow512MiBV1 | StackedDRGWinning512MiBV1 => Ok(SectorSize::_512MiB),
             StackedDRGWindow32GiBV1 | StackedDRGWinning32GiBV1 => Ok(SectorSize::_32GiB),
             StackedDRGWindow64GiBV1 | StackedDRGWinning64GiBV1 => Ok(SectorSize::_64GiB),
-            Invalid(i) => Err(format!("unsupported proof type: {}", i)),
-        }
-    }
-
-    /// RegisteredSealProof produces the seal-specific RegisteredProof corresponding
-    /// to the receiving RegisteredProof.
-    pub fn registered_seal_proof(self) -> Result<RegisteredSealProof, String> {
-        use RegisteredPoStProof::*;
-        match self {
-            StackedDRGWindow64GiBV1 | StackedDRGWinning64GiBV1 => {
-                Ok(RegisteredSealProof::StackedDRG64GiBV1)
-            }
-            StackedDRGWindow32GiBV1 | StackedDRGWinning32GiBV1 => {
-                Ok(RegisteredSealProof::StackedDRG32GiBV1)
-            }
-            StackedDRGWindow2KiBV1 | StackedDRGWinning2KiBV1 => {
-                Ok(RegisteredSealProof::StackedDRG2KiBV1)
-            }
-            StackedDRGWindow8MiBV1 | StackedDRGWinning8MiBV1 => {
-                Ok(RegisteredSealProof::StackedDRG8MiBV1)
-            }
-            StackedDRGWindow512MiBV1 | StackedDRGWinning512MiBV1 => {
-                Ok(RegisteredSealProof::StackedDRG512MiBV1)
-            }
             Invalid(i) => Err(format!("unsupported proof type: {}", i)),
         }
     }


### PR DESCRIPTION
builtin-actors build with this, but I'm not 100% sure that this isn't a breaking change

Related to https://github.com/filecoin-project/ref-fvm/pull/481