### PR TITLE
feat: resolve the memory once

### DIFF
--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -2,7 +2,7 @@ use std::mem;
 
 use anyhow::{anyhow, Context as _};
 use cid::Cid;
-use wasmtime::{AsContextMut, Global, Linker, Val};
+use wasmtime::{AsContextMut, Global, Linker, Memory, Val};
 
 use crate::call_manager::backtrace;
 use crate::kernel::ExecutionError;
@@ -30,16 +30,21 @@ pub(self) use context::Context;
 pub struct InvocationData<K> {
     /// The kernel on which this actor is being executed.
     pub kernel: K,
+
     /// The last-seen syscall error. This error is considered the abort "cause" if an actor aborts
     /// after receiving this error without calling any other syscalls.
     pub last_error: Option<backtrace::Cause>,
 
     /// The global containing remaining available gas.
     pub avail_gas_global: Global,
+
     /// The last-set milligas limit. When `charge_for_exec` is called, we charge for the
     /// _difference_ between the current gas available (the wasm global) and the
     /// `last_milligas_available`.
     pub last_milligas_available: i64,
+
+    /// The invocation's imported "memory".
+    pub memory: Memory,
 }
 
 pub fn update_gas_available(

--- a/testing/integration/tests/lib.rs
+++ b/testing/integration/tests/lib.rs
@@ -73,6 +73,7 @@ fn out_of_gas() {
     const WAT: &str = r#"
     ;; Mock invoke function
     (module
+      (memory (export "memory") 1)
       (func (export "invoke") (param $x i32) (result i32)
         (loop
             (br 0)
@@ -127,6 +128,7 @@ fn out_of_stack() {
     const WAT: &str = r#"
     ;; Mock invoke function
     (module
+      (memory (export "memory") 1)
       (func (export "invoke") (param $x i32) (result i32)
         (i64.const 123)
         (call 1)


### PR DESCRIPTION
Instead of looking up the memory export on every syscall, resolve it when we construct the invocation container.

fixes #510