### PR TITLE
Strongly typed gas units, and fix two related bugs

### DIFF
--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -15,7 +15,7 @@ use num_traits::Zero;
 
 use super::{ApplyFailure, ApplyKind, ApplyRet, Executor};
 use crate::call_manager::{backtrace, CallManager, InvocationResult};
-use crate::gas::{milligas_to_gas, GasCharge, GasOutputs};
+use crate::gas::{Gas, GasCharge, GasOutputs};
 use crate::kernel::{ClassifyResult, Context as _, ExecutionError, Kernel};
 use crate::machine::{Machine, BURNT_FUNDS_ACTOR_ADDR, REWARD_ACTOR_ADDR};
 
@@ -231,10 +231,13 @@ where
         let pl = &self.context().price_list;
 
         let (inclusion_cost, miner_penalty_amount) = match apply_kind {
-            ApplyKind::Implicit => (GasCharge::new("none", 0, 0), Default::default()),
+            ApplyKind::Implicit => (
+                GasCharge::new("none", Gas::zero(), Gas::zero()),
+                Default::default(),
+            ),
             ApplyKind::Explicit => {
                 let inclusion_cost = pl.on_chain_message(raw_length);
-                let inclusion_total = milligas_to_gas(inclusion_cost.total(), true);
+                let inclusion_total = inclusion_cost.total().round_up();
 
                 // Verify the cost of the message is not over the message gas limit.
                 if inclusion_total > msg.gas_limit {

--- a/fvm/src/gas/charge.rs
+++ b/fvm/src/gas/charge.rs
@@ -1,20 +1,20 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::gas::Milligas;
+use super::Gas;
 
 /// Single gas charge in the VM. Contains information about what gas was for, as well
 /// as the amount of gas needed for computation and storage respectively.
 pub struct GasCharge<'a> {
     pub name: &'a str,
-    /// Compute costs in milligas.
-    pub compute_gas: Milligas,
-    /// Storage costs in milligas.
-    pub storage_gas: Milligas,
+    /// Compute costs
+    pub compute_gas: Gas,
+    /// Storage costs
+    pub storage_gas: Gas,
 }
 
 impl<'a> GasCharge<'a> {
-    pub fn new(name: &'a str, compute_gas: Milligas, storage_gas: Milligas) -> Self {
+    pub fn new(name: &'a str, compute_gas: Gas, storage_gas: Gas) -> Self {
         Self {
             name,
             compute_gas,
@@ -24,7 +24,7 @@ impl<'a> GasCharge<'a> {
 
     /// Calculates total gas charge (in milligas) by summing compute and
     /// storage gas associated with this charge.
-    pub fn total(&self) -> Milligas {
+    pub fn total(&self) -> Gas {
         self.compute_gas + self.storage_gas
     }
 }

--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -1,6 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::fmt::{Debug, Display};
+use std::ops::{Add, AddAssign, Mul, Sub, SubAssign};
+
 pub use self::charge::GasCharge;
 pub(crate) use self::outputs::GasOutputs;
 pub use self::price_list::{price_list_by_network_version, PriceList, WasmGasPrices};
@@ -12,13 +15,142 @@ mod price_list;
 
 pub const MILLIGAS_PRECISION: i64 = 1000;
 
-// Type aliases to disambiguate units in interfaces.
-pub type Gas = i64;
-pub type Milligas = i64;
+/// A typesafe representation of gas (internally stored as milligas).
+///
+/// - All math operations are _saturating_ and never overflow.
+/// - Enforces correct units by making it impossible to, e.g., get gas squared (by multiplying gas
+///   by gas).
+/// - Makes it harder to confuse gas and milligas.
+#[derive(Hash, Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Default)]
+pub struct Gas(i64 /* milligas */);
+
+impl Debug for Gas {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0 == 0 {
+            f.debug_tuple("Gas").field(&0 as &dyn Debug).finish()
+        } else {
+            let integral = self.0 / MILLIGAS_PRECISION;
+            let fractional = self.0 % MILLIGAS_PRECISION;
+            f.debug_tuple("Gas")
+                .field(&format_args!("{integral}.{fractional:03}"))
+                .finish()
+        }
+    }
+}
+
+impl Display for Gas {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0 == 0 {
+            f.write_str("0")
+        } else {
+            let integral = self.0 / MILLIGAS_PRECISION;
+            let fractional = self.0 % MILLIGAS_PRECISION;
+            write!(f, "{integral}.{fractional:03}")
+        }
+    }
+}
+
+impl Gas {
+    /// Construct a `Gas` from milligas.
+    #[inline]
+    pub fn from_milligas(milligas: i64) -> Gas {
+        Gas(milligas)
+    }
+
+    /// Construct a `Gas` from gas, scaling up. If this exceeds the width of an i64, it saturates at
+    /// `i64::MAX` milligas.
+    #[inline]
+    pub fn new(gas: i64) -> Gas {
+        Gas(gas.saturating_mul(MILLIGAS_PRECISION))
+    }
+
+    #[inline]
+    pub fn is_saturated(&self) -> bool {
+        self.0 == i64::MAX
+    }
+
+    /// Returns the gas value as an integer, rounding the fractional part up.
+    #[inline]
+    pub fn round_up(&self) -> i64 {
+        milligas_to_gas(self.0, true)
+    }
+
+    /// Returns the gas value as an integer, truncating the fractional part.
+    #[inline]
+    pub fn round_down(&self) -> i64 {
+        milligas_to_gas(self.0, false)
+    }
+
+    /// Returns the gas value as milligas, without loss of precision.
+    #[inline]
+    pub fn as_milligas(&self) -> i64 {
+        self.0
+    }
+}
+
+impl num_traits::Zero for Gas {
+    fn zero() -> Self {
+        Gas(0)
+    }
+
+    fn is_zero(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl Add for Gas {
+    type Output = Gas;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0.saturating_add(rhs.0))
+    }
+}
+
+impl AddAssign for Gas {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 = self.0.saturating_add(rhs.0)
+    }
+}
+
+impl SubAssign for Gas {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0 = self.0.saturating_sub(rhs.0)
+    }
+}
+
+impl Sub for Gas {
+    type Output = Gas;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0.saturating_sub(rhs.0))
+    }
+}
+
+impl Mul<i64> for Gas {
+    type Output = Gas;
+
+    #[inline]
+    fn mul(self, rhs: i64) -> Self::Output {
+        Self(self.0.saturating_mul(rhs))
+    }
+}
+
+impl Mul<i32> for Gas {
+    type Output = Gas;
+
+    #[inline]
+    fn mul(self, rhs: i32) -> Self::Output {
+        Self(self.0.saturating_mul(rhs.into()))
+    }
+}
 
 pub struct GasTracker {
-    milligas_limit: i64,
-    milligas_used: i64,
+    gas_limit: Gas,
+    gas_used: Gas,
 }
 
 impl GasTracker {
@@ -26,72 +158,45 @@ impl GasTracker {
     /// They are converted to milligas for internal canonical accounting.
     pub fn new(gas_limit: Gas, gas_used: Gas) -> Self {
         Self {
-            milligas_limit: gas_to_milligas(gas_limit),
-            milligas_used: gas_to_milligas(gas_used),
+            gas_limit,
+            gas_used,
         }
     }
 
     /// Safely consumes gas and returns an out of gas error if there is not sufficient
     /// enough gas remaining for charge.
-    pub fn charge_milligas(&mut self, name: &str, to_use: Milligas) -> Result<()> {
-        match self.milligas_used.checked_add(to_use) {
-            None => {
-                log::trace!("gas overflow: {}", name);
-                self.milligas_used = self.milligas_limit;
-                Err(ExecutionError::OutOfGas)
-            }
-            Some(used) => {
-                log::trace!("charged {} gas: {}", to_use, name);
-                if used > self.milligas_limit {
-                    log::trace!("out of gas: {}", name);
-                    self.milligas_used = self.milligas_limit;
-                    Err(ExecutionError::OutOfGas)
-                } else {
-                    self.milligas_used = used;
-                    Ok(())
-                }
-            }
+    pub fn charge_gas(&mut self, name: &str, to_use: Gas) -> Result<()> {
+        log::trace!("charging gas: {} {}", name, to_use);
+        // The gas type uses saturating math.
+        self.gas_used += to_use;
+        if self.gas_used > self.gas_limit {
+            log::trace!("gas limit reached");
+            self.gas_used = self.gas_limit;
+            Err(ExecutionError::OutOfGas)
+        } else {
+            Ok(())
         }
     }
 
     /// Applies the specified gas charge, where quantities are supplied in milligas.
     pub fn apply_charge(&mut self, charge: GasCharge) -> Result<()> {
-        self.charge_milligas(charge.name, charge.total())
+        self.charge_gas(charge.name, charge.total())
     }
 
-    /// Getter for gas available.
+    /// Getter for the maximum gas usable by this message.
     pub fn gas_limit(&self) -> Gas {
-        milligas_to_gas(self.milligas_limit, false)
-    }
-
-    /// Getter for milligas available.
-    pub fn milligas_limit(&self) -> Milligas {
-        self.milligas_limit
+        self.gas_limit
     }
 
     /// Getter for gas used.
     pub fn gas_used(&self) -> Gas {
-        milligas_to_gas(self.milligas_used, true)
+        self.gas_used
     }
 
-    /// Getter for milligas used.
-    pub fn milligas_used(&self) -> Milligas {
-        self.milligas_used
-    }
-
+    /// Getter for gas available.
     pub fn gas_available(&self) -> Gas {
-        milligas_to_gas(self.milligas_available(), false)
+        self.gas_limit - self.gas_used
     }
-
-    pub fn milligas_available(&self) -> Milligas {
-        self.milligas_limit.saturating_sub(self.milligas_used)
-    }
-}
-
-/// Converts the specified gas into equivalent fractional gas units
-#[inline]
-pub(crate) fn gas_to_milligas(gas: i64) -> i64 {
-    gas.saturating_mul(MILLIGAS_PRECISION)
 }
 
 /// Converts the specified fractional gas units into gas units
@@ -108,18 +213,20 @@ pub(crate) fn milligas_to_gas(milligas: i64, round_up: bool) -> i64 {
 
 #[cfg(test)]
 mod tests {
+    use num_traits::Zero;
+
     use super::*;
 
     #[test]
     #[allow(clippy::identity_op)]
     fn basic_gas_tracker() -> Result<()> {
-        let mut t = GasTracker::new(20, 10);
-        t.apply_charge(GasCharge::new("", 5 * MILLIGAS_PRECISION, 0))?;
-        assert_eq!(t.gas_used(), 15);
-        t.apply_charge(GasCharge::new("", 5 * MILLIGAS_PRECISION, 0))?;
-        assert_eq!(t.gas_used(), 20);
+        let mut t = GasTracker::new(Gas::new(20), Gas::new(10));
+        t.apply_charge(GasCharge::new("", Gas::new(5), Gas::zero()))?;
+        assert_eq!(t.gas_used(), Gas::new(15));
+        t.apply_charge(GasCharge::new("", Gas::new(5), Gas::zero()))?;
+        assert_eq!(t.gas_used(), Gas::new(20));
         assert!(t
-            .apply_charge(GasCharge::new("", 1 * MILLIGAS_PRECISION, 0))
+            .apply_charge(GasCharge::new("", Gas::new(1), Gas::zero()))
             .is_err());
         Ok(())
     }

--- a/fvm/src/gas/outputs.rs
+++ b/fvm/src/gas/outputs.rs
@@ -3,8 +3,6 @@ use std::convert::TryFrom;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::econ::TokenAmount;
 
-use crate::gas::Gas;
-
 #[derive(Clone, Default)]
 pub(crate) struct GasOutputs {
     pub base_fee_burn: TokenAmount,
@@ -13,14 +11,16 @@ pub(crate) struct GasOutputs {
     pub miner_tip: TokenAmount,
     pub refund: TokenAmount,
 
-    pub gas_refund: Gas,
-    pub gas_burned: Gas,
+    // In whole gas units.
+    pub gas_refund: i64,
+    pub gas_burned: i64,
 }
 
 impl GasOutputs {
     pub fn compute(
-        gas_used: Gas,
-        gas_limit: Gas,
+        // In whole gas units.
+        gas_used: i64,
+        gas_limit: i64,
         base_fee: &TokenAmount,
         fee_cap: &TokenAmount,
         gas_premium: &TokenAmount,
@@ -59,7 +59,7 @@ impl GasOutputs {
     }
 }
 
-fn compute_gas_overestimation_burn(gas_used: Gas, gas_limit: Gas) -> (Gas, Gas) {
+fn compute_gas_overestimation_burn(gas_used: i64, gas_limit: i64) -> (i64, i64) {
     const GAS_OVERUSE_NUM: i64 = 11;
     const GAS_OVERUSE_DENOM: i64 = 10;
 

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -17,51 +17,43 @@ use lazy_static::lazy_static;
 use num_traits::Zero;
 
 use super::GasCharge;
-use crate::gas::Milligas;
-
-/// Converts a static value to milligas. This operation does not saturate,
-/// and should only be used with constant values in pricelists.
-macro_rules! static_milligas {
-    ($ex:expr) => {
-        $ex * $crate::gas::MILLIGAS_PRECISION
-    };
-}
+use crate::gas::Gas;
 
 lazy_static! {
     static ref OH_SNAP_PRICES: PriceList = PriceList {
         storage_gas_multiplier: 1300,
 
-        on_chain_message_compute_base: static_milligas!(38863),
-        on_chain_message_storage_base: static_milligas!(36),
-        on_chain_message_storage_per_byte: static_milligas!(1),
+        on_chain_message_compute_base: Gas::new(38863),
+        on_chain_message_storage_base: Gas::new(36),
+        on_chain_message_storage_per_byte: Gas::new(1),
 
-        on_chain_return_value_per_byte: static_milligas!(1),
+        on_chain_return_value_per_byte: Gas::new(1),
 
-        send_base: static_milligas!(29233),
-        send_transfer_funds: static_milligas!(27500),
-        send_transfer_only_premium: static_milligas!(159672),
-        send_invoke_method: static_milligas!(-5377),
+        send_base: Gas::new(29233),
+        send_transfer_funds: Gas::new(27500),
+        send_transfer_only_premium: Gas::new(159672),
+        send_invoke_method: Gas::new(-5377),
 
-        create_actor_compute: static_milligas!(1108454),
-        create_actor_storage: static_milligas!(36 + 40),
-        delete_actor: static_milligas!(-(36 + 40)),
+        create_actor_compute: Gas::new(1108454),
+        create_actor_storage: Gas::new(36 + 40),
+        delete_actor: Gas::new(-(36 + 40)),
 
-        bls_sig_cost: static_milligas!(16598605),
-        secp256k1_sig_cost: static_milligas!(1637292),
+        bls_sig_cost: Gas::new(16598605),
+        secp256k1_sig_cost: Gas::new(1637292),
 
-        hashing_base: static_milligas!(31355),
-        compute_unsealed_sector_cid_base: static_milligas!(98647),
-        verify_seal_base: static_milligas!(2000), // TODO revisit potential removal of this
+        hashing_base: Gas::new(31355),
+        compute_unsealed_sector_cid_base: Gas::new(98647),
+        verify_seal_base: Gas::new(2000), // TODO revisit potential removal of this
 
-        verify_aggregate_seal_base: 0,
+        verify_aggregate_seal_base: Zero::zero(),
         verify_aggregate_seal_per: [
             (
                 RegisteredSealProof::StackedDRG32GiBV1P1,
-                static_milligas!(449900)
+                Gas::new(449900)
             ),
             (
                 RegisteredSealProof::StackedDRG64GiBV1P1,
-                static_milligas!(359272)
+                Gas::new(359272)
             )
         ].iter().copied().collect(),
         verify_aggregate_seal_steps: [
@@ -69,14 +61,14 @@ lazy_static! {
                 RegisteredSealProof::StackedDRG32GiBV1P1,
                 StepCost (
                     vec![
-                        Step{start: 4, cost: static_milligas!(103994170)},
-                        Step{start: 7, cost: static_milligas!(112356810)},
-                        Step{start: 13, cost: static_milligas!(122912610)},
-                        Step{start: 26, cost: static_milligas!(137559930)},
-                        Step{start: 52, cost: static_milligas!(162039100)},
-                        Step{start: 103, cost: static_milligas!(210960780)},
-                        Step{start: 205, cost: static_milligas!(318351180)},
-                        Step{start: 410, cost: static_milligas!(528274980)},
+                        Step{start: 4, cost: Gas::new(103994170)},
+                        Step{start: 7, cost: Gas::new(112356810)},
+                        Step{start: 13, cost: Gas::new(122912610)},
+                        Step{start: 26, cost: Gas::new(137559930)},
+                        Step{start: 52, cost: Gas::new(162039100)},
+                        Step{start: 103, cost: Gas::new(210960780)},
+                        Step{start: 205, cost: Gas::new(318351180)},
+                        Step{start: 410, cost: Gas::new(528274980)},
                     ]
                 )
             ),
@@ -84,14 +76,14 @@ lazy_static! {
                 RegisteredSealProof::StackedDRG64GiBV1P1,
                 StepCost (
                     vec![
-                        Step{start: 4, cost: static_milligas!(102581240)},
-                        Step{start: 7, cost: static_milligas!(110803030)},
-                        Step{start: 13, cost: static_milligas!(120803700)},
-                        Step{start: 26, cost: static_milligas!(134642130)},
-                        Step{start: 52, cost: static_milligas!(157357890)},
-                        Step{start: 103, cost: static_milligas!(203017690)},
-                        Step{start: 205, cost: static_milligas!(304253590)},
-                        Step{start: 410, cost: static_milligas!(509880640)},
+                        Step{start: 4, cost: Gas::new(102581240)},
+                        Step{start: 7, cost: Gas::new(110803030)},
+                        Step{start: 13, cost: Gas::new(120803700)},
+                        Step{start: 26, cost: Gas::new(134642130)},
+                        Step{start: 52, cost: Gas::new(157357890)},
+                        Step{start: 103, cost: Gas::new(203017690)},
+                        Step{start: 205, cost: Gas::new(304253590)},
+                        Step{start: 410, cost: Gas::new(509880640)},
                     ]
                 )
             )
@@ -99,28 +91,28 @@ lazy_static! {
         .cloned()
         .collect(),
 
-        verify_consensus_fault: static_milligas!(495422),
-        verify_replica_update: static_milligas!(36316136),
+        verify_consensus_fault: Gas::new(495422),
+        verify_replica_update: Gas::new(36316136),
         verify_post_lookup: [
             (
                 RegisteredPoStProof::StackedDRGWindow512MiBV1,
                 ScalingCost {
-                    flat: static_milligas!(117680921),
-                    scale: static_milligas!(43780),
+                    flat: Gas::new(117680921),
+                    scale: Gas::new(43780),
                 },
             ),
             (
                 RegisteredPoStProof::StackedDRGWindow32GiBV1,
                 ScalingCost {
-                    flat: static_milligas!(117680921),
-                    scale: static_milligas!(43780),
+                    flat: Gas::new(117680921),
+                    scale: Gas::new(43780),
                 },
             ),
             (
                 RegisteredPoStProof::StackedDRGWindow64GiBV1,
                 ScalingCost {
-                    flat: static_milligas!(117680921),
-                    scale: static_milligas!(43780),
+                    flat: Gas::new(117680921),
+                    scale: Gas::new(43780),
                 },
             ),
         ]
@@ -128,65 +120,65 @@ lazy_static! {
         .copied()
         .collect(),
 
-        get_randomness_base: 0,
-        get_randomness_per_byte: 0,
+        get_randomness_base: Zero::zero(),
+        get_randomness_per_byte: Zero::zero(),
 
-        block_memcpy_per_byte_cost: 0,
+        block_memcpy_per_byte_cost: Zero::zero(),
 
-        block_open_base: static_milligas!(114617),
-        block_open_memret_per_byte_cost: 0,
+        block_open_base: Gas::new(114617),
+        block_open_memret_per_byte_cost: Zero::zero(),
 
-        block_link_base: static_milligas!(353640),
-        block_link_storage_per_byte_cost: static_milligas!(1),
+        block_link_base: Gas::new(353640),
+        block_link_storage_per_byte_cost: Gas::new(1),
 
-        block_create_base: 0,
-        block_create_memret_per_byte_cost: 0,
+        block_create_base: Zero::zero(),
+        block_create_memret_per_byte_cost: Zero::zero(),
 
-        block_read_base: 0,
-        block_stat_base: 0,
+        block_read_base: Zero::zero(),
+        block_stat_base: Zero::zero(),
 
-        syscall_cost: 0,
-        extern_cost: 0,
+        syscall_cost: Zero::zero(),
+        extern_cost: Zero::zero(),
 
         wasm_rules: WasmGasPrices{
-            exec_instruction_cost_milli: 0,
+            exec_instruction_cost: Zero::zero(),
         },
     };
 
     static ref SKYR_PRICES: PriceList = PriceList {
         storage_gas_multiplier: 1300,
 
-        on_chain_message_compute_base: static_milligas!(38863),
-        on_chain_message_storage_base: static_milligas!(36),
-        on_chain_message_storage_per_byte: static_milligas!(1),
+        on_chain_message_compute_base: Gas::new(38863),
+        on_chain_message_storage_base: Gas::new(36),
+        on_chain_message_storage_per_byte: Gas::new(1),
 
-        on_chain_return_value_per_byte: static_milligas!(1),
+        on_chain_return_value_per_byte: Gas::new(1),
 
-        send_base: static_milligas!(29233),
-        send_transfer_funds: static_milligas!(27500),
-        send_transfer_only_premium: static_milligas!(159672),
-        send_invoke_method: static_milligas!(-5377),
+        send_base: Gas::new(29233),
+        send_transfer_funds: Gas::new(27500),
+        send_transfer_only_premium: Gas::new(159672),
+        send_invoke_method: Gas::new(-5377),
 
-        create_actor_compute: static_milligas!(1108454),
-        create_actor_storage: static_milligas!(36 + 40),
-        delete_actor: static_milligas!(-(36 + 40)),
+        create_actor_compute: Gas::new(1108454),
+        create_actor_storage: Gas::new(36 + 40),
+        delete_actor: Gas::new(-(36 + 40)),
 
-        bls_sig_cost: static_milligas!(16598605),
-        secp256k1_sig_cost: static_milligas!(1637292),
+        bls_sig_cost: Gas::new(16598605),
+        secp256k1_sig_cost: Gas::new(1637292),
 
-        hashing_base: static_milligas!(31355),
-        compute_unsealed_sector_cid_base: static_milligas!(98647),
-        verify_seal_base: static_milligas!(2000), // TODO revisit potential removal of this
+        hashing_base: Gas::new(31355),
+        compute_unsealed_sector_cid_base: Gas::new(98647),
+        verify_seal_base: Gas::new(2000), // TODO revisit potential removal of this
 
-        verify_aggregate_seal_base: 0,
+        verify_aggregate_seal_base: Zero::zero(),
         verify_aggregate_seal_per: [
             (
                 RegisteredSealProof::StackedDRG32GiBV1P1,
-                static_milligas!(449900)
+                Gas::new(449900)
             ),
             (
                 RegisteredSealProof::StackedDRG64GiBV1P1,
-                static_milligas!(359272)
+                Gas::new(359272)
             )
         ].iter().copied().collect(),
         verify_aggregate_seal_steps: [
@@ -194,14 +186,14 @@ lazy_static! {
                 RegisteredSealProof::StackedDRG32GiBV1P1,
                 StepCost (
                     vec![
-                        Step{start: 4, cost: static_milligas!(103994170)},
-                        Step{start: 7, cost: static_milligas!(112356810)},
-                        Step{start: 13, cost: static_milligas!(122912610)},
-                        Step{start: 26, cost: static_milligas!(137559930)},
-                        Step{start: 52, cost: static_milligas!(162039100)},
-                        Step{start: 103, cost: static_milligas!(210960780)},
-                        Step{start: 205, cost: static_milligas!(318351180)},
-                        Step{start: 410, cost: static_milligas!(528274980)},
+                        Step{start: 4, cost: Gas::new(103994170)},
+                        Step{start: 7, cost: Gas::new(112356810)},
+                        Step{start: 13, cost: Gas::new(122912610)},
+                        Step{start: 26, cost: Gas::new(137559930)},
+                        Step{start: 52, cost: Gas::new(162039100)},
+                        Step{start: 103, cost: Gas::new(210960780)},
+                        Step{start: 205, cost: Gas::new(318351180)},
+                        Step{start: 410, cost: Gas::new(528274980)},
                     ]
                 )
             ),
@@ -209,14 +201,14 @@ lazy_static! {
                 RegisteredSealProof::StackedDRG64GiBV1P1,
                 StepCost (
                     vec![
-                        Step{start: 4, cost: static_milligas!(102581240)},
-                        Step{start: 7, cost: static_milligas!(110803030)},
-                        Step{start: 13, cost: static_milligas!(120803700)},
-                        Step{start: 26, cost: static_milligas!(134642130)},
-                        Step{start: 52, cost: static_milligas!(157357890)},
-                        Step{start: 103, cost: static_milligas!(203017690)},
-                        Step{start: 205, cost: static_milligas!(304253590)},
-                        Step{start: 410, cost: static_milligas!(509880640)},
+                        Step{start: 4, cost: Gas::new(102581240)},
+                        Step{start: 7, cost: Gas::new(110803030)},
+                        Step{start: 13, cost: Gas::new(120803700)},
+                        Step{start: 26, cost: Gas::new(134642130)},
+                        Step{start: 52, cost: Gas::new(157357890)},
+                        Step{start: 103, cost: Gas::new(203017690)},
+                        Step{start: 205, cost: Gas::new(304253590)},
+                        Step{start: 410, cost: Gas::new(509880640)},
                     ]
                 )
             )
@@ -225,28 +217,28 @@ lazy_static! {
         .collect(),
 
         // TODO: PARAM_FINISH: this may need to be increased to account for the cost of an extern
-        verify_consensus_fault: static_milligas!(495422),
-        verify_replica_update: static_milligas!(36316136),
+        verify_consensus_fault: Gas::new(495422),
+        verify_replica_update: Gas::new(36316136),
         verify_post_lookup: [
             (
                 RegisteredPoStProof::StackedDRGWindow512MiBV1,
                 ScalingCost {
-                    flat: static_milligas!(117680921),
-                    scale: static_milligas!(43780),
+                    flat: Gas::new(117680921),
+                    scale: Gas::new(43780),
                 },
             ),
             (
                 RegisteredPoStProof::StackedDRGWindow32GiBV1,
                 ScalingCost {
-                    flat: static_milligas!(117680921),
-                    scale: static_milligas!(43780),
+                    flat: Gas::new(117680921),
+                    scale: Gas::new(43780),
                 },
             ),
             (
                 RegisteredPoStProof::StackedDRGWindow64GiBV1,
                 ScalingCost {
-                    flat: static_milligas!(117680921),
-                    scale: static_milligas!(43780),
+                    flat: Gas::new(117680921),
+                    scale: Gas::new(43780),
                 },
             ),
         ]
@@ -254,36 +246,36 @@ lazy_static! {
         .copied()
         .collect(),
 
-        get_randomness_base: 0,
-        get_randomness_per_byte: 0,
+        get_randomness_base: Zero::zero(),
+        get_randomness_per_byte: Zero::zero(),
 
-        block_memcpy_per_byte_cost: 500,
+        block_memcpy_per_byte_cost: Gas::from_milligas(500),
 
-        block_open_base: static_milligas!(114617),
-        block_open_memret_per_byte_cost: static_milligas!(10),
+        block_open_base: Gas::new(114617),
+        block_open_memret_per_byte_cost: Gas::new(10),
 
-        block_link_base: static_milligas!(353640),
-        block_link_storage_per_byte_cost: static_milligas!(1),
+        block_link_base: Gas::new(353640),
+        block_link_storage_per_byte_cost: Gas::new(1),
 
-        block_create_base: 0,
-        block_create_memret_per_byte_cost: static_milligas!(10),
+        block_create_base: Zero::zero(),
+        block_create_memret_per_byte_cost: Gas::new(10),
 
-        block_read_base: 0,
-        block_stat_base: 0,
+        block_read_base: Zero::zero(),
+        block_stat_base: Zero::zero(),
 
-        syscall_cost: static_milligas!(14000),
-        extern_cost: static_milligas!(21000),
+        syscall_cost: Gas::new(14000),
+        extern_cost: Gas::new(21000),
 
         wasm_rules: WasmGasPrices{
-            exec_instruction_cost_milli: static_milligas!(4) as u64,
+            exec_instruction_cost: Gas::new(4),
         },
     };
 }
 
 #[derive(Clone, Debug, Copy)]
 pub(crate) struct ScalingCost {
-    flat: i64,
-    scale: i64,
+    flat: Gas,
+    scale: Gas,
 }
 
 #[derive(Clone, Debug)]
@@ -292,11 +284,11 @@ pub(crate) struct StepCost(Vec<Step>);
 #[derive(Clone, Debug, Copy)]
 pub(crate) struct Step {
     start: i64,
-    cost: i64,
+    cost: Gas,
 }
 
 impl StepCost {
-    pub(crate) fn lookup(&self, x: i64) -> i64 {
+    pub(crate) fn lookup(&self, x: i64) -> Gas {
         let mut i: i64 = 0;
         while i < self.0.len() as i64 {
             if self.0[i as usize].start > x {
@@ -306,7 +298,7 @@ impl StepCost {
         }
         i -= 1;
         if i < 0 {
-            return 0;
+            return Gas::zero();
         }
         self.0[i as usize].cost
     }
@@ -325,96 +317,96 @@ pub struct PriceList {
     /// Together, these account for the cost of message propagation and validation,
     /// up to but excluding any actual processing by the VM.
     /// This is the cost a block producer burns when including an invalid message.
-    pub(crate) on_chain_message_compute_base: Milligas,
-    pub(crate) on_chain_message_storage_base: Milligas,
-    pub(crate) on_chain_message_storage_per_byte: Milligas,
+    pub(crate) on_chain_message_compute_base: Gas,
+    pub(crate) on_chain_message_storage_base: Gas,
+    pub(crate) on_chain_message_storage_per_byte: Gas,
 
     /// Gas cost charged to the originator of a non-nil return value produced
     /// by an on-chain message is given by:
     ///   len(return value)*OnChainReturnValuePerByte
-    pub(crate) on_chain_return_value_per_byte: Milligas,
+    pub(crate) on_chain_return_value_per_byte: Gas,
 
     /// Gas cost for any message send execution(including the top-level one
     /// initiated by an on-chain message).
     /// This accounts for the cost of loading sender and receiver actors and
     /// (for top-level messages) incrementing the sender's sequence number.
     /// Load and store of actor sub-state is charged separately.
-    pub(crate) send_base: Milligas,
+    pub(crate) send_base: Gas,
 
     /// Gas cost charged, in addition to SendBase, if a message send
     /// is accompanied by any nonzero currency amount.
     /// Accounts for writing receiver's new balance (the sender's state is
     /// already accounted for).
-    pub(crate) send_transfer_funds: Milligas,
+    pub(crate) send_transfer_funds: Gas,
 
     /// Gas cost charged, in addition to SendBase, if message only transfers funds.
-    pub(crate) send_transfer_only_premium: Milligas,
+    pub(crate) send_transfer_only_premium: Gas,
 
     /// Gas cost charged, in addition to SendBase, if a message invokes
     /// a method on the receiver.
     /// Accounts for the cost of loading receiver code and method dispatch.
-    pub(crate) send_invoke_method: Milligas,
+    pub(crate) send_invoke_method: Gas,
 
     /// Gas cost for creating a new actor (via InitActor's Exec method).
     /// Note: this costs assume that the extra will be partially or totally refunded while
     /// the base is covering for the put.
-    pub(crate) create_actor_compute: Milligas,
-    pub(crate) create_actor_storage: Milligas,
+    pub(crate) create_actor_compute: Gas,
+    pub(crate) create_actor_storage: Gas,
 
     /// Gas cost for deleting an actor.
     /// Note: this partially refunds the create cost to incentivise the deletion of the actors.
-    pub(crate) delete_actor: Milligas,
+    pub(crate) delete_actor: Gas,
 
     /// Gas cost for verifying bls signature
-    pub(crate) bls_sig_cost: Milligas,
+    pub(crate) bls_sig_cost: Gas,
     /// Gas cost for verifying secp256k1 signature
-    pub(crate) secp256k1_sig_cost: Milligas,
+    pub(crate) secp256k1_sig_cost: Gas,
 
-    pub(crate) hashing_base: Milligas,
+    pub(crate) hashing_base: Gas,
 
-    pub(crate) compute_unsealed_sector_cid_base: Milligas,
-    pub(crate) verify_seal_base: Milligas,
+    pub(crate) compute_unsealed_sector_cid_base: Gas,
+    pub(crate) verify_seal_base: Gas,
     #[allow(unused)]
-    pub(crate) verify_aggregate_seal_base: Milligas,
-    pub(crate) verify_aggregate_seal_per: AHashMap<RegisteredSealProof, i64>,
+    pub(crate) verify_aggregate_seal_base: Gas,
+    pub(crate) verify_aggregate_seal_per: AHashMap<RegisteredSealProof, Gas>,
     pub(crate) verify_aggregate_seal_steps: AHashMap<RegisteredSealProof, StepCost>,
 
     pub(crate) verify_post_lookup: AHashMap<RegisteredPoStProof, ScalingCost>,
-    pub(crate) verify_consensus_fault: Milligas,
-    pub(crate) verify_replica_update: Milligas,
+    pub(crate) verify_consensus_fault: Gas,
+    pub(crate) verify_replica_update: Gas,
 
     /// Gas cost for fetching randomness.
-    pub(crate) get_randomness_base: Milligas,
+    pub(crate) get_randomness_base: Gas,
     /// Gas cost per every byte of randomness fetched.
-    pub(crate) get_randomness_per_byte: Milligas,
+    pub(crate) get_randomness_per_byte: Gas,
 
     /// Gas cost per every block byte memcopied across boundaries.
-    pub(crate) block_memcpy_per_byte_cost: Milligas,
+    pub(crate) block_memcpy_per_byte_cost: Gas,
 
     /// Gas cost for opening a block.
-    pub(crate) block_open_base: Milligas,
+    pub(crate) block_open_base: Gas,
     /// Gas cost for every byte retained in FVM space when opening a block.
-    pub(crate) block_open_memret_per_byte_cost: Milligas,
+    pub(crate) block_open_memret_per_byte_cost: Gas,
 
     /// Gas cost for linking a block.
-    pub(crate) block_link_base: Milligas,
+    pub(crate) block_link_base: Gas,
     /// Multiplier for storage gas per byte.
-    pub(crate) block_link_storage_per_byte_cost: Milligas,
+    pub(crate) block_link_storage_per_byte_cost: Gas,
 
     /// Gas cost for creating a block.
-    pub(crate) block_create_base: Milligas,
+    pub(crate) block_create_base: Gas,
     /// Gas cost for every byte retained in FVM space when writing a block.
-    pub(crate) block_create_memret_per_byte_cost: Milligas,
+    pub(crate) block_create_memret_per_byte_cost: Gas,
 
     /// Gas cost for reading a block into actor space.
-    pub(crate) block_read_base: Milligas,
+    pub(crate) block_read_base: Gas,
     /// Gas cost for statting a block.
-    pub(crate) block_stat_base: Milligas,
+    pub(crate) block_stat_base: Gas,
 
     /// General gas cost for performing a syscall, accounting for the overhead thereof.
-    pub(crate) syscall_cost: Milligas,
+    pub(crate) syscall_cost: Gas,
     /// General gas cost for calling an extern, accounting for the overhead thereof.
-    pub(crate) extern_cost: Milligas,
+    pub(crate) extern_cost: Gas,
 
     /// Rules for execution gas.
     pub(crate) wasm_rules: WasmGasPrices,
@@ -422,7 +414,7 @@ pub struct PriceList {
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct WasmGasPrices {
-    pub(crate) exec_instruction_cost_milli: u64,
+    pub(crate) exec_instruction_cost: Gas,
 }
 
 impl PriceList {
@@ -443,8 +435,8 @@ impl PriceList {
     pub fn on_chain_return_value(&self, data_size: usize) -> GasCharge<'static> {
         GasCharge::new(
             "OnChainReturnValue",
-            0,
-            data_size as i64 * self.on_chain_return_value_per_byte * self.storage_gas_multiplier,
+            Zero::zero(),
+            self.on_chain_return_value_per_byte * data_size as i64 * self.storage_gas_multiplier,
         )
     }
 
@@ -465,12 +457,12 @@ impl PriceList {
         if method_num != METHOD_SEND {
             ret += self.send_invoke_method;
         }
-        GasCharge::new("OnMethodInvocation", ret, 0)
+        GasCharge::new("OnMethodInvocation", ret, Zero::zero())
     }
 
     /// Returns the gas cost to be applied on a syscall.
     pub fn on_syscall(&self) -> GasCharge<'static> {
-        GasCharge::new("OnSyscall", self.syscall_cost, 0)
+        GasCharge::new("OnSyscall", self.syscall_cost, Zero::zero())
     }
 
     /// Returns the gas required for creating an actor.
@@ -488,7 +480,7 @@ impl PriceList {
     pub fn on_delete_actor(&self) -> GasCharge<'static> {
         GasCharge::new(
             "OnDeleteActor",
-            0,
+            Zero::zero(),
             self.delete_actor * self.storage_gas_multiplier,
         )
     }
@@ -500,13 +492,13 @@ impl PriceList {
             SignatureType::BLS => self.bls_sig_cost,
             SignatureType::Secp256k1 => self.secp256k1_sig_cost,
         };
-        GasCharge::new("OnVerifySignature", val, 0)
+        GasCharge::new("OnVerifySignature", val, Zero::zero())
     }
 
     /// Returns gas required for hashing data.
     #[inline]
     pub fn on_hashing(&self, _: usize) -> GasCharge<'static> {
-        GasCharge::new("OnHashing", self.hashing_base, 0)
+        GasCharge::new("OnHashing", self.hashing_base, Zero::zero())
     }
 
     /// Returns gas required for computing unsealed sector Cid.
@@ -519,14 +511,14 @@ impl PriceList {
         GasCharge::new(
             "OnComputeUnsealedSectorCid",
             self.compute_unsealed_sector_cid_base,
-            0,
+            Zero::zero(),
         )
     }
 
     /// Returns gas required for seal verification.
     #[inline]
     pub fn on_verify_seal(&self, _info: &SealVerifyInfo) -> GasCharge<'static> {
-        GasCharge::new("OnVerifySeal", self.verify_seal_base, 0)
+        GasCharge::new("OnVerifySeal", self.verify_seal_base, Zero::zero())
     }
     #[inline]
     pub fn on_verify_aggregate_seals(
@@ -534,7 +526,7 @@ impl PriceList {
         aggregate: &AggregateSealVerifyProofAndInfos,
     ) -> GasCharge<'static> {
         let proof_type = aggregate.seal_proof;
-        let per_proof = self
+        let per_proof = *self
             .verify_aggregate_seal_per
             .get(&proof_type)
             .unwrap_or_else(|| {
@@ -560,14 +552,18 @@ impl PriceList {
         GasCharge::new(
             "OnVerifyAggregateSeals",
             per_proof * num + step.lookup(num),
-            0,
+            Zero::zero(),
         )
     }
 
     /// Returns gas required for replica verification.
     #[inline]
     pub fn on_verify_replica_update(&self, _replica: &ReplicaUpdateInfo) -> GasCharge<'static> {
-        GasCharge::new("OnVerifyReplicaUpdate", self.verify_replica_update, 0)
+        GasCharge::new(
+            "OnVerifyReplicaUpdate",
+            self.verify_replica_update,
+            Zero::zero(),
+        )
     }
 
     /// Returns gas required for PoSt verification.
@@ -584,9 +580,9 @@ impl PriceList {
                 .expect("512MiB lookup must exist in price table")
         });
 
-        let gas_used = cost.flat + info.challenged_sectors.len() as i64 * cost.scale;
+        let gas_used = cost.flat + cost.scale * info.challenged_sectors.len() as i64;
 
-        GasCharge::new("OnVerifyPost", gas_used, 0)
+        GasCharge::new("OnVerifyPost", gas_used, Zero::zero())
     }
 
     /// Returns gas required for verifying consensus fault.
@@ -594,8 +590,8 @@ impl PriceList {
     pub fn on_verify_consensus_fault(&self) -> GasCharge<'static> {
         GasCharge::new(
             "OnVerifyConsensusFault",
-            self.extern_cost.saturating_add(self.verify_consensus_fault),
-            0,
+            self.extern_cost + self.verify_consensus_fault,
+            Zero::zero(),
         )
     }
 
@@ -606,12 +602,9 @@ impl PriceList {
         GasCharge::new(
             "OnGetRandomness",
             self.extern_cost
-                .saturating_add(self.get_randomness_base)
-                .saturating_add(
-                    self.get_randomness_per_byte
-                        .saturating_mul(entropy_size as i64),
-                ),
-            0,
+                + self.get_randomness_base
+                + (self.get_randomness_per_byte * entropy_size as i64),
+            Zero::zero(),
         )
     }
 
@@ -620,8 +613,8 @@ impl PriceList {
     pub fn on_block_open_base(&self) -> GasCharge<'static> {
         GasCharge::new(
             "OnBlockOpenBase",
-            self.extern_cost.saturating_add(self.block_open_base),
-            0,
+            self.extern_cost + self.block_open_base,
+            Zero::zero(),
         )
     }
 
@@ -631,9 +624,9 @@ impl PriceList {
         let size = data_size as i64;
         GasCharge::new(
             "OnBlockOpenPerByte",
-            self.block_open_memret_per_byte_cost.saturating_mul(size)
-                + self.block_memcpy_per_byte_cost.saturating_mul(size),
-            0,
+            (self.block_open_memret_per_byte_cost * size)
+                + (self.block_memcpy_per_byte_cost * size),
+            Zero::zero(),
         )
     }
 
@@ -642,11 +635,8 @@ impl PriceList {
     pub fn on_block_read(&self, data_size: usize) -> GasCharge<'static> {
         GasCharge::new(
             "OnBlockRead",
-            self.block_read_base.saturating_add(
-                self.block_memcpy_per_byte_cost
-                    .saturating_mul(data_size as i64),
-            ),
-            0,
+            self.block_read_base + (self.block_memcpy_per_byte_cost * data_size as i64),
+            Zero::zero(),
         )
     }
 
@@ -654,14 +644,12 @@ impl PriceList {
     #[inline]
     pub fn on_block_create(&self, data_size: usize) -> GasCharge<'static> {
         let size = data_size as i64;
-        let mem_costs = self
-            .block_create_memret_per_byte_cost
-            .saturating_mul(size)
-            .saturating_add(self.block_memcpy_per_byte_cost.saturating_mul(size));
+        let mem_costs = (self.block_create_memret_per_byte_cost * size)
+            + (self.block_memcpy_per_byte_cost * size);
         GasCharge::new(
             "OnBlockCreate",
-            self.block_create_base.saturating_add(mem_costs),
-            0,
+            self.block_create_base + mem_costs,
+            Zero::zero(),
         )
     }
 
@@ -669,25 +657,22 @@ impl PriceList {
     #[inline]
     pub fn on_block_link(&self, data_size: usize) -> GasCharge<'static> {
         let size = data_size as i64;
-        let memcpy = self.block_memcpy_per_byte_cost.saturating_mul(size);
+        let memcpy = self.block_memcpy_per_byte_cost * size;
         GasCharge::new(
             "OnBlockLink",
             // twice the memcpy cost:
             // - one from the block registry to the FVM BufferedBlockstore
             // - one from the FVM BufferedBlockstore to the Node's Blockstore
             //   when the machine finishes.
-            self.block_link_base
-                .saturating_add((2_i64).saturating_mul(memcpy)),
-            self.block_link_storage_per_byte_cost
-                .saturating_mul(self.storage_gas_multiplier)
-                .saturating_mul(size),
+            self.block_link_base + (memcpy * 2),
+            self.block_link_storage_per_byte_cost * self.storage_gas_multiplier * size,
         )
     }
 
     /// Returns the gas required for storing an object.
     #[inline]
     pub fn on_block_stat(&self) -> GasCharge<'static> {
-        GasCharge::new("OnBlockStat", self.block_stat_base, 0)
+        GasCharge::new("OnBlockStat", self.block_stat_base, Zero::zero())
     }
 }
 
@@ -701,7 +686,7 @@ pub fn price_list_by_network_version(network_version: NetworkVersion) -> &'stati
 
 impl Rules for WasmGasPrices {
     fn instruction_cost(&self, instruction: &Instruction) -> Option<u64> {
-        if self.exec_instruction_cost_milli == 0 {
+        if self.exec_instruction_cost.is_zero() {
             return Some(0);
         }
 
@@ -719,7 +704,7 @@ impl Rules for WasmGasPrices {
             | Instruction::Return
             | Instruction::Else
             | Instruction::End => Some(0),
-            _ => Some(self.exec_instruction_cost_milli),
+            _ => Some(self.exec_instruction_cost.as_milligas() as u64),
         }
     }
 

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -106,21 +106,21 @@ lazy_static! {
                 RegisteredPoStProof::StackedDRGWindow512MiBV1,
                 ScalingCost {
                     flat: static_milligas!(117680921),
-                    scale: 43780,
+                    scale: static_milligas!(43780),
                 },
             ),
             (
                 RegisteredPoStProof::StackedDRGWindow32GiBV1,
                 ScalingCost {
                     flat: static_milligas!(117680921),
-                    scale: 43780,
+                    scale: static_milligas!(43780),
                 },
             ),
             (
                 RegisteredPoStProof::StackedDRGWindow64GiBV1,
                 ScalingCost {
                     flat: static_milligas!(117680921),
-                    scale: 43780,
+                    scale: static_milligas!(43780),
                 },
             ),
         ]
@@ -232,21 +232,21 @@ lazy_static! {
                 RegisteredPoStProof::StackedDRGWindow512MiBV1,
                 ScalingCost {
                     flat: static_milligas!(117680921),
-                    scale: 43780,
+                    scale: static_milligas!(43780),
                 },
             ),
             (
                 RegisteredPoStProof::StackedDRGWindow32GiBV1,
                 ScalingCost {
                     flat: static_milligas!(117680921),
-                    scale: 43780,
+                    scale: static_milligas!(43780),
                 },
             ),
             (
                 RegisteredPoStProof::StackedDRGWindow64GiBV1,
                 ScalingCost {
                     flat: static_milligas!(117680921),
-                    scale: 43780,
+                    scale: static_milligas!(43780),
                 },
             ),
         ]

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -544,8 +544,8 @@ where
         if self.network_version() <= NetworkVersion::V15 {
             self.call_manager.charge_gas(GasCharge::new(
                 "verify_consensus_fault_accesses",
-                gas,
-                0,
+                Gas::new(gas),
+                Gas::zero(),
             ))?;
         }
 
@@ -693,25 +693,18 @@ impl<C> GasOps for DefaultKernel<C>
 where
     C: CallManager,
 {
-    fn gas_used(&self) -> i64 {
+    fn gas_used(&self) -> Gas {
         self.call_manager.gas_tracker().gas_used()
     }
 
-    fn milligas_used(&self) -> i64 {
-        self.call_manager.gas_tracker().milligas_used()
-    }
-
-    fn gas_available(&self) -> i64 {
+    fn gas_available(&self) -> Gas {
         self.call_manager.gas_tracker().gas_available()
     }
 
-    fn milligas_available(&self) -> i64 {
-        self.call_manager.gas_tracker().milligas_available()
-    }
-
-    fn charge_milligas(&mut self, name: &str, compute: Milligas) -> Result<()> {
-        let charge = GasCharge::new(name, compute, 0);
-        self.call_manager.gas_tracker_mut().apply_charge(charge)
+    fn charge_gas(&mut self, name: &str, compute: Gas) -> Result<()> {
+        self.call_manager
+            .gas_tracker_mut()
+            .charge_gas(name, compute)
     }
 
     fn price_list(&self) -> &PriceList {

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -24,7 +24,7 @@ mod error;
 pub use error::{ClassifyResult, Context, ExecutionError, Result, SyscallError};
 
 use crate::call_manager::{CallManager, InvocationResult};
-use crate::gas::{Gas, Milligas, PriceList};
+use crate::gas::{Gas, PriceList};
 use crate::machine::Machine;
 
 pub trait Kernel:
@@ -215,15 +215,13 @@ pub trait CircSupplyOps {
 pub trait GasOps {
     /// Returns the gas used by the transaction so far.
     fn gas_used(&self) -> Gas;
-    fn milligas_used(&self) -> Milligas;
 
     /// Returns the remaining gas for the transaction.
     fn gas_available(&self) -> Gas;
-    fn milligas_available(&self) -> Milligas;
 
     /// ChargeGas charges specified amount of `gas` for execution.
     /// `name` provides information about gas charging point.
-    fn charge_milligas(&mut self, name: &str, compute: Milligas) -> Result<()>;
+    fn charge_gas(&mut self, name: &str, compute: Gas) -> Result<()>;
 
     /// Returns the currently active gas price list.
     fn price_list(&self) -> &PriceList;

--- a/fvm/src/syscalls/bind.rs
+++ b/fvm/src/syscalls/bind.rs
@@ -99,7 +99,7 @@ macro_rules! charge_syscall_gas {
     ($kernel:expr) => {
         let charge = $kernel.price_list().on_syscall();
         $kernel
-            .charge_milligas(charge.name, charge.compute_gas)
+            .charge_gas(charge.name, charge.compute_gas)
             .map_err(Abort::from_error_as_fatal)?;
     };
 }

--- a/fvm/src/syscalls/gas.rs
+++ b/fvm/src/syscalls/gas.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use super::Context;
-use crate::gas::gas_to_milligas;
+use crate::gas::Gas;
 use crate::kernel::{ClassifyResult, Result};
 use crate::Kernel;
 
@@ -14,7 +14,5 @@ pub fn charge_gas(
     let name =
         str::from_utf8(context.memory.try_slice(name_off, name_len)?).or_illegal_argument()?;
     // Gas charges from actors are always in full gas units. We use milligas internally, so convert here.
-    context
-        .kernel
-        .charge_milligas(name, gas_to_milligas(compute))
+    context.kernel.charge_gas(name, Gas::new(compute))
 }

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -5,6 +5,7 @@ use cid::Cid;
 use wasmtime::{AsContextMut, Global, Linker, Memory, Val};
 
 use crate::call_manager::backtrace;
+use crate::gas::Gas;
 use crate::Kernel;
 
 pub(crate) mod error;
@@ -50,7 +51,7 @@ pub fn update_gas_available(
     ctx: &mut impl AsContextMut<Data = InvocationData<impl Kernel>>,
 ) -> Result<(), Abort> {
     let mut ctx = ctx.as_context_mut();
-    let avail_milligas = ctx.data_mut().kernel.milligas_available();
+    let avail_milligas = ctx.data_mut().kernel.gas_available().as_milligas();
 
     let gas_global = ctx.data_mut().avail_gas_global;
     gas_global
@@ -84,7 +85,7 @@ pub fn charge_for_exec(
 
     ctx.data_mut()
         .kernel
-        .charge_milligas("wasm_exec", milligas_used)
+        .charge_gas("wasm_exec", Gas::from_milligas(milligas_used))
         .map_err(Abort::from_error_as_fatal)?;
 
     Ok(())


### PR DESCRIPTION
Motivation: we had two bugs in gas units (milligas versus gas):

1. Consensus fault charges from lotus (only applies to nv15).
2. Window post scaling charge.

This fixes those bugs, and adds a new "safe" gas type that lets us automatically avoid:

1. Multiplying gas by gas. Only `Gas * (i32/i64)` is implemented.
2. Adding gas to non-gas. Only `Gas + Gas` is implemented.
3. Swapping gas/milligas.
4. Not using saturating arithmetic. All gas operations use saturating arithmetic internally.

The automatic saturating arithmetic also makes the code significantly cleaner.