### PR TITLE
sdk: reinstate the message package for message accessors.

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -4,6 +4,7 @@ pub mod debug;
 pub mod error;
 pub mod gas;
 pub mod ipld;
+pub mod message;
 pub mod network;
 pub mod rand;
 pub mod send;
@@ -19,6 +20,9 @@ pub const MAX_CID_LEN: usize = 100;
 
 /// The maximum actor address length (class 2 addresses).
 pub const MAX_ACTOR_ADDR_LEN: usize = 21;
+
+/// BlockID representing nil parameters or return data.
+pub const NO_DATA_BLOCK_ID: u32 = 0;
 
 // TODO: provide a custom panic handler?
 

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -1,0 +1,63 @@
+use std::convert::TryInto;
+
+use fvm_ipld_encoding::DAG_CBOR;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::sys::{BlockId, Codec};
+use fvm_shared::{ActorID, MethodNum};
+
+use crate::vm::INVOCATION_CONTEXT;
+use crate::{sys, SyscallResult, NO_DATA_BLOCK_ID};
+
+/// Returns the ID address of the caller.
+#[inline(always)]
+pub fn caller() -> ActorID {
+    INVOCATION_CONTEXT.caller
+}
+
+/// Returns the ID address of the actor.
+#[inline(always)]
+pub fn receiver() -> ActorID {
+    INVOCATION_CONTEXT.receiver
+}
+
+/// Returns the message's method number.
+#[inline(always)]
+pub fn method_number() -> MethodNum {
+    INVOCATION_CONTEXT.method_number
+}
+
+/// Returns the value received from the caller in AttoFIL.
+#[inline(always)]
+pub fn value_received() -> TokenAmount {
+    INVOCATION_CONTEXT
+        .value_received
+        .try_into()
+        .expect("invalid bigint")
+}
+
+/// Returns the message codec and parameters.
+pub fn params_raw(id: BlockId) -> SyscallResult<(Codec, Vec<u8>)> {
+    if id == NO_DATA_BLOCK_ID {
+        return Ok((DAG_CBOR, Vec::default())); // DAG_CBOR is a lie, but we have no nil codec.
+    }
+    unsafe {
+        let fvm_shared::sys::out::ipld::IpldStat { codec, size } = sys::ipld::stat(id)?;
+        log::trace!(
+            "params_raw -> ipld stat: size={:?}; codec={:?}",
+            size,
+            codec
+        );
+
+        let mut buf: Vec<u8> = Vec::with_capacity(size as usize);
+        let ptr = buf.as_mut_ptr();
+        let bytes_read = sys::ipld::read(id, 0, ptr, size)?;
+        buf.set_len(bytes_read as usize);
+        log::trace!(
+            "params_raw -> ipld read: bytes_read={:?}, data: {:x?}",
+            bytes_read,
+            &buf
+        );
+        debug_assert!(bytes_read == size, "read an unexpected number of bytes");
+        Ok((codec, buf))
+    }
+}

--- a/sdk/src/send.rs
+++ b/sdk/src/send.rs
@@ -7,8 +7,7 @@ use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::receipt::Receipt;
 use fvm_shared::MethodNum;
 
-use crate::vm::NO_DATA_BLOCK_ID;
-use crate::{sys, SyscallResult};
+use crate::{sys, SyscallResult, NO_DATA_BLOCK_ID};
 
 /// Sends a message to another actor.
 // TODO: Drop the use of receipts here as we don't return the gas used. Alternatively, we _could_

--- a/sdk/src/vm.rs
+++ b/sdk/src/vm.rs
@@ -1,16 +1,8 @@
-use std::convert::TryInto;
 use std::ptr;
 
-use fvm_ipld_encoding::DAG_CBOR;
-use fvm_shared::econ::TokenAmount;
 use fvm_shared::sys::out::vm::InvocationContext;
-use fvm_shared::sys::{BlockId, Codec};
-use fvm_shared::{ActorID, MethodNum};
 
-use crate::{sys, SyscallResult};
-
-/// BlockID representing nil parameters or return data.
-pub const NO_DATA_BLOCK_ID: u32 = 0;
+use crate::sys;
 
 lazy_static::lazy_static! {
     pub(crate) static ref INVOCATION_CONTEXT: InvocationContext = {
@@ -18,60 +10,6 @@ lazy_static::lazy_static! {
             sys::vm::context().expect("failed to lookup invocation context")
         }
     };
-}
-
-/// Returns the ID address of the caller.
-#[inline(always)]
-pub fn caller() -> ActorID {
-    INVOCATION_CONTEXT.caller
-}
-
-/// Returns the ID address of the actor.
-#[inline(always)]
-pub fn receiver() -> ActorID {
-    INVOCATION_CONTEXT.receiver
-}
-
-/// Returns the message's method number.
-#[inline(always)]
-pub fn method_number() -> MethodNum {
-    INVOCATION_CONTEXT.method_number
-}
-
-/// Returns the message codec and parameters.
-pub fn params_raw(id: BlockId) -> SyscallResult<(Codec, Vec<u8>)> {
-    if id == NO_DATA_BLOCK_ID {
-        return Ok((DAG_CBOR, Vec::default())); // DAG_CBOR is a lie, but we have no nil codec.
-    }
-    unsafe {
-        let fvm_shared::sys::out::ipld::IpldStat { codec, size } = sys::ipld::stat(id)?;
-        log::trace!(
-            "params_raw -> ipld stat: size={:?}; codec={:?}",
-            size,
-            codec
-        );
-
-        let mut buf: Vec<u8> = Vec::with_capacity(size as usize);
-        let ptr = buf.as_mut_ptr();
-        let bytes_read = sys::ipld::read(id, 0, ptr, size)?;
-        buf.set_len(bytes_read as usize);
-        log::trace!(
-            "params_raw -> ipld read: bytes_read={:?}, data: {:x?}",
-            bytes_read,
-            &buf
-        );
-        debug_assert!(bytes_read == size, "read an unexpected number of bytes");
-        Ok((codec, buf))
-    }
-}
-
-/// Returns the value received from the caller in AttoFIL.
-#[inline(always)]
-pub fn value_received() -> TokenAmount {
-    INVOCATION_CONTEXT
-        .value_received
-        .try_into()
-        .expect("invalid bigint")
 }
 
 /// Abort execution.


### PR DESCRIPTION
They make more sense here than in the `vm` package.