### PR TITLE
transmute fatal errors into `SYS_ASSERTION_FAILED` exit code.

### DIFF
--- a/fvm/src/call_manager/backtrace.rs
+++ b/fvm/src/call_manager/backtrace.rs
@@ -112,10 +112,8 @@ pub struct SyscallCause {
 
 #[derive(Clone, Debug)]
 pub struct FatalCause {
-    /// The error message from the error.
+    /// The alternate-formatted message from the anyhow error.
     pub error_msg: String,
-    /// The original cause that initiated the error chain.
-    pub root_cause: String,
     /// The backtrace, captured if the relevant
     /// [environment variables](https://doc.rust-lang.org/std/backtrace/index.html#environment-variables) are enabled.
     pub backtrace: String,
@@ -144,8 +142,7 @@ impl Cause {
     /// Records a fatal error as the cause of a backtrace.
     pub fn from_fatal(err: anyhow::Error) -> Self {
         Self::Fatal(FatalCause {
-            error_msg: err.to_string(),
-            root_cause: err.root_cause().to_string(),
+            error_msg: format!("{:#}", err),
             backtrace: err.backtrace().to_string(),
         })
     }
@@ -164,8 +161,8 @@ impl Display for Cause {
             Cause::Fatal(msg) => {
                 write!(
                     f,
-                    "[FATAL] Root cause: {}, Stacktrace: {}",
-                    msg.root_cause, msg.backtrace
+                    "[FATAL] Error: {}, Backtrace:\n{}",
+                    msg.error_msg, msg.backtrace
                 )
             }
         }

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -393,7 +393,7 @@ where
                 Ok(value) => Ok(InvocationResult::Return(value)),
                 Err(abort) => {
                     if let Some(err) = last_error {
-                        cm.backtrace.set_cause(err);
+                        cm.backtrace.begin(err);
                     }
 
                     let (code, message, res) = match abort {

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -130,24 +130,29 @@ where
                     ErrorNumber::Forbidden => ExitCode::SYS_ASSERTION_FAILED,
                 };
 
-                backtrace.set_cause(backtrace::Cause::new("send", "send", err));
+                backtrace.begin(backtrace::Cause::from_syscall("send", "send", err));
                 Receipt {
                     exit_code,
                     return_data: Default::default(),
                     gas_used,
                 }
             }
-            Err(ExecutionError::Fatal(e)) => {
-                // Annotate the error with the message context.
-                let _err = e.context(format!(
-                    "[from={}, to={}, seq={}, m={}, h={}] fatal error",
-                    msg.from,
-                    msg.to,
-                    msg.sequence,
-                    msg.method_num,
-                    self.context().epoch
-                ));
-                // TODO backtrace
+            Err(ExecutionError::Fatal(err)) => {
+                // // Annotate the error with the message context.
+                // let err = {
+                //     let backtrace = String::from("foo"); //e.backtrace().to_string();
+                //                                          // e.context(format!(
+                //                                          //     "[from={}, to={}, seq={}, m={}, h={}] fatal error; backtrace: {}",
+                //                                          //     msg.from,
+                //                                          //     msg.to,
+                //                                          //     msg.sequence,
+                //                                          //     msg.method_num,
+                //                                          //     self.context().epoch,
+                //                                          //     backtrace,
+                //                                          // ))
+                // };
+                backtrace.set_cause(backtrace::Cause::from_fatal(err));
+                // Produce a receipt that consumes the full gas amount.
                 Receipt {
                     exit_code: ExitCode::SYS_ASSERTION_FAILED,
                     return_data: Default::default(),

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -138,14 +138,21 @@ where
                 }
             }
             Err(ExecutionError::Fatal(e)) => {
-                return Err(e.context(format!(
+                // Annotate the error with the message context.
+                let _err = e.context(format!(
                     "[from={}, to={}, seq={}, m={}, h={}] fatal error",
                     msg.from,
                     msg.to,
                     msg.sequence,
                     msg.method_num,
                     self.context().epoch
-                )));
+                ));
+                // TODO backtrace
+                Receipt {
+                    exit_code: ExitCode::SYS_ASSERTION_FAILED,
+                    return_data: Default::default(),
+                    gas_used: msg.gas_limit,
+                }
             }
         };
 

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -113,6 +113,9 @@ where
         // This interface works for now because we know all actor CIDs
         // ahead of time, but with user-supplied code, we won't have that
         // guarantee.
+        // Skip preloading all builtin actors when testing. This results in JIT
+        // bytecode to machine code compilation, and leads to faster tests.
+        #[cfg(not(feature = "testing"))]
         engine.preload(state_tree.store(), builtin_actors.left_values())?;
 
         Ok(DefaultMachine {

--- a/fvm/src/syscalls/bind.rs
+++ b/fvm/src/syscalls/bind.rs
@@ -141,7 +141,7 @@ macro_rules! impl_bind_syscalls {
                             Ok(Err(err)) => {
                                 let code = err.1;
                                 log::trace!("syscall {}::{}: fail ({})", module, name, code as u32);
-                                data.last_error = Some(backtrace::Cause::new(module, name, err));
+                                data.last_error = Some(backtrace::Cause::from_syscall(module, name, err));
                                 Ok(code as u32)
                             },
                             Err(e) => Err(e.into()),
@@ -163,7 +163,7 @@ macro_rules! impl_bind_syscalls {
                         if (ret as u64) > (memory.len() as u64)
                             || memory.len() - (ret as usize) < mem::size_of::<Ret::Value>() {
                             let code = ErrorNumber::IllegalArgument;
-                            data.last_error = Some(backtrace::Cause::new(module, name, SyscallError(format!("no space for return value"), code)));
+                            data.last_error = Some(backtrace::Cause::from_syscall(module, name, SyscallError(format!("no space for return value"), code)));
                             return Ok(code as u32);
                         }
 
@@ -178,7 +178,7 @@ macro_rules! impl_bind_syscalls {
                             Ok(Err(err)) => {
                                 let code = err.1;
                                 log::trace!("syscall {}::{}: fail ({})", module, name, code as u32);
-                                data.last_error = Some(backtrace::Cause::new(module, name, err));
+                                data.last_error = Some(backtrace::Cause::from_syscall(module, name, err));
                                 Ok(code as u32)
                             },
                             Err(e) => Err(e.into()),

--- a/testing/integration/examples/integration.rs
+++ b/testing/integration/examples/integration.rs
@@ -1,5 +1,6 @@
 use fvm::executor::{ApplyKind, Executor};
 use fvm_integration_tests::tester::{Account, Tester};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
@@ -25,7 +26,12 @@ struct State {
 
 pub fn main() {
     // Instantiate tester
-    let mut tester = Tester::new(NetworkVersion::V15, StateTreeVersion::V4).unwrap();
+    let mut tester = Tester::new(
+        NetworkVersion::V15,
+        StateTreeVersion::V4,
+        MemoryBlockstore::default(),
+    )
+    .unwrap();
 
     let sender: [Account; 1] = tester.create_accounts().unwrap();
 

--- a/testing/integration/src/builtin.rs
+++ b/testing/integration/src/builtin.rs
@@ -5,7 +5,7 @@ use cid::Cid;
 use futures::executor::block_on;
 use fvm::state_tree::{ActorState, StateTree};
 use fvm::{init_actor, system_actor};
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_car::load_car;
 use fvm_ipld_encoding::CborStore;
 use fvm_shared::actor::builtin::{load_manifest, Type};
@@ -24,7 +24,7 @@ const BUNDLES: [(NetworkVersion, &[u8]); 3] = [
 
 // Import built-in actors
 pub fn import_builtin_actors(
-    blockstore: &MemoryBlockstore,
+    blockstore: &impl Blockstore,
 ) -> Result<BTreeMap<NetworkVersion, Cid>> {
     BUNDLES
         .into_iter()
@@ -40,7 +40,7 @@ pub fn import_builtin_actors(
 
 // Retrieve system, init and accounts actors code CID
 pub fn fetch_builtin_code_cid(
-    blockstore: &MemoryBlockstore,
+    blockstore: &impl Blockstore,
     builtin_actors: &Cid,
     ver: u32,
 ) -> Result<(Cid, Cid, Cid)> {

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -99,10 +99,7 @@ where
     /// Creates new accounts in the testing context
     pub fn create_accounts<const N: usize>(&mut self) -> Result<[Account; N]> {
         // Create accounts.
-        put_secp256k1_accounts(
-            &mut self.state_tree.as_mut().unwrap(),
-            self.accounts_code_cid,
-        )
+        put_secp256k1_accounts(self.state_tree.as_mut().unwrap(), self.accounts_code_cid)
     }
 
     /// Set a new state in the state tree

--- a/testing/integration/tests/lib.rs
+++ b/testing/integration/tests/lib.rs
@@ -206,6 +206,8 @@ fn out_of_stack() {
 
 #[test]
 fn backtraces() {
+    // Note: this test **does not actually assert anything**, but it's useful to
+    // let us peep into FVM backtrace generation under different scenarios.
     const WAT_ABORT: &str = r#"
     (module
       ;; ipld::open
@@ -300,8 +302,7 @@ fn backtraces() {
         .execute_message(message, ApplyKind::Explicit, 100)
         .unwrap();
 
-    println!("abort backtrace:");
-    dbg!(res.failure_info);
+    println!("abort backtrace: {}", res.failure_info.unwrap());
 
     // Send message
     let message = Message {
@@ -320,8 +321,7 @@ fn backtraces() {
         .execute_message(message, ApplyKind::Explicit, 100)
         .unwrap();
 
-    println!("fatal backtrace:");
-    dbg!(res.failure_info);
+    println!("fatal backtrace: {}", res.failure_info.unwrap());
 }
 
 #[derive(Default)]

--- a/testing/integration/tests/lib.rs
+++ b/testing/integration/tests/lib.rs
@@ -1,14 +1,21 @@
+use std::cell::RefCell;
+use std::collections::HashSet;
 use std::env;
 
+use cid::multihash::Multihash;
+use cid::Cid;
 use fvm::executor::{ApplyKind, Executor};
 use fvm_integration_tests::tester::{Account, Tester};
+use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::tuple::*;
+use fvm_ipld_encoding::DAG_CBOR;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::error::ExitCode;
 use fvm_shared::message::Message;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
+use fvm_shared::IDENTITY_HASH;
 use num_traits::Zero;
 use wabt::wat2wasm;
 
@@ -24,7 +31,12 @@ const WASM_COMPILED_PATH: &str =
 #[test]
 fn hello_world() {
     // Instantiate tester
-    let mut tester = Tester::new(NetworkVersion::V15, StateTreeVersion::V4).unwrap();
+    let mut tester = Tester::new(
+        NetworkVersion::V15,
+        StateTreeVersion::V4,
+        MemoryBlockstore::default(),
+    )
+    .unwrap();
 
     let sender: [Account; 1] = tester.create_accounts().unwrap();
 
@@ -84,7 +96,12 @@ fn out_of_gas() {
     "#;
 
     // Instantiate tester
-    let mut tester = Tester::new(NetworkVersion::V16, StateTreeVersion::V4).unwrap();
+    let mut tester = Tester::new(
+        NetworkVersion::V16,
+        StateTreeVersion::V4,
+        MemoryBlockstore::default(),
+    )
+    .unwrap();
 
     let sender: [Account; 1] = tester.create_accounts().unwrap();
 
@@ -143,7 +160,12 @@ fn out_of_stack() {
     "#;
 
     // Instantiate tester
-    let mut tester = Tester::new(NetworkVersion::V16, StateTreeVersion::V4).unwrap();
+    let mut tester = Tester::new(
+        NetworkVersion::V16,
+        StateTreeVersion::V4,
+        MemoryBlockstore::default(),
+    )
+    .unwrap();
 
     let sender: [Account; 1] = tester.create_accounts().unwrap();
 
@@ -180,4 +202,146 @@ fn out_of_stack() {
         .unwrap();
 
     assert_eq!(res.msg_receipt.exit_code, ExitCode::SYS_ILLEGAL_INSTRUCTION)
+}
+
+#[test]
+fn backtraces() {
+    const WAT_ABORT: &str = r#"
+    (module
+      ;; ipld::open
+      (type (;0;) (func (param i32 i32) (result i32)))
+      (import "ipld" "open" (func $fvm_sdk::sys::ipld::open::syscall (type 0)))
+      ;; vm::abort
+      (type (;1;) (func (param i32 i32 i32) (result i32)))
+      (import "vm" "abort" (func $fvm_sdk::sys::vm::abort::syscall (type 1)))
+      (memory (export "memory") 1)
+      (func (export "invoke") (param $x i32) (result i32)
+        (i32.const 123)
+        (i32.const 123)
+        (call $fvm_sdk::sys::ipld::open::syscall)
+        (i32.const 0)
+        (i32.const 0)
+        (call $fvm_sdk::sys::vm::abort::syscall)
+        unreachable
+      )
+    )
+    "#;
+
+    const WAT_FATAL: &str = r#"
+    (module
+      ;; ipld::open
+      (type (;0;) (func (param i32 i32) (result i32)))
+      (import "ipld" "open" (func $fvm_sdk::sys::ipld::open::syscall (type 0)))
+      ;; vm::abort
+      (type (;1;) (func (param i32 i32 i32) (result i32)))
+      (import "vm" "abort" (func $fvm_sdk::sys::vm::abort::syscall (type 1)))
+      (memory (export "memory") 1)
+      (func (export "invoke") (param $x i32) (result i32)
+        (i32.const 128)
+        (memory.grow)
+        (i32.const 4)
+        (i32.const 25493505)
+        (i32.store)
+        (i32.const 8)
+        (i32.const 0)
+        (i32.store)
+        (i32.const 4)
+        (call $fvm_sdk::sys::ipld::open::syscall)
+        (i32.const 0)
+        (i32.const 0)
+        (call $fvm_sdk::sys::vm::abort::syscall)
+        unreachable
+      )
+    )
+    "#;
+
+    let blockstore = FailingBlockstore::default();
+    let identity_cid = Cid::new_v1(DAG_CBOR, Multihash::wrap(IDENTITY_HASH, &[0]).unwrap());
+    blockstore.add_fail(identity_cid);
+
+    // Instantiate tester
+    let mut tester = Tester::new(
+        NetworkVersion::V16,
+        StateTreeVersion::V4,
+        MemoryBlockstore::default(),
+    )
+    .unwrap();
+
+    let sender: [Account; 1] = tester.create_accounts().unwrap();
+
+    let state_cid = tester.set_state(&State { count: 0 }).unwrap();
+
+    // Set an actor that aborts.
+    let (wasm_abort, wasm_fatal) = (wat2wasm(WAT_ABORT).unwrap(), wat2wasm(WAT_FATAL).unwrap());
+    let (abort_address, fatal_address) = (Address::new_id(10000), Address::new_id(10001));
+    tester
+        .set_actor_from_bin(&wasm_abort, state_cid, abort_address, BigInt::zero())
+        .unwrap();
+    tester
+        .set_actor_from_bin(&wasm_fatal, state_cid, fatal_address, BigInt::zero())
+        .unwrap();
+
+    // Instantiate machine
+    tester.instantiate_machine().unwrap();
+
+    // Send message
+    let message = Message {
+        from: sender[0].1,
+        to: abort_address,
+        gas_limit: 10_000_000,
+        method_num: 1,
+        ..Message::default()
+    };
+
+    let res = tester
+        .executor
+        .as_mut()
+        .unwrap()
+        .execute_message(message, ApplyKind::Explicit, 100)
+        .unwrap();
+
+    println!("abort backtrace:");
+    dbg!(res.failure_info);
+
+    // Send message
+    let message = Message {
+        from: sender[0].1,
+        to: fatal_address,
+        gas_limit: 10_000_000,
+        method_num: 1,
+        sequence: 1,
+        ..Message::default()
+    };
+
+    let res = tester
+        .executor
+        .as_mut()
+        .unwrap()
+        .execute_message(message, ApplyKind::Explicit, 100)
+        .unwrap();
+
+    println!("fatal backtrace:");
+    dbg!(res.failure_info);
+}
+
+#[derive(Default)]
+pub struct FailingBlockstore {
+    fail_for: RefCell<HashSet<Cid>>,
+    target: MemoryBlockstore,
+}
+
+impl FailingBlockstore {
+    pub fn add_fail(&self, cid: Cid) {
+        self.fail_for.borrow_mut().insert(cid);
+    }
+}
+
+impl Blockstore for FailingBlockstore {
+    fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
+        self.target.get(k)
+    }
+
+    fn put_keyed(&self, k: &Cid, block: &[u8]) -> anyhow::Result<()> {
+        self.target.put_keyed(k, block)
+    }
 }


### PR DESCRIPTION
Closes #508.

This PR transmutes fatal errors into the `SYS_ASSERTION_FAILED`  exit code at the top layer (Executor) to produce a consensus outcome on fatal errors.

It also modifies the Backtrace components to generalise them so they can tackle syscall errors as well as fatal errors. The cause is informed at different times for each, so the APIs have been adapted accordingly:
- For syscall errors, we inform the cause as soon as the syscall fails. Thus we reset the backtrace and accumulate the propagation chain (`Backtrace#begin()`).
- For fatal errors, we inform the cause at the top. Thus we accumulate the propagation chain, _then_ we inform the cause (`Backtrace#set_cause()`).

I think capturing backtraces (both FVM backtraces and Rust backtraces) is crucial for debuggability. Because I had no way of generating fatal errors to verify the behaviour, I added an integration test which performs no assertions, but prints the backtrace on stdout.

Backtraces from syscall-motivated aborts look like this:

```
message failed with backtrace:
00: f010000 (method 1) -- actor aborted with code 1 (9)
--> caused by: ipld::open -- failed to parse cid: CIDv0 requires a DagPB codec (1: illegal argument)
```

Whereas fatal error backtraces display the error chain from anyhow, as well as the backtrace if captured:

```
fatal backtrace: message failed with backtrace:
00: f010001 (method 1) -- fatal error (10)
--> caused by: [FATAL] Error: [from=f1d3nehuc4u3l5mn7hazppnogf3oe6l6ymaicbkhi, to=f010001, seq=1, m=1, h=0]: missing state: baeaikaia, Stacktrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/cb121987158d69bb894ba1bcc21dc45d1e0a488f/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/cb121987158d69bb894ba1bcc21dc45d1e0a488f/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2: std::backtrace::Backtrace::create
             at /rustc/cb121987158d69bb894ba1bcc21dc45d1e0a488f/library/std/src/backtrace.rs:328:13
   3: std::backtrace::Backtrace::capture
             at /rustc/cb121987158d69bb894ba1bcc21dc45d1e0a488f/library/std/src/backtrace.rs:296:9
   4: anyhow::error::<impl anyhow::Error>::msg
             at /Users/raul/.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.56/src/error.rs:81:36
   5: <fvm::kernel::default::DefaultKernel<C> as fvm::kernel::BlockOps>::block_open::{{closure}}
             at /Users/raul/W/pl/fvm/fvm/src/kernel/default.rs:304:28
   6: core::option::Option<T>::ok_or_else
             at /rustc/cb121987158d69bb894ba1bcc21dc45d1e0a488f/library/core/src/option.rs:1067:25
   7: <fvm::kernel::default::DefaultKernel<C> as fvm::kernel::BlockOps>::block_open
             at /Users/raul/W/pl/fvm/fvm/src/kernel/default.rs:299:20
   8: fvm::syscalls::ipld::open
             at /Users/raul/W/pl/fvm/fvm/src/syscalls/ipld.rs:10:22
   9: core::ops::function::Fn::call
             at /rustc/cb121987158d69bb894ba1bcc21dc45d1e0a488f/library/core/src/ops/function.rs:77:5
  10: <wasmtime::linker::Linker<fvm::syscalls::InvocationData<K>> as fvm::syscalls::bind::BindSyscall<(A,),Ret,Func>>::bind::{{closure}}
             at /Users/raul/W/pl/fvm/fvm/src/syscalls/bind.rs:171:44
  ...
```