### PR TITLE
fix: charge randomness gas based on length of entropy

### DIFF
--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -564,19 +564,16 @@ impl PriceList {
         }
     }
 
-    /// Returns the base cost of the gas required for getting randomness from the client.
+    /// Returns the cost of the gas required for getting randomness from the client, based on the
+    /// numebr of bytes of entropy.
     #[inline]
-    pub fn on_get_randomness_base(&self) -> GasCharge<'static> {
-        GasCharge::new("OnGetRandomnessBase", self.get_randomness_base, 0)
-    }
-
-    /// Returns the gas required for getting randomness from the client based on the number of bytes of randomness.
-    #[inline]
-    pub fn on_get_randomness_per_byte(&self, randomness_size: usize) -> GasCharge<'static> {
+    pub fn on_get_randomness(&self, entropy_size: usize) -> GasCharge<'static> {
         GasCharge::new(
-            "OnGetRandomnessPerByte",
-            self.get_randomness_per_byte
-                .saturating_mul(randomness_size as i64),
+            "OnGetRandomness",
+            self.get_randomness_base.saturating_add(
+                self.get_randomness_per_byte
+                    .saturating_mul(entropy_size as i64),
+            ),
             0,
         )
     }

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -793,21 +793,16 @@ where
         rand_epoch: ChainEpoch,
         entropy: &[u8],
     ) -> Result<[u8; RANDOMNESS_LENGTH]> {
-        self.call_manager
-            .charge_gas(self.call_manager.price_list().on_get_randomness_base())?;
+        self.call_manager.charge_gas(
+            self.call_manager
+                .price_list()
+                .on_get_randomness(entropy.len()),
+        )?;
         // TODO: Check error code
-        let rand = self
-            .call_manager
+        self.call_manager
             .externs()
             .get_chain_randomness(personalization, rand_epoch, entropy)
-            .or_illegal_argument()?;
-        self.call_manager
-            .charge_gas(
-                self.call_manager
-                    .price_list()
-                    .on_get_randomness_per_byte(rand.len()),
-            )
-            .map(|_| rand)
+            .or_illegal_argument()
     }
 
     #[allow(unused)]
@@ -817,22 +812,16 @@ where
         rand_epoch: ChainEpoch,
         entropy: &[u8],
     ) -> Result<[u8; RANDOMNESS_LENGTH]> {
-        self.call_manager
-            .charge_gas(self.call_manager.price_list().on_get_randomness_base())?;
+        self.call_manager.charge_gas(
+            self.call_manager
+                .price_list()
+                .on_get_randomness(entropy.len()),
+        )?;
         // TODO: Check error code
-        let rand = self
-            .call_manager
+        self.call_manager
             .externs()
             .get_beacon_randomness(personalization, rand_epoch, entropy)
-            .or_illegal_argument()?;
-
-        self.call_manager
-            .charge_gas(
-                self.call_manager
-                    .price_list()
-                    .on_get_randomness_per_byte(rand.len()),
-            )
-            .map(|_| rand)
+            .or_illegal_argument()
     }
 }
 


### PR DESCRIPTION
We're charging for the number of bytes hashed, not the size of the entropy.