### PR TITLE
refactor: combine/refactor context/config/machine arguments

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -100,7 +100,7 @@ where
         //
         // NOTE: Unlike the FVM, Lotus adds _then_ checks. It does this because the
         // `call_stack_depth` in lotus is 0 for the top-level call, unlike in the FVM where it's 1.
-        if self.call_stack_depth > self.machine.config().max_call_depth {
+        if self.call_stack_depth > self.machine.context().max_call_depth {
             return Err(
                 syscall_error!(LimitExceeded, "message execution exceeds call depth").into(),
             );

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -915,7 +915,7 @@ where
     }
 
     fn debug_enabled(&self) -> bool {
-        self.call_manager.context().debug
+        self.call_manager.context().actor_debugging
     }
 }
 

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -7,7 +7,8 @@ use fvm_shared::ActorID;
 use super::{Engine, Machine, MachineContext};
 use crate::kernel::Result;
 use crate::state_tree::{ActorState, StateTree};
-use crate::Config;
+
+type Type = MachineContext;
 
 impl<M: Machine> Machine for Box<M> {
     type Blockstore = M::Blockstore;
@@ -19,17 +20,12 @@ impl<M: Machine> Machine for Box<M> {
     }
 
     #[inline(always)]
-    fn config(&self) -> &Config {
-        (&**self).config()
-    }
-
-    #[inline(always)]
     fn blockstore(&self) -> &Self::Blockstore {
         (&**self).blockstore()
     }
 
     #[inline(always)]
-    fn context(&self) -> &MachineContext {
+    fn context(&self) -> &Type {
         (&**self).context()
     }
 

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -1,4 +1,5 @@
 use cid::Cid;
+use derive_more::{Deref, DerefMut};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::actor::builtin::Manifest;
 use fvm_shared::address::Address;
@@ -6,12 +7,12 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::ActorID;
+use num_traits::Zero;
 
 use crate::externs::Externs;
-use crate::gas::PriceList;
+use crate::gas::{price_list_by_network_version, PriceList};
 use crate::kernel::Result;
 use crate::state_tree::{ActorState, StateTree};
-use crate::Config;
 
 mod default;
 
@@ -46,9 +47,6 @@ pub trait Machine: 'static {
     /// Returns the underlying WASM engine. Cloning it will simply create a new handle with a
     /// static lifetime.
     fn engine(&self) -> &Engine;
-
-    /// Returns the FVM's configuration.
-    fn config(&self) -> &Config;
 
     /// Returns a reference to the machine's blockstore.
     fn blockstore(&self) -> &Self::Blockstore;
@@ -88,23 +86,110 @@ pub trait Machine: 'static {
     fn consume(self) -> Self::Blockstore;
 }
 
-/// Execution context supplied to the machine.
-#[derive(Clone, Debug)]
+/// Network-level settings. Except when testing locally, changing any of these likely requires a
+/// network upgrade.
+#[derive(Debug, Clone)]
+pub struct NetworkConfig {
+    /// The network version at epoch
+    pub network_version: NetworkVersion,
+
+    /// The maximum call depth.
+    ///
+    /// DEFAULT: 4096
+    pub max_call_depth: u32,
+
+    /// An override for builtin-actors. If specified, this should be the CID of a builtin-actors
+    /// "manifest".
+    ///
+    /// DEFAULT: `None`
+    pub builtin_actors_override: Option<Cid>,
+
+    /// Enable actor debugging.
+    ///
+    /// DEFAULT: `false`
+    pub actor_debugging: bool,
+
+    /// The price list.
+    ///
+    /// DEFAULT: The price-list for the current network version.
+    pub price_list: &'static PriceList,
+}
+
+impl NetworkConfig {
+    /// Create a new network config for the given network version.
+    pub fn new(network_version: NetworkVersion) -> Self {
+        NetworkConfig {
+            network_version,
+            max_call_depth: 4096,
+            actor_debugging: false,
+            builtin_actors_override: None,
+            price_list: price_list_by_network_version(network_version),
+        }
+    }
+
+    /// Enable actor debugging. This is a consensus-critical option (affects gas usage) so it should
+    /// only be enabled for local testing or as a network-wide parameter.
+    pub fn enable_actor_debugging(&mut self, enabled: bool) -> &mut Self {
+        self.actor_debugging = enabled;
+        self
+    }
+
+    /// Override actors with the specific manifest. This is primarily useful for testing, or
+    /// networks prior to NV16 (where the actor's "manifest" isn't specified on-chain).
+    pub fn override_actors(&mut self, manifest: Cid) -> &mut Self {
+        self.builtin_actors_override = Some(manifest);
+        self
+    }
+
+    /// Create a [`MachineContext`] for a given `epoch` with the specified `initial_state`.
+    pub fn for_epoch(&self, epoch: ChainEpoch, initial_state: Cid) -> MachineContext {
+        MachineContext {
+            network: self.clone(),
+            epoch,
+            initial_state_root: initial_state,
+            base_fee: TokenAmount::zero(),
+            circ_supply: fvm_shared::TOTAL_FILECOIN.clone(),
+        }
+    }
+}
+
+/// Per-epoch machine context.
+#[derive(Clone, Debug, Deref, DerefMut)]
 pub struct MachineContext {
+    /// Network-level settings.
+    #[deref]
+    #[deref_mut]
+    pub network: NetworkConfig,
+
     /// The epoch at which the Machine runs.
     pub epoch: ChainEpoch,
+
+    /// The initial state root on which this block is based.
+    pub initial_state_root: Cid,
+
     /// The base fee that's in effect when the Machine runs.
+    ///
+    /// Default: 0.
     pub base_fee: TokenAmount,
+
     /// v15 and onwards: The amount of FIL that has vested from genesis actors.
     /// v14 and earlier: The amount of FIL that has vested from genesis msigs
     /// (the remainder of the circ supply must be calculated by the FVM)
+    ///
+    /// DEFAULT: Total FIL supply (likely not what you want).
     pub circ_supply: TokenAmount,
-    /// The initial state root on which this block is based.
-    pub initial_state_root: Cid,
-    /// The price list.
-    pub price_list: &'static PriceList,
-    /// The network version at epoch
-    pub network_version: NetworkVersion,
-    /// Whether debug mode is enabled or not.
-    pub debug: bool,
+}
+
+impl MachineContext {
+    /// Sets [`EpochContext::base_fee`].
+    pub fn set_base_fee(&mut self, amt: TokenAmount) -> &mut Self {
+        self.base_fee = amt;
+        self
+    }
+
+    /// Set [`EpochContext::circ_supply`].
+    pub fn set_circulating_supply(&mut self, amt: TokenAmount) -> &mut Self {
+        self.circ_supply = amt;
+        self
+    }
 }

--- a/testing/conformance/benches/bench_drivers.rs
+++ b/testing/conformance/benches/bench_drivers.rs
@@ -45,7 +45,7 @@ pub fn bench_vector_variant(
                 let vector = &(*vector).clone();
                 let bs = bs.clone();
                 // TODO next few lines don't impact the benchmarks, but it might make them run waaaay more slowly... ought to make a base copy of the machine and exec and deepcopy them each time.
-                let machine = TestMachine::new_for_vector(vector, variant, bs, engine.clone());
+                let machine = TestMachine::new_for_vector(vector, variant, bs, engine);
                 // can assume this works because it passed a test before this ran
                 let exec: DefaultExecutor<TestKernel> = DefaultExecutor::new(machine);
                 (messages_with_lengths.clone(), exec)

--- a/testing/conformance/src/driver.rs
+++ b/testing/conformance/src/driver.rs
@@ -190,7 +190,7 @@ pub fn run_variant(
     let id = variant.id.clone();
 
     // Construct the Machine.
-    let machine = TestMachine::new_for_vector(v, variant, bs, engine.clone());
+    let machine = TestMachine::new_for_vector(v, variant, bs, engine);
     let mut exec: DefaultExecutor<TestKernel> = DefaultExecutor::new(machine);
 
     // Apply all messages in the vector.


### PR DESCRIPTION
1. Reduce the number of arguments to the constructor.
2. Renames "debug" to actor_debugging to make it clear what it does, and document that it's
   consensus critical.
3. Split the config into "network-wide" and "epoch-specific" sections.

This change also makes it clear that these options are all consensus critical.

fixes #249