### PR TITLE
fix: make things independent of the Multihash code table

### DIFF
--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -21,7 +21,9 @@ use crate::state_tree::{ActorState, StateTree};
 use crate::syscall_error;
 use crate::system_actor::State as SystemActorState;
 
-pub struct DefaultMachine<B, E> {
+const DEFAULT_MULTIHASH_ALLOC_SIZE: usize = 64;
+
+pub struct DefaultMachine<B: Blockstore, E> {
     /// The initial execution context for this epoch.
     context: MachineContext,
     /// The WASM engine is created on construction of the DefaultMachine, and
@@ -34,7 +36,7 @@ pub struct DefaultMachine<B, E> {
     /// execution as the call stack for every message concludes.
     ///
     /// Owned.
-    state_tree: StateTree<BufferedBlockstore<B>>,
+    state_tree: StateTree<BufferedBlockstore<B, DEFAULT_MULTIHASH_ALLOC_SIZE>>,
     /// Mapping of CIDs to builtin actor types.
     builtin_actors: Manifest,
 }
@@ -130,7 +132,7 @@ where
     B: Blockstore + 'static,
     E: Externs + 'static,
 {
-    type Blockstore = BufferedBlockstore<B>;
+    type Blockstore = BufferedBlockstore<B, DEFAULT_MULTIHASH_ALLOC_SIZE>;
     type Externs = E;
 
     fn engine(&self) -> &Engine {

--- a/ipld/amt/src/lib.rs
+++ b/ipld/amt/src/lib.rs
@@ -25,6 +25,8 @@ const MAX_HEIGHT: u32 = 64;
 /// don't overflow u64::MAX when computing the length.
 pub const MAX_INDEX: u64 = (std::u64::MAX - 1) as u64;
 
+const BLAKE2B_256: u64 = 0xb220;
+
 fn nodes_for_height(bit_width: u32, height: u32) -> u64 {
     let height_log_two = bit_width as u64 * height as u64;
     if height_log_two >= 64 {

--- a/ipld/amt/src/root.rs
+++ b/ipld/amt/src/root.rs
@@ -9,14 +9,14 @@ use crate::{init_sized_vec, Node};
 
 /// Root of an AMT vector, can be serialized and keeps track of height and count
 #[derive(PartialEq, Debug)]
-pub(super) struct Root<V> {
+pub(super) struct Root<V, const S: usize> {
     pub bit_width: u32,
     pub height: u32,
     pub count: u64,
-    pub node: Node<V>,
+    pub node: Node<V, S>,
 }
 
-impl<V> Root<V> {
+impl<V, const S: usize> Root<V, S> {
     pub(super) fn new(bit_width: u32) -> Self {
         Self {
             bit_width,
@@ -29,19 +29,19 @@ impl<V> Root<V> {
     }
 }
 
-impl<V> Serialize for Root<V>
+impl<V, const S: usize> Serialize for Root<V, S>
 where
     V: Serialize,
 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    fn serialize<Ser>(&self, s: Ser) -> Result<Ser::Ok, Ser::Error>
     where
-        S: ser::Serializer,
+        Ser: ser::Serializer,
     {
         (&self.bit_width, &self.height, &self.count, &self.node).serialize(s)
     }
 }
 
-impl<'de, V> Deserialize<'de> for Root<V>
+impl<'de, V, const S: usize> Deserialize<'de> for Root<V, S>
 where
     V: Deserialize<'de>,
 {
@@ -49,7 +49,7 @@ where
     where
         D: de::Deserializer<'de>,
     {
-        let (bit_width, height, count, node): (_, _, _, CollapsedNode<V>) =
+        let (bit_width, height, count, node): (_, _, _, CollapsedNode<V, S>) =
             Deserialize::deserialize(deserializer)?;
         Ok(Self {
             bit_width,

--- a/ipld/blockstore/Cargo.toml
+++ b/ipld/blockstore/Cargo.toml
@@ -10,9 +10,8 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 [dependencies]
 cid = { version = "0.8.2", default-features = false, features = ["serde-codec", "std"] }
 anyhow = "1.0.51"
-# multihash is also re-exported by `cid`. Having `multihash` here as a
-# depdendency is needed to enable the features of the re-export.
-multihash = { version = "0.16.1", default-features = false, features = ["multihash-impl"] }
+# Only needed for the `MemoryBlockStore`.
+multihash = { version = "0.16.2", default-features = false, features = ["multihash-impl", "blake2b"] }
 
 [features]
 default = []

--- a/ipld/blockstore/src/block.rs
+++ b/ipld/blockstore/src/block.rs
@@ -1,5 +1,5 @@
-use cid::multihash::{self, MultihashDigest};
-use cid::Cid;
+use cid::multihash::MultihashDigest;
+use cid::CidGeneric;
 
 /// Block represents a typed (i.e., with codec) IPLD block.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -23,8 +23,11 @@ where
         Self { codec, data }
     }
 
-    pub fn cid(&self, mh_code: multihash::Code) -> Cid {
-        Cid::new_v1(self.codec, mh_code.digest(self.data.as_ref()))
+    pub fn cid<H, const S: usize>(&self, mh_code: H) -> CidGeneric<S>
+    where
+        H: MultihashDigest<S>,
+    {
+        CidGeneric::new_v1(self.codec, mh_code.digest(self.data.as_ref()))
     }
 
     #[allow(clippy::len_without_is_empty)]

--- a/ipld/blockstore/src/memory.rs
+++ b/ipld/blockstore/src/memory.rs
@@ -2,31 +2,33 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 
 use anyhow::Result;
-use cid::Cid;
+use cid::CidGeneric;
 
-use super::Blockstore;
+use super::{Blockstore, DEFAULT_MULTIHASH_ALLOC_SIZE};
 
 #[derive(Debug, Default, Clone)]
-pub struct MemoryBlockstore {
-    blocks: RefCell<HashMap<Cid, Vec<u8>>>,
+pub struct MemoryBlockstore<const S: usize = DEFAULT_MULTIHASH_ALLOC_SIZE> {
+    blocks: RefCell<HashMap<CidGeneric<S>, Vec<u8>>>,
 }
 
-impl MemoryBlockstore {
+impl<const S: usize> MemoryBlockstore<S> {
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl Blockstore for MemoryBlockstore {
-    fn has(&self, k: &Cid) -> Result<bool> {
+impl Blockstore<DEFAULT_MULTIHASH_ALLOC_SIZE> for MemoryBlockstore<DEFAULT_MULTIHASH_ALLOC_SIZE> {
+    type CodeTable = multihash::Code;
+
+    fn has(&self, k: &CidGeneric<DEFAULT_MULTIHASH_ALLOC_SIZE>) -> Result<bool> {
         Ok(self.blocks.borrow().contains_key(k))
     }
 
-    fn get(&self, k: &Cid) -> Result<Option<Vec<u8>>> {
+    fn get(&self, k: &CidGeneric<DEFAULT_MULTIHASH_ALLOC_SIZE>) -> Result<Option<Vec<u8>>> {
         Ok(self.blocks.borrow().get(k).cloned())
     }
 
-    fn put_keyed(&self, k: &Cid, block: &[u8]) -> Result<()> {
+    fn put_keyed(&self, k: &CidGeneric<DEFAULT_MULTIHASH_ALLOC_SIZE>, block: &[u8]) -> Result<()> {
         self.blocks.borrow_mut().insert(*k, block.into());
         Ok(())
     }

--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -17,8 +17,7 @@ cid = { version = "0.8.2", default-features = false, features = ["serde-codec", 
 thiserror = "1.0"
 anyhow = "1.0.56"
 fvm_ipld_blockstore = { version = "0.1", path = "../blockstore" }
-# multihash is also re-exported by `cid`. Having `multihash` here as a
-# depdendency is needed to enable the features of the re-export.
+# Only needed for the `Cbor` trait.
 multihash = { version = "0.16.1", default-features = false, features = ["blake2b", "multihash-impl"] }
 
 [features]

--- a/ipld/encoding/src/cbor.rs
+++ b/ipld/encoding/src/cbor.rs
@@ -4,7 +4,7 @@
 use std::ops::Deref;
 use std::rc::Rc;
 
-use cid::{multihash, Cid};
+use cid::Cid;
 use serde::{Deserialize, Serialize};
 
 use super::errors::Error;

--- a/ipld/encoding/src/cbor_store.rs
+++ b/ipld/encoding/src/cbor_store.rs
@@ -1,13 +1,13 @@
-use cid::{multihash, Cid};
+use cid::CidGeneric;
 use fvm_ipld_blockstore::{Block, Blockstore};
 use serde::{de, ser};
 
 use crate::DAG_CBOR;
 
 /// Wrapper for database to handle inserting and retrieving ipld data with Cids
-pub trait CborStore: Blockstore + Sized {
+pub trait CborStore<const S: usize>: Blockstore<S> + Sized {
     /// Get typed object from block store by Cid.
-    fn get_cbor<T>(&self, cid: &Cid) -> anyhow::Result<Option<T>>
+    fn get_cbor<T>(&self, cid: &CidGeneric<S>) -> anyhow::Result<Option<T>>
     where
         T: de::DeserializeOwned,
     {
@@ -21,9 +21,9 @@ pub trait CborStore: Blockstore + Sized {
     }
 
     /// Put an object in the block store and return the Cid identifier.
-    fn put_cbor<S>(&self, obj: &S, code: multihash::Code) -> anyhow::Result<Cid>
+    fn put_cbor<Ser>(&self, obj: &Ser, code: Self::CodeTable) -> anyhow::Result<CidGeneric<S>>
     where
-        S: ser::Serialize,
+        Ser: ser::Serialize,
     {
         let bytes = crate::to_vec(obj)?;
         self.put(
@@ -36,4 +36,4 @@ pub trait CborStore: Blockstore + Sized {
     }
 }
 
-impl<T: Blockstore> CborStore for T {}
+impl<const S: usize, T: Blockstore<S>> CborStore<S> for T {}

--- a/ipld/hamt/src/lib.rs
+++ b/ipld/hamt/src/lib.rs
@@ -31,6 +31,8 @@ const MAX_ARRAY_WIDTH: usize = 3;
 /// Default bit width for indexing a hash at each depth level
 const DEFAULT_BIT_WIDTH: u32 = 8;
 
+const BLAKE2B_256: u64 = 0xb220;
+
 type HashedKey = [u8; 32];
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -46,6 +46,9 @@ pub const IPLD_RAW: u64 = 0x55;
 /// Multihash code for the identity hash function.
 pub const IDENTITY_HASH: u64 = 0x0;
 
+/// Multihash code for the Blake2b 256-bit hash function.
+pub const BLAKE2B_256: u64 = 0xb220;
+
 /// Identifier for Actors, includes builtin and initialized actors
 pub type ActorID = u64;
 

--- a/testing/integration/src/builtin.rs
+++ b/testing/integration/src/builtin.rs
@@ -58,7 +58,7 @@ pub fn fetch_builtin_code_cid(
 }
 
 pub fn set_sys_actor(
-    state_tree: &mut StateTree<impl Blockstore>,
+    state_tree: &mut StateTree<impl Blockstore<CodeTable = Code>>,
     sys_state: system_actor::State,
     sys_code_cid: Cid,
 ) -> Result<()> {
@@ -80,7 +80,7 @@ pub fn set_sys_actor(
 }
 
 pub fn set_init_actor(
-    state_tree: &mut StateTree<impl Blockstore>,
+    state_tree: &mut StateTree<impl Blockstore<CodeTable = Code>>,
     init_code_cid: Cid,
     init_state: init_actor::State,
 ) -> Result<()> {

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -173,7 +173,7 @@ impl Tester {
     }
 
     /// Get blockstore
-    pub fn blockstore(&self) -> &dyn Blockstore {
+    pub fn blockstore(&self) -> &dyn Blockstore<CodeTable = multihash::Code> {
         if self.executor.is_some() {
             self.executor.as_ref().unwrap().blockstore()
         } else {
@@ -184,7 +184,7 @@ impl Tester {
 /// Inserts the specified number of accounts in the state tree, all with 1000 FIL,
 /// returning their IDs and Addresses.
 fn put_secp256k1_accounts<const N: usize>(
-    state_tree: &mut StateTree<impl Blockstore>,
+    state_tree: &mut StateTree<impl Blockstore<CodeTable = Code>>,
     account_code_cid: Cid,
 ) -> Result<[Account; N]> {
     use libsecp256k1::{PublicKey, SecretKey};


### PR DESCRIPTION
It should now be possible to specify your own Multihash code
table.

@Stebalien this one is for you. Please let me know if this is something we want to tackle and whether it's the right direction. Ideally I'd like to use the default alloc value as little as possible and make it explicit most of the time.

It currently build, but I haven't even tried to compile the tests yet, as I'd like to get basic feedback, before I start making everything pretty.