### PR TITLE
chore: release for cbor library switch

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -20,11 +20,11 @@ ahash = "0.7"
 num-derive = "0.3.3"
 cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.1", default-features = false }
-fvm_shared = { version = "0.6.0", path = "../shared", features = ["crypto"] }
-fvm_ipld_hamt = { version = "0.5.0", path = "../ipld/hamt"}
-fvm_ipld_amt = { version = "0.4.0", path = "../ipld/amt"}
+fvm_shared = { version = "0.6.1", path = "../shared", features = ["crypto"] }
+fvm_ipld_hamt = { version = "0.5.1", path = "../ipld/hamt"}
+fvm_ipld_amt = { version = "0.4.1", path = "../ipld/amt"}
 fvm_ipld_blockstore = { version = "0.1.0", path = "../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.1.0", path = "../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.2.0", path = "../ipld/encoding" }
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = "0.5"
 serde_repr = "0.1"

--- a/ipld/amt/CHANGELOG.md
+++ b/ipld/amt/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+
+## 0.4.1
+
+- Update `fvm_ipld_encoding` to 0.2.0.

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_amt"
 description = "Sharded IPLD Array implementation."
-version = "0.4.0"
+version = "0.4.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -16,7 +16,7 @@ ahash = { version = "0.7", optional = true }
 itertools = "0.10"
 anyhow = "1.0.51"
 fvm_ipld_blockstore = { version = "0.1", path = "../blockstore" }
-fvm_ipld_encoding = { version = "0.1", path = "../encoding" }
+fvm_ipld_encoding = { version = "0.2", path = "../encoding" }
 
 [features]
 go-interop = ["ahash"]

--- a/ipld/bitfield/CHANGELOG.md
+++ b/ipld/bitfield/CHANGELOG.md
@@ -3,3 +3,7 @@
 Changes to Filecoin's Bitfield library.
 
 ## [Unreleased]
+
+## 0.5.1 [2022-04-29]
+
+- Update `fvm_ipld_encoding`.

--- a/ipld/bitfield/Cargo.toml
+++ b/ipld/bitfield/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_bitfield"
 description = "Bitfield logic for use in Filecoin actors"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
 thiserror = "1.0.30"
 arbitrary = { version = "1.1.0", optional = true}
-fvm_ipld_encoding = { version = "0.1", path = "../encoding" }
+fvm_ipld_encoding = { version = "0.2", path = "../encoding" }
 
 [dev-dependencies]
 rand_xorshift = "0.2.0"

--- a/ipld/car/CHANGELOG.md
+++ b/ipld/car/CHANGELOG.md
@@ -3,3 +3,7 @@
 Changes to the FVM's CAR implementation.
 
 ## [Unreleased]
+
+## 0.4.1
+
+- Update `fvm_ipld_encoding` to 0.2.0.

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_car"
 description = "IPLD CAR handling library"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ thiserror = "1.0"
 futures = "0.3.5"
 integer-encoding = { version = "3.0", features = ["futures_async"] }
 fvm_ipld_blockstore = { version = "0.1", path = "../blockstore" }
-fvm_ipld_encoding = { version = "0.1", path = "../encoding" }
+fvm_ipld_encoding = { version = "0.2", path = "../encoding" }
 
 [dev-dependencies]
 async-std = { version = "1.9", features = ["attributes"] }

--- a/ipld/encoding/CHANGELOG.md
+++ b/ipld/encoding/CHANGELOG.md
@@ -3,3 +3,9 @@
 Changes to the FVM's shared encoding utilities.
 
 ## [Unreleased]
+
+## 0.2.0 [2022-04-29]
+
+Update `serde_ipld_cbor` to 0.2.0, switching to cbor4ii.
+
+The only breaking change is that `from_reader` now requires `io::BufRead`, not just `io::Read`.

--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_encoding"
 description = "Sharded IPLD encoding."
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"

--- a/ipld/hamt/CHANGELOG.md
+++ b/ipld/hamt/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 0.5.1
+
+- Update `fvm_ipld_encoding` to 0.2.0.
+
 ## 0.5.0
 
 - BREAKING: update fvm_shared to 0.5.1 for error refactor.

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_hamt"
 description = "Sharded IPLD HashMap implementation."
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -19,7 +19,7 @@ once_cell = "1.5"
 forest_hash_utils = "0.1"
 anyhow = "1.0.51"
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
-fvm_ipld_encoding = { version = "0.1", path = "../encoding" }
+fvm_ipld_encoding = { version = "0.2", path = "../encoding" }
 fvm_ipld_blockstore = { version = "0.1", path = "../blockstore" }
 
 [features]

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Added _cfg = "testing"_ on `testing` module.
 - Added a `testing` module to access `assert_*` macros to be able to do assertions in actors code.
