### PR TITLE
propagate all gas outputs in ApplyRet

### DIFF
--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -5,6 +5,7 @@ use std::fmt::Display;
 pub use default::DefaultExecutor;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::bigint::{BigInt, Sign};
+use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::message::Message;
 use fvm_shared::receipt::Receipt;
@@ -70,6 +71,14 @@ pub struct ApplyRet {
     pub penalty: BigInt,
     /// Tip given to miner from message.
     pub miner_tip: BigInt,
+
+    // Gas stuffs
+    pub base_fee_burn: TokenAmount,
+    pub over_estimation_burn: TokenAmount,
+    pub refund: TokenAmount,
+    pub gas_refund: i64,
+    pub gas_burned: i64,
+
     /// Additional failure information for debugging, if any.
     pub failure_info: Option<ApplyFailure>,
     /// Execution trace information, for debugging.
@@ -90,8 +99,13 @@ impl ApplyRet {
                 gas_used: 0,
             },
             penalty: miner_penalty,
-            failure_info: Some(ApplyFailure::PreValidation(message.into())),
             miner_tip: BigInt::zero(),
+            base_fee_burn: TokenAmount::from(0),
+            over_estimation_burn: TokenAmount::from(0),
+            refund: TokenAmount::from(0),
+            gas_refund: 0,
+            gas_burned: 0,
+            failure_info: Some(ApplyFailure::PreValidation(message.into())),
             exec_trace: vec![],
         }
     }

--- a/fvm/src/system_actor.rs
+++ b/fvm/src/system_actor.rs
@@ -1,16 +1,16 @@
 use anyhow::Context;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
 use fvm_ipld_encoding::{Cbor, CborStore};
 use fvm_shared::address::Address;
-use serde::{Deserialize, Serialize};
 
 use crate::kernel::{ClassifyResult, Result};
 use crate::state_tree::{ActorState, StateTree};
 
 pub const SYSTEM_ACTOR_ADDR: Address = Address::new_id(0);
 
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Default, Deserialize_tuple, Serialize_tuple)]
 pub struct State {
     // builtin actor registry: Vec<(String, Cid)>
     pub builtin_actors: Cid,


### PR DESCRIPTION
See #523.

Also fixes a bug in system actors state, which was broken and revealed by the cbor4ii library (which is stricter than its predecessor).