### PR TITLE
feat: parameterize the hash syscall over the hash type

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -474,9 +474,17 @@ where
         Ok(signature.verify(plaintext, &signing_addr).is_ok())
     }
 
-    fn hash_blake2b(&mut self, data: &[u8]) -> Result<[u8; 32]> {
+    fn hash(&mut self, code: u64, data: &[u8]) -> Result<[u8; 32]> {
+        const BLAKE2B_256: u64 = 0xb220;
+
         self.call_manager
             .charge_gas(self.call_manager.price_list().on_hashing(data.len()))?;
+
+        // We only support blake2b for now, but want to support others in the future.
+        if code != BLAKE2B_256 {
+            return Err(syscall_error!(IllegalArgument; "unsupported hash code {}", code).into());
+        }
+
         let digest = blake2b_simd::Params::new()
             .hash_length(32)
             .to_state()

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -239,8 +239,11 @@ pub trait CryptoOps {
         plaintext: &[u8],
     ) -> Result<bool>;
 
-    /// Hashes input data using blake2b with 256 bit output.
-    fn hash_blake2b(&mut self, data: &[u8]) -> Result<[u8; 32]>;
+    /// Hashes input `data_in` using with the specified hash function, writing the output to
+    /// `digest_out`, returning the size of the digest written to `digest_out`. If `digest_out` is
+    /// to small to fit the entire digest, it will be truncated. If too large, the leftover space
+    /// will not be overwritten.
+    fn hash(&mut self, code: u64, data: &[u8]) -> Result<[u8; 32]>;
 
     /// Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.
     fn compute_unsealed_sector_cid(

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -146,7 +146,7 @@ pub fn bind_syscalls(
     )?;
 
     linker.bind("crypto", "verify_signature", crypto::verify_signature)?;
-    linker.bind("crypto", "hash_blake2b", crypto::hash_blake2b)?;
+    linker.bind("crypto", "hash", crypto::hash)?;
     linker.bind("crypto", "verify_seal", crypto::verify_seal)?;
     linker.bind("crypto", "verify_post", crypto::verify_post)?;
     linker.bind(

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -39,9 +39,20 @@ pub fn verify_signature(
 /// Hashes input data using blake2b with 256 bit output.
 #[allow(unused)]
 pub fn hash_blake2b(data: &[u8]) -> [u8; 32] {
+    const BLAKE2B_256: u64 = 0xb220;
     // This can only fail if we manage to pass in corrupted memory.
-    unsafe { sys::crypto::hash_blake2b(data.as_ptr(), data.len() as u32) }
-        .expect("failed to compute blake2b hash")
+    let mut ret = [0u8; 32];
+    unsafe {
+        sys::crypto::hash(
+            BLAKE2B_256,
+            data.as_ptr(),
+            data.len() as u32,
+            ret.as_mut_ptr(),
+            32,
+        )
+    }
+    .expect("failed to compute blake2b hash");
+    ret
 }
 
 /// Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -34,23 +34,30 @@ super::fvm_syscalls! {
         plaintext_len: u32,
     ) -> Result<i32>;
 
-    /// Hashes input data using blake2b with 256 bit output.
+    /// Hashes input data using the specified hash function. The digest is written to the passed
+    /// digest buffer and truncated to `digest_len`.
     ///
-    /// Returns a 32-byte hash digest.
+    /// Returns the length of the digest written to the digest buffer.
     ///
     /// # Arguments
     ///
     /// - `data_off` and `data_len` specify location and length of the data to be hashed.
+    /// - `digest_off` and `digest_len` specify the location and length of the output digest buffer.
+    ///
+    /// **NOTE:** The digest and input buffers _may_ overlap.
     ///
     /// # Errors
     ///
     /// | Error               | Reason                                          |
     /// |---------------------|-------------------------------------------------|
     /// | [`IllegalArgument`] | the input buffer does not point to valid memory |
-    pub fn hash_blake2b(
+    pub fn hash(
+        hash_code: u64,
         data_off: *const u8,
         data_len: u32,
-    ) -> Result<[u8; 32]>;
+        digest_off: *mut u8,
+        digest_len: u32,
+    ) -> Result<u32>;
 
     /// Computes an unsealed sector CID (CommD) from its constituent piece CIDs
     /// (CommPs) and sizes.

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -397,8 +397,8 @@ where
     K: Kernel<CallManager = TestCallManager<C>>,
 {
     // forwarded
-    fn hash_blake2b(&mut self, data: &[u8]) -> Result<[u8; 32]> {
-        self.0.hash_blake2b(data)
+    fn hash(&mut self, code: u64, data: &[u8]) -> Result<[u8; 32]> {
+        self.0.hash(code, data)
     }
 
     // forwarded


### PR DESCRIPTION
This makes it a bit easier to add support for additional hash functions later. We could just have many syscalls, but parameterizing over a multicodec makes it easier to implement/use multihash libraries in actors.

fixes #270