### PR TITLE
chore: upgrade actors to use the new syscall abi

### DIFF
--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -47,8 +47,8 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 walkdir = "2.3"
 regex = { version = "1.0" }
 ittapi-rs = { version = "0.1.6", optional = true }
-actors-v6 = { version = "6.1.0", package = "fil_builtin_actors_bundle" }
-actors-v7 = { version = "7.1.0", package = "fil_builtin_actors_bundle" }
+actors-v6 = { version = "~6.2", package = "fil_builtin_actors_bundle" }
+actors-v7 = { version = "~7.2", package = "fil_builtin_actors_bundle" }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [features]


### PR DESCRIPTION
This also fixes the actors version with the tilde version constraint so we won't auto-upgrade to the next _minor_ version (but will auto-upgrade patch releases).