### PR TITLE
fix clippy on nightly.

### DIFF
--- a/ipld/amt/benches/amt_benchmark.rs
+++ b/ipld/amt/benches/amt_benchmark.rs
@@ -28,7 +28,9 @@ impl Serialize for BenchData {
         ().serialize(serializer)
     }
 }
+
 impl<'de> Deserialize<'de> for BenchData {
+    #[allow(clippy::let_unit_value)]
     fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
     where
         D: Deserializer<'de>,


### PR DESCRIPTION
Looks like something changed on nightly making this clippy lint more aggressive. Assuming this is like this to prevent optimizations, although I'm not sure how effective it is.