### PR TITLE
fix: abort if aborting fails

### DIFF
--- a/sdk/src/sys/mod.rs
+++ b/sdk/src/sys/mod.rs
@@ -156,7 +156,12 @@ macro_rules! fvm_syscalls {
             }
 
             syscall($($args),*);
-            panic!(concat!("syscall ", stringify!($name), " should not have returned"))
+
+            // This should be unreachable unless the syscall has a bug. We abort instead of panicing
+            // to help the compiler optimize. It has no way of _proving_ that the syscall doesn't
+            // return, so this gives it a way to prove that even if the syscall does return, this
+            // function won't.
+            std::process::abort()
         }
         $crate::sys::fvm_syscalls! {
             module = $module;


### PR DESCRIPTION
If the fvm::abort syscall fails, abort from within rust instead of panicing. This will compile to an "unreachable" instruction in wasm and _won't_ invoke the panic processing logic.