### PR TITLE
chore: use a specific Rust nightly version

### DIFF
--- a/ipld/amt/benches/amt_benchmark.rs
+++ b/ipld/amt/benches/amt_benchmark.rs
@@ -30,13 +30,11 @@ impl Serialize for BenchData {
 }
 
 impl<'de> Deserialize<'de> for BenchData {
-    #[allow(clippy::let_unit_value)]
     fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
     where
         D: Deserializer<'de>,
     {
-        let _s: () = Deserialize::deserialize(deserializer)?;
-
+        Deserialize::deserialize(deserializer)?;
         Ok(Self::default())
     }
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2022-05-09


### PR DESCRIPTION
Currently Rust nightly is needed as the currently used `bellperson` version
needs else wouldn't build on ARM64. Using a specific version makes sure
that we don't get arbitrary Clippy failures on CI.

Also fix Clippy warning that comes up with using this nightly version.