### PR TITLE
fix: make sure bitfield is within limits

### DIFF
--- a/ipld/bitfield/src/lib.rs
+++ b/ipld/bitfield/src/lib.rs
@@ -21,6 +21,12 @@ pub use rleplus::Error;
 use thiserror::Error;
 pub use unvalidated::{UnvalidatedBitField, Validate};
 
+/// MaxEncodedSize is the maximum encoded size of a bitfield. When expanded into
+/// a slice of runs, a bitfield of this size should not exceed 2MiB of memory.
+///
+/// This bitfield can fit at least 3072 sparse elements.
+pub(crate) const MAX_ENCODED_SIZE: usize = 32 << 10;
+
 #[derive(Clone, Error, Debug)]
 #[error("bitfields may not include u64::MAX")]
 pub struct OutOfRangeError;

--- a/ipld/bitfield/src/rleplus/mod.rs
+++ b/ipld/bitfield/src/rleplus/mod.rs
@@ -75,13 +75,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub use writer::BitWriter;
 
 use super::BitField;
-use crate::RangeSize;
-
-// MaxEncodedSize is the maximum encoded size of a bitfield. When expanded into
-// a slice of runs, a bitfield of this size should not exceed 2MiB of memory.
-//
-// This bitfield can fit at least 3072 sparse elements.
-const MAX_ENCODED_SIZE: usize = 32 << 10;
+use crate::{RangeSize, MAX_ENCODED_SIZE};
 
 impl Serialize for BitField {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/ipld/bitfield/src/unvalidated.rs
+++ b/ipld/bitfield/src/unvalidated.rs
@@ -7,7 +7,7 @@ use fvm_ipld_encoding::serde_bytes;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::BitField;
-use crate::Error;
+use crate::{Error, MAX_ENCODED_SIZE};
 
 /// A trait for types that can produce a `&BitField` (or fail to do so).
 /// Generalizes over `&BitField` and `&mut UnvalidatedBitField`.
@@ -77,6 +77,12 @@ impl<'de> Deserialize<'de> for UnvalidatedBitField {
         D: Deserializer<'de>,
     {
         let bytes: Vec<u8> = serde_bytes::deserialize(deserializer)?;
+        if bytes.len() > MAX_ENCODED_SIZE {
+            return Err(serde::de::Error::custom(format!(
+                "encoded bitfield was too large {}",
+                bytes.len()
+            )));
+        }
         Ok(Self::Unvalidated(bytes))
     }
 }


### PR DESCRIPTION
Error if one tries to decode a bitfield that is too large.

I don't know if that's really needed or not. I've added the test case from the Forest Actor Review.