-- Update `fvm_ipld_encoding` for CBOR library switch.
+- Update `fvm_ipld_encoding` to 0.2.0 for CBOR library switch.
 
 ## 0.6.0 [2022-04-14]
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## [Unreleased]
 
+## 0.6.1 [2022-04-29]
+
 - Added _cfg = "testing"_ on `testing` module.
 - Added a `testing` module to access `assert_*` macros to be able to do assertions in actors code.
+- Update `fvm_ipld_encoding` for CBOR library switch.
 
 ## 0.6.0 [2022-04-14]
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -12,13 +12,13 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { version = "0.8.2", default-features = false }
-fvm_shared = { version = "0.6.0", path = "../shared" }
+fvm_shared = { version = "0.6.1", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
 log = "0.4.14"
 thiserror = "1.0.30"
-fvm_ipld_encoding = { version = "0.1", path = "../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.2", path = "../ipld/encoding" }
 
 [features]
 default = ["debug"]

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## Unreleased
+## [Unreleased]
 
-- Added `testing` feature to have `Default` derive on `Message`. Extended this feature to `Address` and `Payload`. 
+## 0.6.1 [2022-04-29]
+
+- Added `testing` feature to have `Default` derive on `Message`. Extended this feature to `Address` and `Payload`.
+- Improve `ErrorNumber` documentation.
+- Update `fvm_ipld_encoding` for the cbor encoder switch.
 
 ## 0.6.0 [2022-04-14]
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
@@ -26,7 +26,7 @@ unsigned-varint = "0.7.1"
 anyhow = "1.0.51"
 bimap = { version = "0.6.2", features = ["serde"] }
 fvm_ipld_blockstore = { version = "0.1", path = "../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.1", path = "../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.2", path = "../ipld/encoding" }
 serde = { version = "1", default-features = false }
 serde_tuple = "0.5"
 serde_repr = "0.1"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -10,12 +10,12 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
 fvm = { version = "0.7.1", path = "../../fvm", default-features = false }
-fvm_shared = { version = "0.6.0", path = "../../shared" }
-fvm_ipld_hamt = { version = "0.5.0", path = "../../ipld/hamt"}
-fvm_ipld_amt = { version = "0.4.0", path = "../../ipld/amt"}
-fvm_ipld_car = { version = "0.4.0", path = "../../ipld/car" }
+fvm_shared = { version = "0.6.1", path = "../../shared" }
+fvm_ipld_hamt = { version = "0.5.1", path = "../../ipld/hamt"}
+fvm_ipld_amt = { version = "0.4.1", path = "../../ipld/amt"}
+fvm_ipld_car = { version = "0.4.1", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.0", path = "../../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.1.0", path = "../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.2.0", path = "../../ipld/encoding" }
 
 anyhow = "1.0.47"
 thiserror = "1.0.30"

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -7,12 +7,12 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
 fvm = { version = "0.7.1", path = "../../fvm", default-features = false }
-fvm_shared = { version = "0.6.0", path = "../../shared" }
-fvm_ipld_hamt = { version = "0.5.0", path = "../../ipld/hamt"}
-fvm_ipld_amt = { version = "0.4.0", path = "../../ipld/amt"}
-fvm_ipld_car = { version = "0.4.0", path = "../../ipld/car" }
+fvm_shared = { version = "0.6.1", path = "../../shared" }
+fvm_ipld_hamt = { version = "0.5.1", path = "../../ipld/hamt"}
+fvm_ipld_amt = { version = "0.4.1", path = "../../ipld/amt"}
+fvm_ipld_car = { version = "0.4.1", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.0", path = "../../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.1.0", path = "../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.2.0", path = "../../ipld/encoding" }
 
 actors-v6 = { version = "6.1.1", package = "fil_builtin_actors_bundle" }
 actors-v7 = { version = "7.1.2", package = "fil_builtin_actors_bundle" }

--- a/testing/integration/tests/fil-hello-world-actor/Cargo.toml
+++ b/testing/integration/tests/fil-hello-world-actor/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fvm_sdk = { version = "0.6.0", path = "../../../../sdk" }
-fvm_shared = { version = "0.6.0", path = "../../../../shared" }
+fvm_sdk = { version = "0.6.1", path = "../../../../sdk" }
+fvm_shared = { version = "0.6.1", path = "../../../../shared" }
 
 
 [build-dependencies]


### PR DESCRIPTION
Unfortunately, this requires a bunch of releases because the change in fvm_ipld_encoding is technically a breaking one. But _most_ of these releases are small patch releases.

- fvm_shared - 0.6.1
- fvm_ipld_car - 0.4.1
- fvm_ipld_hamt - 0.5.1
- fvm_ipld_amt - 0.4.1
- fvm_ipld_encoding - 0.2.0
- fvm_sdk - 0.6.1