### PR TITLE
feat: refactor gas charging to remove "borrowing"

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -755,19 +755,27 @@ where
         self.call_manager.gas_tracker().gas_used()
     }
 
+    fn milligas_used(&self) -> i64 {
+        self.call_manager.gas_tracker().milligas_used()
+    }
+
+    fn gas_available(&self) -> i64 {
+        self.call_manager.gas_tracker().gas_available()
+    }
+    fn milligas_available(&self) -> i64 {
+        self.call_manager.gas_tracker().milligas_available()
+    }
+
     fn charge_gas(&mut self, name: &str, compute: i64) -> Result<()> {
         let charge = GasCharge::new(name, compute, 0);
-        self.call_manager.charge_gas(charge)
+        self.call_manager.gas_tracker_mut().charge_gas(charge)
     }
 
-    fn return_milligas(&mut self, name: &str, new_gas: i64) -> Result<()> {
+    fn charge_milligas(&mut self, name: &str, compute: i64) -> Result<()> {
         self.call_manager
             .gas_tracker_mut()
-            .return_milligas(name, new_gas)
-    }
-
-    fn borrow_milligas(&mut self) -> Result<i64> {
-        self.call_manager.gas_tracker_mut().borrow_milligas()
+            .charge_milligas(name, compute)?;
+        Ok(())
     }
 
     fn price_list(&self) -> &PriceList {

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -216,16 +216,16 @@ pub trait CircSupplyOps {
 pub trait GasOps {
     /// GasUsed return the gas used by the transaction so far.
     fn gas_used(&self) -> i64;
+    fn milligas_used(&self) -> i64;
+
+    fn gas_available(&self) -> i64;
+    fn milligas_available(&self) -> i64;
 
     /// ChargeGas charges specified amount of `gas` for execution.
     /// `name` provides information about gas charging point
     fn charge_gas(&mut self, name: &str, compute: i64) -> Result<()>;
 
-    /// Returns available gas.
-    fn borrow_milligas(&mut self) -> Result<i64>;
-
-    /// Sets available gas to a new value, creating a gas charge if needed
-    fn return_milligas(&mut self, name: &str, newgas: i64) -> Result<()>;
+    fn charge_milligas(&mut self, name: &str, compute: i64) -> Result<()>;
 
     fn price_list(&self) -> &PriceList;
 }

--- a/fvm/src/machine/engine.rs
+++ b/fvm/src/machine/engine.rs
@@ -308,6 +308,7 @@ impl Engine {
             kernel,
             last_error: None,
             avail_gas_global: self.0.dummy_gas_global,
+            last_milligas_available: 0,
         };
 
         let mut store = wasmtime::Store::new(&self.0.engine, id);

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -1,7 +1,11 @@
+use std::mem;
+
+use anyhow::{anyhow, Context as _};
 use cid::Cid;
-use wasmtime::{Global, Linker};
+use wasmtime::{AsContextMut, Global, Linker, Val};
 
 use crate::call_manager::backtrace;
+use crate::kernel::ExecutionError;
 use crate::Kernel;
 
 pub(crate) mod error;
@@ -30,11 +34,62 @@ pub struct InvocationData<K> {
     /// after receiving this error without calling any other syscalls.
     pub last_error: Option<backtrace::Cause>,
 
-    /// The global containing remaining available gas
+    /// The global containing remaining available gas.
     pub avail_gas_global: Global,
+    /// The last-set milligas limit. When `cahrge_for_exec` is called, we charge for the
+    /// _difference_ between the current gas available (the wasm global) and the
+    /// `last_milligas_available`.
+    pub last_milligas_available: i64,
+}
+
+pub fn update_gas_available(
+    ctx: &mut impl AsContextMut<Data = InvocationData<impl Kernel>>,
+) -> Result<(), Abort> {
+    let mut ctx = ctx.as_context_mut();
+    let avail_milligas = ctx.data_mut().kernel.milligas_available();
+
+    let gas_global = ctx.data_mut().avail_gas_global;
+    gas_global
+        .set(&mut ctx, Val::I64(avail_milligas))
+        .map_err(|e| Abort::Fatal(anyhow!("failed to set available gas global: {}", e)))?;
+
+    ctx.data_mut().last_milligas_available = avail_milligas;
+    Ok(())
+}
+
+pub fn charge_for_exec(
+    ctx: &mut impl AsContextMut<Data = InvocationData<impl Kernel>>,
+) -> Result<(), Abort> {
+    let mut ctx = ctx.as_context_mut();
+    let global = ctx.data_mut().avail_gas_global;
+
+    let milligas_available = global
+        .get(&mut ctx)
+        .i64()
+        .context("failed to get wasm gas")
+        .map_err(Abort::Fatal)?;
+
+    // Determine milligas used, and update the "o
+    let milligas_used = {
+        let data = ctx.data_mut();
+        let last_milligas = mem::replace(&mut data.last_milligas_available, milligas_available);
+        // This should never be negative, but we might as well check.
+        last_milligas.saturating_sub(milligas_available)
+    };
+
+    ctx.data_mut()
+        .kernel
+        .charge_milligas("wasm_exec", milligas_used)
+        .map_err(|e| match e {
+            ExecutionError::OutOfGas => Abort::OutOfGas,
+            ExecutionError::Fatal(e) => Abort::Fatal(e),
+            ExecutionError::Syscall(e) => Abort::Fatal(anyhow!("unexpected syscall error: {}", e)),
+        })?;
+    Ok(())
 }
 
 use self::bind::BindSyscall;
+use self::error::Abort;
 
 /// The maximum supported CID size. (SPEC_AUDIT)
 pub const MAX_CID_LEN: usize = 100;

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -36,7 +36,7 @@ pub struct InvocationData<K> {
 
     /// The global containing remaining available gas.
     pub avail_gas_global: Global,
-    /// The last-set milligas limit. When `cahrge_for_exec` is called, we charge for the
+    /// The last-set milligas limit. When `charge_for_exec` is called, we charge for the
     /// _difference_ between the current gas available (the wasm global) and the
     /// `last_milligas_available`.
     pub last_milligas_available: i64,

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -494,16 +494,24 @@ where
         self.0.charge_gas(name, compute)
     }
 
-    fn borrow_milligas(&mut self) -> Result<i64> {
-        self.0.borrow_milligas()
-    }
-
-    fn return_milligas(&mut self, name: &str, newgas: i64) -> Result<()> {
-        self.0.return_milligas(name, newgas)
-    }
-
     fn price_list(&self) -> &PriceList {
         self.0.price_list()
+    }
+
+    fn milligas_used(&self) -> i64 {
+        self.0.milligas_used()
+    }
+
+    fn gas_available(&self) -> i64 {
+        self.0.gas_available()
+    }
+
+    fn milligas_available(&self) -> i64 {
+        self.0.milligas_available()
+    }
+
+    fn charge_milligas(&mut self, name: &str, compute: i64) -> Result<()> {
+        self.0.charge_milligas(name, compute)
     }
 }
 


### PR DESCRIPTION
Basically:

1. On entering wasm, we call `update_gas_available` to update the available gas for the actor.
2. On exiting wasm, we call `charge_for_exec` to charge for execution gas.

Unlike the previous code:

1. We can handle this the same way in both the CallManager and the syscalls.
2. We never "borrow" or "return" the gas from/to the gas tracker.