### PR TITLE
doc: improve syscall documentation

### DIFF
--- a/sdk/src/sys/actor.rs
+++ b/sdk/src/sys/actor.rs
@@ -3,17 +3,24 @@
 #[doc(inline)]
 pub use fvm_shared::sys::out::actor::*;
 
+// for documentation links
+#[cfg(doc)]
+use crate::sys::ErrorNumber::*;
+
 super::fvm_syscalls! {
     module = "actor";
 
     /// Resolves the ID address of an actor.
     ///
+    /// # Arguments
+    ///
+    /// `addr_off` and `addr_len` specify the location and length of an address to be resolved.
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason                                                    |
-    /// |-------------------|-----------------------------------------------------------|
-    /// | `NotFound`        | target actor doesn't exist                                |
-    /// | `IllegalArgument` | if the passed address buffer isn't valid, in memory, etc. |
+    /// | Error               | Reason                                                    |
+    /// |---------------------|-----------------------------------------------------------|
+    /// | [`IllegalArgument`] | if the passed address buffer isn't valid, in memory, etc. |
     pub fn resolve_address(
         addr_off: *const u8,
         addr_len: u32,
@@ -21,14 +28,18 @@ super::fvm_syscalls! {
 
     /// Gets the CodeCID of an actor by address.
     ///
-    /// Returns the
+    /// # Arguments
+    ///
+    /// - `addr_off` and `addr_len` specify the location and length of an address of the target
+    ///   actor.
+    /// - `obuf_off` and `obuf_len` specify the location and length of a byte buffer into which the
+    ///   FVM will write the actor's code CID, if the actor is found. If the
     ///
     /// # Errors
     ///
-    /// | Error             | Reason                                                    |
-    /// |-------------------|-----------------------------------------------------------|
-    /// | `NotFound`        | target actor doesn't exist                                |
-    /// | `IllegalArgument` | if the passed address buffer isn't valid, in memory, etc. |
+    /// | Error               | Reason                                                    |
+    /// |---------------------|-----------------------------------------------------------|
+    /// | [`IllegalArgument`] | if the passed address buffer isn't valid, in memory, etc. |
     pub fn get_actor_code_cid(
         addr_off: *const u8,
         addr_len: u32,
@@ -41,10 +52,10 @@ super::fvm_syscalls! {
     /// internal errors.
     pub fn resolve_builtin_actor_type(cid_off: *const u8) -> Result<i32>;
 
-     /// Returns the CodeCID for the given built-in actor type. Aborts with exit
-     /// code IllegalArgument if the supplied type is invalid. Returns the
-     /// length of the written CID written to the output buffer. Can only
-     /// return a failure due to internal errors.
+    /// Returns the CodeCID for the given built-in actor type. Aborts with exit
+    /// code IllegalArgument if the supplied type is invalid. Returns the
+    /// length of the written CID written to the output buffer. Can only
+    /// return a failure due to internal errors.
     pub fn get_code_cid_for_type(typ: i32, obuf_off: *mut u8, obuf_len: u32) -> Result<i32>;
 
     /// Generates a new actor address for an actor deployed

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -3,6 +3,10 @@
 #[doc(inline)]
 pub use fvm_shared::sys::out::crypto::*;
 
+// for documentation links
+#[cfg(doc)]
+use crate::sys::ErrorNumber::*;
+
 super::fvm_syscalls! {
     module = "crypto";
 
@@ -10,11 +14,17 @@ super::fvm_syscalls! {
     ///
     /// Returns 0 on success, or -1 if the signature fails to validate.
     ///
+    /// # Arguments
+    ///
+    /// - `sig_off` and `sig_len` specify location and length of the signature.
+    /// - `addr_off` and `addr_len` specify location and length of expected signer's address.
+    /// - `plaintext_off` and `plaintext_len` specify location and length of the signed data.
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason                                               |
-    /// |-------------------|------------------------------------------------------|
-    /// | `IllegalArgument` | signature, address, or plaintext buffers are invalid |
+    /// | Error               | Reason                                               |
+    /// |---------------------|------------------------------------------------------|
+    /// | [`IllegalArgument`] | signature, address, or plaintext buffers are invalid |
     pub fn verify_signature(
         sig_off: *const u8,
         sig_len: u32,
@@ -26,13 +36,17 @@ super::fvm_syscalls! {
 
     /// Hashes input data using blake2b with 256 bit output.
     ///
-    /// The output buffer must be sized to a minimum of 32 bytes.
+    /// Returns a 32-byte hash digest.
+    ///
+    /// # Arguments
+    ///
+    /// - `data_off` and `data_len` specify location and length of the data to be hashed.
     ///
     /// # Errors
     ///
-    /// | Error             | Reason                                          |
-    /// |-------------------|-------------------------------------------------|
-    /// | `IllegalArgument` | the input buffer does not point to valid memory |
+    /// | Error               | Reason                                          |
+    /// |---------------------|-------------------------------------------------|
+    /// | [`IllegalArgument`] | the input buffer does not point to valid memory |
     pub fn hash_blake2b(
         data_off: *const u8,
         data_len: u32,
@@ -44,11 +58,19 @@ super::fvm_syscalls! {
     /// Writes the CID in the provided output buffer, and returns the length of
     /// the written CID.
     ///
+    /// # Arguments
+    ///
+    /// - `proof_type` is the type of seal proof.
+    /// - `pieces_off` and `pieces_len` specify the location and length of a cbor-encoded list of
+    ///   [`PieceInfo`][fvm_shared::piece::PieceInfo] in tuple representation.
+    /// - `cid_off` is the offset at which the computed CID will be written.
+    /// - `cid_len` is the size of the buffer at `cid_off`. 100 bytes is guaranteed to be enough.
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason                   |
-    /// |-------------------|--------------------------|
-    /// | `IllegalArgument` | an argument is malformed |
+    /// | Error               | Reason                   |
+    /// |---------------------|--------------------------|
+    /// | [`IllegalArgument`] | an argument is malformed |
     pub fn compute_unsealed_sector_cid(
         proof_type: i64,
         pieces_off: *const u8,
@@ -61,22 +83,32 @@ super::fvm_syscalls! {
     ///
     /// Returns 0 to indicate that the proof was valid, -1 otherwise.
     ///
+    /// # Arguments
+    ///
+    /// `info_off` and `info_len` specify the location and length of a cbor-encoded
+    /// [`SealVerifyInfo`][fvm_shared::sector::SealVerifyInfo] in tuple representation.
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason                   |
-    /// |-------------------|--------------------------|
-    /// | `IllegalArgument` | an argument is malformed |
+    /// | Error               | Reason                   |
+    /// |---------------------|--------------------------|
+    /// | [`IllegalArgument`] | an argument is malformed |
     pub fn verify_seal(info_off: *const u8, info_len: u32) -> Result<i32>;
 
     /// Verifies a window proof of spacetime.
     ///
     /// Returns 0 to indicate that the proof was valid, -1 otherwise.
     ///
+    /// # Arguments
+    ///
+    /// `info_off` and `info_len` specify the location and length of a cbor-encoded
+    /// [`WindowPoStVerifyInfo`][fvm_shared::sector::WindowPoStVerifyInfo] in tuple representation.
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason                   |
-    /// |-------------------|--------------------------|
-    /// | `IllegalArgument` | an argument is malformed |
+    /// | Error               | Reason                   |
+    /// |---------------------|--------------------------|
+    /// | [`IllegalArgument`] | an argument is malformed |
     pub fn verify_post(info_off: *const u8, info_len: u32) -> Result<i32>;
 
     /// Verifies that two block headers provide proof of a consensus fault.
@@ -85,12 +117,19 @@ super::fvm_syscalls! {
     /// BlockId containing the fault details. Otherwise, a -1 status is returned,
     /// and the second result parameter must be ignored.
     ///
+    /// # Arguments
+    ///
+    /// - `h1_off`/`h1_len` and `h2_off`/`h2_len` specify the location and length of the block
+    ///   headers that allegedly represent a consensus fault.
+    /// - `extra_off` and `extra_len` specifies the "extra data" passed in the
+    ///   `ReportConsensusFault` message.
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason                                |
-    /// |-------------------|---------------------------------------|
-    /// | `LimitExceeded`   | exceeded lookback limit finding block |
-    /// | `IllegalArgument` | an argument is malformed              |
+    /// | Error               | Reason                                |
+    /// |---------------------|---------------------------------------|
+    /// | [`LimitExceeded`]   | exceeded lookback limit finding block |
+    /// | [`IllegalArgument`] | an argument is malformed              |
     pub fn verify_consensus_fault(
         h1_off: *const u8,
         h1_len: u32,
@@ -104,32 +143,52 @@ super::fvm_syscalls! {
     ///
     /// Returns 0 to indicate that the proof was valid, -1 otherwise.
     ///
+    /// # Arguments
+    ///
+    /// `agg_off` and `agg_len` specify the location and length of a cbor-encoded
+    /// [`AggregateSealVerifyProofAndInfos`][fvm_shared::sector::AggregateSealVerifyProofAndInfos]
+    /// in tuple representation.
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason                         |
-    /// |-------------------|--------------------------------|
-    /// | `LimitExceeded`   | exceeds seal aggregation limit |
-    /// | `IllegalArgument` | an argument is malformed       |
+    /// | Error               | Reason                         |
+    /// |---------------------|--------------------------------|
+    /// | [`LimitExceeded`]   | exceeds seal aggregation limit |
+    /// | [`IllegalArgument`] | an argument is malformed       |
     pub fn verify_aggregate_seals(agg_off: *const u8, agg_len: u32) -> Result<i32>;
 
     /// Verifies a replica update proof.
     ///
     /// Returns 0 to indicate that the proof was valid, -1 otherwise.
     ///
+    /// # Arguments
+    ///
+    /// `rep_off` and `rep_len` specify the location and length of a cbor-encoded
+    /// [`ReplicaUpdateInfo`][fvm_shared::sector::ReplicaUpdateInfo] in tuple representation.
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason                        |
-    /// |-------------------|-------------------------------|
-    /// | `LimitExceeded`   | exceeds replica update limit  |
-    /// | `IllegalArgument` | an argument is malformed      |
+    /// | Error               | Reason                        |
+    /// |---------------------|-------------------------------|
+    /// | [`LimitExceeded`]   | exceeds replica update limit  |
+    /// | [`IllegalArgument`] | an argument is malformed      |
     pub fn verify_replica_update(rep_off: *const u8, rep_len: u32) -> Result<i32>;
 
-    /// Verifies an aggregated batch of sector seal proofs.
+    /// Verifies a batch of sector seal proofs.
+    ///
+    /// # Arguments
+    ///
+    /// - `batch_off` and `batch_len` specify the location and length of a cbor-encoded list of
+    ///   [`SealVerifyInfo`][fvm_shared::sector::SealVerifyInfo] in tuple representation.
+    /// - `results_off` specifies the location of a length `L` byte buffer where the results of the
+    ///   verification will be written, where `L` is the number of proofs in the batch. For each
+    ///   proof in the input list (in input order), a 1 or 0 byte will be written on success or
+    ///   failure, respectively.
     ///
     /// # Errors
     ///
-    /// | Error             | Reason                   |
-    /// |-------------------|--------------------------|
-    /// | `IllegalArgument` | an argument is malformed |
+    /// | Error               | Reason                   |
+    /// |---------------------|--------------------------|
+    /// | [`IllegalArgument`] | an argument is malformed |
     pub fn batch_verify_seals(batch_off: *const u8, batch_len: u32, result_off: *const u8) -> Result<()>;
 }

--- a/sdk/src/sys/gas.rs
+++ b/sdk/src/sys/gas.rs
@@ -1,5 +1,9 @@
 //! Syscalls for working with gas.
 
+// for documentation links
+#[cfg(doc)]
+use crate::sys::ErrorNumber::*;
+
 super::fvm_syscalls! {
     module = "gas";
 
@@ -8,11 +12,17 @@ super::fvm_syscalls! {
 
     /// Charge gas.
     ///
+    /// # Arguments
+    ///
+    /// - `name_off` and `name_len` specify the location and length of the "name" of the gas charge,
+    ///   for debugging.
+    /// - `amount` is the amount of gas to charge.
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason               |
-    /// |-------------------|----------------------|
-    /// | `IllegalArgument` | invalid name buffer. |
+    /// | Error               | Reason               |
+    /// |---------------------|----------------------|
+    /// | [`IllegalArgument`] | invalid name buffer. |
     pub fn charge(name_off: *const u8, name_len: u32, amount: u64) -> Result<()>;
 
     // Returns the amount of gas remaining.

--- a/sdk/src/sys/ipld.rs
+++ b/sdk/src/sys/ipld.rs
@@ -6,6 +6,10 @@ pub const UNIT: u32 = 0;
 #[doc(inline)]
 pub use fvm_shared::sys::out::ipld::*;
 
+// for documentation links
+#[cfg(doc)]
+use crate::sys::ErrorNumber::*;
+
 super::fvm_syscalls! {
     module = "ipld";
 
@@ -16,24 +20,35 @@ super::fvm_syscalls! {
     /// - The reachable set is extended to include the direct children of loaded blocks until the
     ///   end of the invocation.
     ///
+    /// # Arguments
+    ///
+    /// - `cid` the location of the input CID (in wasm memory).
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason                                      |
-    /// |-------------------|---------------------------------------------|
-    /// | `NotFound`        | the target block isn't in the reachable set |
-    /// | `IllegalArgument` | there's something wrong with the CID        |
+    /// | Error               | Reason                                      |
+    /// |---------------------|---------------------------------------------|
+    /// | [`NotFound`]        | the target block isn't in the reachable set |
+    /// | [`IllegalArgument`] | there's something wrong with the CID        |
     pub fn open(cid: *const u8) -> Result<IpldOpen>;
 
     /// Creates a new block, returning the block's ID. The block's children must be in the reachable
     /// set. The new block isn't added to the reachable set until the CID is computed.
     ///
-    /// | Error             | Reason                                                  |
-    /// |-------------------|---------------------------------------------------------|
-    /// | `LimitExceeded`   | the block is too big                                    |
-    /// | `NotFound`        | one of the blocks's children isn't in the reachable set |
-    /// | `IllegalCodec`    | the passed codec isn't supported                        |
-    /// | `Serialization`   | the passed block doesn't match the passed codec         |
-    /// | `IllegalArgument` | the block isn't in memory, etc.                         |
+    /// # Arguments
+    ///
+    /// - `codec` is the codec of the block.
+    /// - `data` and `len` specify the location and length of the block data.
+    ///
+    /// # Errors
+    ///
+    /// | Error               | Reason                                                  |
+    /// |---------------------|---------------------------------------------------------|
+    /// | [`LimitExceeded`]   | the block is too big                                    |
+    /// | [`NotFound`]        | one of the blocks's children isn't in the reachable set |
+    /// | [`IllegalCodec`]    | the passed codec isn't supported                        |
+    /// | [`Serialization`]   | the passed block doesn't match the passed codec         |
+    /// | [`IllegalArgument`] | the block isn't in memory, etc.                         |
     pub fn create(codec: u64, data: *const u8, len: u32) -> Result<u32>;
 
     /// Reads the block identified by `id` into `obuf`, starting at `offset`, reading _at most_
@@ -41,21 +56,31 @@ super::fvm_syscalls! {
     ///
     /// Returns the number of bytes read.
     ///
+    /// # Arguments
+    ///
+    /// - `id` is ID of the block to read.
+    /// - `offset` is the offset in the block to start reading.
+    /// - `obuf` is the output buffer (in wasm memory) where the FVM will write the block data.
+    /// - `max_len` is the maximum amount of block data to read.
+    ///
+    /// Passing a length/offset that exceed the length of the block will not result in an error, but
+    /// will result in no data being read.
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason                                            |
-    /// |-------------------|---------------------------------------------------|
-    /// | `InvalidHandle`   | if the handle isn't known.                        |
-    /// | `IllegalArgument` | if the passed buffer isn't valid, in memory, etc. |
+    /// | Error               | Reason                                            |
+    /// |---------------------|---------------------------------------------------|
+    /// | [`InvalidHandle`]   | if the handle isn't known.                        |
+    /// | [`IllegalArgument`] | if the passed buffer isn't valid, in memory, etc. |
     pub fn read(id: u32, offset: u32, obuf: *mut u8, max_len: u32) -> Result<u32>;
 
     /// Returns the codec and size of the specified block.
     ///
     /// # Errors
     ///
-    /// | Error           | Reason                     |
-    /// |-----------------|----------------------------|
-    /// | `InvalidHandle` | if the handle isn't known. |
+    /// | Error             | Reason                     |
+    /// |-------------------|----------------------------|
+    /// | [`InvalidHandle`] | if the handle isn't known. |
     pub fn stat(id: u32) -> Result<IpldStat>;
 
     // TODO: CID versions?
@@ -67,13 +92,21 @@ super::fvm_syscalls! {
     ///
     /// The returned CID is added to the reachable set.
     ///
+    /// # Arguments
+    ///
+    /// - `id` is ID of the block to linked.
+    /// - `hash_fun` is the multicodec of the hash function to use.
+    /// - `hash_len` is the desired length of the hash digest.
+    /// - `cid` is the output buffer (in wasm memory) where the FVM will write the resulting cid.
+    /// - `cid_max_length` is the length of the output CID buffer.
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason                                            |
-    /// |-------------------|---------------------------------------------------|
-    /// | `InvalidHandle`   | if the handle isn't known.                        |
-    /// | `IllegalCid`      | hash code and/or hash length aren't supported.    |
-    /// | `IllegalArgument` | if the passed buffer isn't valid, in memory, etc. |
+    /// | Error               | Reason                                            |
+    /// |---------------------|---------------------------------------------------|
+    /// | [`InvalidHandle`]   | if the handle isn't known.                        |
+    /// | [`IllegalCid`]      | hash code and/or hash length aren't supported.    |
+    /// | [`IllegalArgument`] | if the passed buffer isn't valid, in memory, etc. |
     pub fn cid(
         id: u32,
         hash_fun: u64,

--- a/sdk/src/sys/rand.rs
+++ b/sdk/src/sys/rand.rs
@@ -2,42 +2,56 @@
 
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
 
+// for documentation links
+#[cfg(doc)]
+use crate::sys::ErrorNumber::*;
+
 super::fvm_syscalls! {
     module = "rand";
 
     /// Gets 32 bytes of randomness from the ticket chain.
-    /// The supplied output buffer must have at least 32 bytes of capacity.
-    /// If this syscall succeeds, exactly 32 bytes will be written starting at the
-    /// supplied offset.
+    ///
+    /// # Arguments
+    ///
+    /// - `tag` is the "domain separation tag" for distinguishing between different categories of
+    ///    randomness. Think of it like extra, structured entropy.
+    /// - `epoch` is the epoch to pull the randomness from.
+    /// - `entropy_off` and `entropy_len` specify the location and length of the entropy buffer that
+    ///    will be mixed into the system randomness.
     ///
     /// # Errors
     ///
-    /// | Error             | Reason                  |
-    /// |-------------------|-------------------------|
-    /// | `LimitExceeded`   | lookback exceeds limit. |
-    /// | `IllegalArgument` | invalid buffer, etc.    |
+    /// | Error               | Reason                  |
+    /// |---------------------|-------------------------|
+    /// | [`LimitExceeded`]   | lookback exceeds limit. |
+    /// | [`IllegalArgument`] | invalid buffer, etc.    |
     pub fn get_chain_randomness(
-        dst: i64,
-        round: i64,
-        entropy_offset: *const u8,
+        tag: i64,
+        epoch: i64,
+        entropy_off: *const u8,
         entropy_len: u32,
     ) -> Result<[u8; RANDOMNESS_LENGTH]>;
 
     /// Gets 32 bytes of randomness from the beacon system (currently Drand).
-    /// The supplied output buffer must have at least 32 bytes of capacity.
-    /// If this syscall succeeds, exactly 32 bytes will be written starting at the
-    /// supplied offset.
+    ///
+    /// # Arguments
+    ///
+    /// - `tag` is the "domain separation tag" for distinguishing between different categories of
+    ///    randomness. Think of it like extra, structured entropy.
+    /// - `epoch` is the epoch to pull the randomness from.
+    /// - `entropy_off` and `entropy_len` specify the location and length of the entropy buffer that
+    ///    will be mixed into the system randomness.
     ///
     /// # Errors
     ///
-    /// | Error             | Reason                  |
-    /// |-------------------|-------------------------|
-    /// | `LimitExceeded`   | lookback exceeds limit. |
-    /// | `IllegalArgument` | invalid buffer, etc.    |
+    /// | Error               | Reason                  |
+    /// |---------------------|-------------------------|
+    /// | [`LimitExceeded`]   | lookback exceeds limit. |
+    /// | [`IllegalArgument`] | invalid buffer, etc.    |
     pub fn get_beacon_randomness(
-        dst: i64,
-        round: i64,
-        entropy_offset: *const u8,
+        tag: i64,
+        epoch: i64,
+        entropy_off: *const u8,
         entropy_len: u32,
     ) -> Result<[u8; RANDOMNESS_LENGTH]>;
 }

--- a/sdk/src/sys/send.rs
+++ b/sdk/src/sys/send.rs
@@ -3,11 +3,27 @@
 #[doc(inline)]
 pub use fvm_shared::sys::out::send::*;
 
+// for documentation links
+#[cfg(doc)]
+use crate::sys::ErrorNumber::*;
+
 super::fvm_syscalls! {
     module = "send";
 
     /// Sends a message to another actor, and returns the exit code and block ID of the return
     /// result.
+    ///
+    /// # Arguments
+    ///
+    /// - `recipient_off` and `recipient_len` specify the location and length of the recipient's
+    ///   address (in wasm memory).
+    /// - `method` is the method number to invoke.
+    /// - `params` is the IPLD block handle of the method parameters.
+    /// - `value_hi` are the "high" bits of the token value to send (little-endian) in attoFIL.
+    /// - `value_lo` are the "high" bits of the token value to send (little-endian) in attoFIL.
+    ///
+    /// **NOTE**: This syscall will transfer `(value_hi << 64) | (value_lo)` attoFIL to the
+    /// recipient.
     ///
     /// # Errors
     ///
@@ -15,13 +31,13 @@ super::fvm_syscalls! {
     /// exceeds some limit, aborts, aborts with an invalid code, etc., the syscall will _succeed_
     /// and the failure will be reflected in the exit code contained in the return value.
     ///
-    /// | Error               | Reason                                               |
-    /// |---------------------|------------------------------------------------------|
-    /// | `NotFound`          | target actor does not exist and cannot be created.   |
-    /// | `InsufficientFunds` | tried to send more FIL than available.               |
-    /// | `InvalidHandle`     | parameters block not found.                          |
-    /// | `LimitExceeded`     | recursion limit reached.                             |
-    /// | `IllegalArgument`   | invalid recipient address buffer.                    |
+    /// | Error                 | Reason                                               |
+    /// |-----------------------|------------------------------------------------------|
+    /// | [`NotFound`]          | target actor does not exist and cannot be created.   |
+    /// | [`InsufficientFunds`] | tried to send more FIL than available.               |
+    /// | [`InvalidHandle`]     | parameters block not found.                          |
+    /// | [`LimitExceeded`]     | recursion limit reached.                             |
+    /// | [`IllegalArgument`]   | invalid recipient address buffer.                    |
     pub fn send(
         recipient_off: *const u8,
         recipient_len: u32,

--- a/sdk/src/sys/sself.rs
+++ b/sdk/src/sys/sself.rs
@@ -1,5 +1,9 @@
 //! Syscalls for querying and modifying the current actor.
 
+// for documentation links
+#[cfg(doc)]
+use crate::sys::ErrorNumber::*;
+
 super::fvm_syscalls! {
     module = "self";
 
@@ -8,22 +12,31 @@ super::fvm_syscalls! {
     /// If the CID doesn't fit in the specified maximum length (and/or the length is 0), this
     /// function returns the required size and does not update the cid buffer.
     ///
+    /// # Arguments
+    ///
+    /// - `cid` is the location in memory where the state-root will be written.
+    /// - `max_cid_len` is length of the output CID buffer.
+    ///
     /// # Errors
     ///
-    /// | Error              | Reason                                             |
-    /// |--------------------|----------------------------------------------------|
-    /// | `IllegalOperation` | actor hasn't set the root yet, or has been deleted |
-    /// | `IllegalArgument`  | if the passed buffer isn't valid, in memory, etc.  |
+    /// | Error                | Reason                                             |
+    /// |----------------------|----------------------------------------------------|
+    /// | [`IllegalOperation`] | actor hasn't set the root yet, or has been deleted |
+    /// | [`IllegalArgument`]  | if the passed buffer isn't valid, in memory, etc.  |
     pub fn root(cid: *mut u8, cid_max_len: u32) -> Result<u32>;
 
     /// Sets the root CID for the calling actor. The new root must be in the reachable set.
     ///
+    /// # Arguments
+    ///
+    /// - `cid` is the location in memory of the new state-root CID.
+    ///
     /// # Errors
     ///
-    /// | Error              | Reason                                         |
-    /// |--------------------|------------------------------------------------|
-    /// | `IllegalOperation` | actor has been deleted                         |
-    /// | `NotFound`         | specified root CID is not in the reachable set |
+    /// | Error                | Reason                                         |
+    /// |----------------------|------------------------------------------------|
+    /// | [`IllegalOperation`] | actor has been deleted                         |
+    /// | [`NotFound`]         | specified root CID is not in the reachable set |
     pub fn set_root(cid: *const u8) -> Result<()>;
 
     /// Gets the current balance for the calling actor.
@@ -36,12 +49,17 @@ super::fvm_syscalls! {
     /// Destroys the calling actor, sending its current balance
     /// to the supplied address, which cannot be itself.
     ///
+    /// # Arguments
+    ///
+    /// - `addr_off` and `addr_len` specify the location and length of beneficiary's address in wasm
+    ///   memory.
+    ///
     /// # Errors
     ///
-    /// | Error             | Reason                                                         |
-    /// |-------------------|----------------------------------------------------------------|
-    /// | `NotFound`        | beneficiary isn't found                                        |
-    /// | `Forbidden`       | beneficiary is not allowed (usually means beneficiary is self) |
-    /// | `IllegalArgument` | if the passed address buffer isn't valid, in memory, etc.      |
+    /// | Error               | Reason                                                         |
+    /// |---------------------|----------------------------------------------------------------|
+    /// | [`NotFound`]        | beneficiary isn't found                                        |
+    /// | [`Forbidden`]       | beneficiary is not allowed (usually means beneficiary is self) |
+    /// | [`IllegalArgument`] | if the passed address buffer isn't valid, in memory, etc.      |
     pub fn self_destruct(addr_off: *const u8, addr_len: u32) -> Result<()>;
 }

--- a/sdk/src/sys/vm.rs
+++ b/sdk/src/sys/vm.rs
@@ -6,8 +6,18 @@ super::fvm_syscalls! {
     /// Abort execution with the given code and message. The code is recorded in the receipt, the
     /// message is for debugging only.
     ///
+    /// # Arguments
+    ///
+    /// - `code` is the [`ExitCode`][fvm_shared::error::ExitCode] to abort with. If this code is
+    ///   less than the [minimum "user" exit
+    ///   code][fvm_shared::error::ExitCode::FIRST_USER_EXIT_CODE], it will be replaced with
+    ///   [`SYS_ILLEGAL_EXIT_CODE`][fvm_shared::error::ExitCode::SYS_ILLEGAL_EXIT_CODE].
+    /// - `message_off` and `message_len` specify the offset and length (in wasm memory) of an
+    ///   optional debug message associated with this abort. These parameters may be null/0 and will
+    ///   be ignored if invalid.
+    ///
     /// # Errors
     ///
     /// None. This function doesn't return.
-    pub fn abort(code: u32, message: *const u8, message_len: u32) -> !;
+    pub fn abort(code: u32, message_off: *const u8, message_len: u32) -> !;
 }

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -111,19 +111,38 @@ impl ExitCode {
     // pub const RESERVED_31: ExitCode = ExitCode::new(31);
 }
 
+/// When a syscall fails, it returns an `ErrorNumber` to indicate why. The syscalls themselves
+/// include documentation on _which_ syscall errors they can be expected to return, and what they
+/// mean in the context of the syscall.
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, Debug, PartialEq, Error, FromPrimitive)]
 pub enum ErrorNumber {
+    /// A syscall parameters was invalid.
     IllegalArgument = 1,
+    /// The actor is not in the correct state to perform the requested operation.
     IllegalOperation = 2,
+    /// This syscall would exceed some system limit (memory, lookback, call depth, etc.).
     LimitExceeded = 3,
+    /// A system-level assertion has failed.
+    ///
+    /// # Note
+    ///
+    /// Non-system actors should never receive this error number. A system-level assertion will
+    /// cause the entire message to fail.
     AssertionFailed = 4,
+    /// There were insufficient funds to complete the requested operation.
     InsufficientFunds = 5,
+    /// A resource was not found.
     NotFound = 6,
+    /// The specified IPLD block handle was invalid.
     InvalidHandle = 7,
+    /// The requested CID shape (multihash codec, multihash length) isn't supported.
     IllegalCid = 8,
+    /// The requested IPLD codec isn't supported.
     IllegalCodec = 9,
+    /// The IPLD block did not match the specified IPLD codec.
     Serialization = 10,
+    /// The operation is forbidden.
     Forbidden = 11,
 }
 


### PR DESCRIPTION
Rendered: https://ipfs.fleek.co/ipfs/bafybeicdt5pghmuyzvlpspxmvyaaroio3rfqxw2whcwxmed5kvqtfphuui/fvm_sdk/sys/index.html

1. Document the mapping between syscalls and wasm functions.
2. Linkify error numbers in syscall documentation.
3. Remove some incorrectly documented error numbers.
4. Exhaustively (almost all) arguments.
5. Document the syscall error number enum.
6. Link to the ABI documentation in the spec.