### PR TITLE
catch panics inside Wasm and lower to fatal errors.

### DIFF
--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -14,7 +14,6 @@ fvm_ipld_car = { version = "0.4.1", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.0", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.2.0", path = "../../ipld/encoding" }
 
-actors-v6 = { version = "6.1.1", package = "fil_builtin_actors_bundle" }
 actors-v7 = { version = "7.1.2", package = "fil_builtin_actors_bundle" }
 anyhow = "1.0.47"
 cid = { version = "0.8.2", default-features = false }

--- a/testing/integration/src/builtin.rs
+++ b/testing/integration/src/builtin.rs
@@ -16,8 +16,7 @@ use crate::error::Error::{
     FailedToLoadManifest, FailedToSetActor, FailedToSetState, MultipleRootCid, NoCidInManifest,
 };
 
-const BUNDLES: [(NetworkVersion, &[u8]); 3] = [
-    (NetworkVersion::V14, actors_v6::BUNDLE_CAR),
+const BUNDLES: [(NetworkVersion, &[u8]); 2] = [
     (NetworkVersion::V15, actors_v7::BUNDLE_CAR),
     (NetworkVersion::V16, actors_v7::BUNDLE_CAR), // todo bad hack
 ];

--- a/testing/integration/tests/lib.rs
+++ b/testing/integration/tests/lib.rs
@@ -400,7 +400,7 @@ fn backtraces() {
         let message = Message {
             to: fatal_address,
             sequence: 2,
-            ..message.clone()
+            ..message
         };
         executor
             .execute_message(message, ApplyKind::Explicit, 100)

--- a/testing/integration/tests/lib.rs
+++ b/testing/integration/tests/lib.rs
@@ -1,21 +1,20 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::env;
+use std::rc::Rc;
 
-use cid::multihash::Multihash;
+use anyhow::anyhow;
 use cid::Cid;
 use fvm::executor::{ApplyKind, Executor};
 use fvm_integration_tests::tester::{Account, Tester};
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::DAG_CBOR;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::error::ExitCode;
 use fvm_shared::message::Message;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
-use fvm_shared::IDENTITY_HASH;
 use num_traits::Zero;
 use wabt::wat2wasm;
 
@@ -229,7 +228,7 @@ fn backtraces() {
     )
     "#;
 
-    const WAT_FATAL: &str = r#"
+    const WAT_FAIL: &str = r#"
     (module
       ;; ipld::open
       (type (;0;) (func (param i32 i32) (result i32)))
@@ -257,15 +256,17 @@ fn backtraces() {
     )
     "#;
 
-    let blockstore = FailingBlockstore::default();
-    let identity_cid = Cid::new_v1(DAG_CBOR, Multihash::wrap(IDENTITY_HASH, &[0]).unwrap());
-    blockstore.add_fail(identity_cid);
+    let blockstore = {
+        let b = FailingBlockstore::default();
+        b.add_fail(Cid::try_from("baeaikaia").unwrap());
+        Rc::new(b)
+    };
 
     // Instantiate tester
     let mut tester = Tester::new(
         NetworkVersion::V16,
         StateTreeVersion::V4,
-        MemoryBlockstore::default(),
+        blockstore.clone(),
     )
     .unwrap();
 
@@ -274,7 +275,7 @@ fn backtraces() {
     let state_cid = tester.set_state(&State { count: 0 }).unwrap();
 
     // Set an actor that aborts.
-    let (wasm_abort, wasm_fatal) = (wat2wasm(WAT_ABORT).unwrap(), wat2wasm(WAT_FATAL).unwrap());
+    let (wasm_abort, wasm_fatal) = (wat2wasm(WAT_ABORT).unwrap(), wat2wasm(WAT_FAIL).unwrap());
     let (abort_address, fatal_address) = (Address::new_id(10000), Address::new_id(10001));
     tester
         .set_actor_from_bin(&wasm_abort, state_cid, abort_address, BigInt::zero())
@@ -286,58 +287,82 @@ fn backtraces() {
     // Instantiate machine
     tester.instantiate_machine().unwrap();
 
-    // Send message
+    let executor = tester.executor.as_mut().unwrap();
+
     let message = Message {
         from: sender[0].1,
-        to: abort_address,
         gas_limit: 10_000_000,
         method_num: 1,
         ..Message::default()
     };
 
-    let res = tester
-        .executor
-        .as_mut()
-        .unwrap()
-        .execute_message(message, ApplyKind::Explicit, 100)
-        .unwrap();
+    let res = {
+        let message = Message {
+            to: abort_address,
+            ..message.clone()
+        };
+        executor
+            .execute_message(message, ApplyKind::Explicit, 100)
+            .unwrap()
+    };
 
     println!("abort backtrace: {}", res.failure_info.unwrap());
 
-    // Send message
-    let message = Message {
-        from: sender[0].1,
-        to: fatal_address,
-        gas_limit: 10_000_000,
-        method_num: 1,
-        sequence: 1,
-        ..Message::default()
+    let res = {
+        let message = Message {
+            to: fatal_address,
+            sequence: 1,
+            ..message.clone()
+        };
+        executor
+            .execute_message(message, ApplyKind::Explicit, 100)
+            .unwrap()
     };
 
-    let res = tester
-        .executor
-        .as_mut()
-        .unwrap()
-        .execute_message(message, ApplyKind::Explicit, 100)
-        .unwrap();
-
     println!("fatal backtrace: {}", res.failure_info.unwrap());
+
+    // Now make it panic.
+    blockstore.panic(true);
+
+    let res = {
+        let message = Message {
+            to: fatal_address,
+            sequence: 2,
+            ..message.clone()
+        };
+        executor
+            .execute_message(message, ApplyKind::Explicit, 100)
+            .unwrap()
+    };
+
+    println!("panic backtrace: {}", res.failure_info.unwrap());
 }
 
 #[derive(Default)]
 pub struct FailingBlockstore {
     fail_for: RefCell<HashSet<Cid>>,
     target: MemoryBlockstore,
+    panic: RefCell<bool>,
 }
 
 impl FailingBlockstore {
     pub fn add_fail(&self, cid: Cid) {
         self.fail_for.borrow_mut().insert(cid);
     }
+
+    pub fn panic(&self, enabled: bool) {
+        *self.panic.borrow_mut() = enabled
+    }
 }
 
 impl Blockstore for FailingBlockstore {
     fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
+        if self.fail_for.borrow().contains(k) {
+            if *self.panic.borrow() {
+                panic!("panic triggered")
+            }
+            return Err(anyhow!("an error was triggered"));
+        }
         self.target.get(k)
     }
 


### PR DESCRIPTION
Catches panics when invoking Wasm and transforms them into fatal errors. I'm not sure about the safety properties of this, and if this has the chance of poisoning the machine. It doesn't appear like it will.

This also adds an integration test to induce the behaviour.