### PR TITLE
fix: gas: charge for execunits based on snapshot

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -751,8 +751,8 @@ impl<C> GasOps for DefaultKernel<C>
 where
     C: CallManager,
 {
-    fn gas_available(&self) -> i64 {
-        self.call_manager.gas_tracker().gas_available()
+    fn gas_used(&self) -> i64 {
+        self.call_manager.gas_tracker().gas_used()
     }
 
     fn charge_gas(&mut self, name: &str, compute: i64) -> Result<()> {

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -219,8 +219,8 @@ pub trait CircSupplyOps {
 ///  In the future (Phase 1), this should disappear and be replaced by gas instrumentation
 ///  at the WASM level.
 pub trait GasOps {
-    /// GasAvailable return the gas available for the transaction.
-    fn gas_available(&self) -> i64;
+    /// GasUsed return the gas used by the transaction so far.
+    fn gas_used(&self) -> i64;
 
     /// ChargeGas charges specified amount of `gas` for execution.
     /// `name` provides information about gas charging point

--- a/fvm/src/syscalls/bind.rs
+++ b/fvm/src/syscalls/bind.rs
@@ -106,13 +106,11 @@ fn charge_exec_units_for_gas(caller: &mut Caller<InvocationData<impl Kernel>>) -
         caller.consume_fuel(u64::try_from(exec_units).unwrap_or(0))?;
     }
 
-    let gas_available = caller.data().kernel.gas_available();
+    let gas_used = caller.data().kernel.gas_used();
     let fuel_consumed = caller
         .fuel_consumed()
         .ok_or_else(|| Trap::new("expected to find exec_units consumed"))?;
-    caller
-        .data_mut()
-        .set_snapshots(gas_available, fuel_consumed);
+    caller.data_mut().set_snapshots(gas_used, fuel_consumed);
     Ok(())
 }
 

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -80,7 +80,9 @@ impl<K: Kernel> InvocationData<K> {
             "exec_units",
             self.kernel
                 .price_list()
-                .on_consume_exec_units(exec_units_consumed)
+                .on_consume_exec_units(
+                    exec_units_consumed.saturating_sub(self.exec_units_consumed_snapshot),
+                )
                 .total(),
         )?;
         self.set_snapshots(self.kernel.gas_available(), exec_units_consumed);

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -488,8 +488,8 @@ where
     C: CallManager<Machine = TestMachine<M>>,
     K: Kernel<CallManager = TestCallManager<C>>,
 {
-    fn gas_available(&self) -> i64 {
-        self.0.gas_available()
+    fn gas_used(&self) -> i64 {
+        self.0.gas_used()
     }
 
     fn charge_gas(&mut self, name: &str, compute: i64) -> Result<()> {


### PR DESCRIPTION
Commit #1: I think this got clobbered in one of the review periods. 
Commit #2: The GasTracker's gas_available doesn't actually get updated through execution, so we should snapshot and consume based on gas_used instead.

Thanks to AWade for the catches.