### PR TITLE
chore: update actors in conformance tests

### DIFF
--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -47,8 +47,8 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 walkdir = "2.3"
 regex = { version = "1.0" }
 ittapi-rs = { version = "0.1.6", optional = true }
-actors-v6 = { version = "~6.2", package = "fil_builtin_actors_bundle" }
-actors-v7 = { version = "~7.2", package = "fil_builtin_actors_bundle" }
+actors-v6 = { version = "~6.3", package = "fil_builtin_actors_bundle" }
+actors-v7 = { version = "~7.3", package = "fil_builtin_actors_bundle" }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [features]


### PR DESCRIPTION
Switches actors to the cbor4ii-backed encoding library.