### PR TITLE
feat: raw signatures in syscalls

### DIFF
--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -5,7 +5,7 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::randomness::DomainSeparationTag;
-use fvm_shared::crypto::signature::Signature;
+use fvm_shared::crypto::signature::SignatureType;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::{Randomness, RANDOMNESS_LENGTH};
@@ -234,7 +234,8 @@ pub trait CryptoOps {
     /// Verifies that a signature is valid for an address and plaintext.
     fn verify_signature(
         &mut self,
-        signature: &Signature,
+        sig_type: SignatureType,
+        signature: &[u8],
         signer: &Address,
         plaintext: &[u8],
     ) -> Result<bool>;

--- a/fvm/src/syscalls/bind.rs
+++ b/fvm/src/syscalls/bind.rs
@@ -211,3 +211,4 @@ impl_bind_syscalls!(A B C);
 impl_bind_syscalls!(A B C D);
 impl_bind_syscalls!(A B C D E);
 impl_bind_syscalls!(A B C D E F);
+impl_bind_syscalls!(A B C D E F G);

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -19,14 +19,14 @@ pub fn verify_signature(
     signer: &Address,
     plaintext: &[u8],
 ) -> SyscallResult<bool> {
-    let signature = signature
-        .marshal_cbor()
-        .expect("failed to marshal signature");
+    let sig_type = signature.signature_type();
+    let sig_bytes = signature.bytes();
     let signer = signer.to_bytes();
     unsafe {
         sys::crypto::verify_signature(
-            signature.as_ptr(),
-            signature.len() as u32,
+            sig_type as u32,
+            sig_bytes.as_ptr(),
+            sig_bytes.len() as u32,
             signer.as_ptr(),
             signer.len() as u32,
             plaintext.as_ptr(),

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -26,6 +26,7 @@ super::fvm_syscalls! {
     /// |---------------------|------------------------------------------------------|
     /// | [`IllegalArgument`] | signature, address, or plaintext buffers are invalid |
     pub fn verify_signature(
+        sig_type: u32,
         sig_off: *const u8,
         sig_len: u32,
         addr_off: *const u8,

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -17,7 +17,7 @@ use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::randomness::DomainSeparationTag;
-use fvm_shared::crypto::signature::Signature;
+use fvm_shared::crypto::signature::SignatureType;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
@@ -413,11 +413,13 @@ where
     // forwarded
     fn verify_signature(
         &mut self,
-        signature: &Signature,
+        sig_type: SignatureType,
+        signature: &[u8],
         signer: &Address,
         plaintext: &[u8],
     ) -> Result<bool> {
-        self.0.verify_signature(signature, signer, plaintext)
+        self.0
+            .verify_signature(sig_type, signature, signer, plaintext)
     }
 
     // NOT forwarded


### PR DESCRIPTION
Don't pass signatures as cbor-encoded objects with signature types. Instead, pass the type and the signature bytes separately.

This change _also_ avoids copying the signature when verifying it.

fixes https://github.com/filecoin-project/ref-fvm/issues/511