### PR TITLE
clean up ipld syscall naming.

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -245,7 +245,7 @@ where
     }
 }
 
-impl<C> BlockOps for DefaultKernel<C>
+impl<C> IpldBlockOps for DefaultKernel<C>
 where
     C: CallManager,
 {

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -34,7 +34,7 @@ pub enum SendResult {
 /// The "kernel" implements
 pub trait Kernel:
     ActorOps
-    + BlockOps
+    + IpldBlockOps
     + CircSupplyOps
     + CryptoOps
     + DebugOps
@@ -101,7 +101,7 @@ pub trait MessageOps {
 }
 
 /// The IPLD subset of the kernel.
-pub trait BlockOps {
+pub trait IpldBlockOps {
     /// Open a block.
     ///
     /// This method will fail if the requested block isn't reachable.
@@ -134,7 +134,7 @@ pub trait BlockOps {
 
 /// Actor state access and manipulation.
 /// Depends on BlockOps to read and write blocks in the state tree.
-pub trait SelfOps: BlockOps {
+pub trait SelfOps: IpldBlockOps {
     /// Get the state root.
     fn root(&self) -> Result<Cid>;
 

--- a/fvm/src/syscalls/ipld.rs
+++ b/fvm/src/syscalls/ipld.rs
@@ -4,7 +4,7 @@ use super::Context;
 use crate::kernel::Result;
 use crate::Kernel;
 
-pub fn open(context: Context<'_, impl Kernel>, cid: u32) -> Result<sys::out::ipld::IpldOpen> {
+pub fn block_open(context: Context<'_, impl Kernel>, cid: u32) -> Result<sys::out::ipld::IpldOpen> {
     let cid = context.memory.read_cid(cid)?;
     let (id, stat) = context.kernel.block_open(&cid)?;
     Ok(sys::out::ipld::IpldOpen {
@@ -14,7 +14,7 @@ pub fn open(context: Context<'_, impl Kernel>, cid: u32) -> Result<sys::out::ipl
     })
 }
 
-pub fn create(
+pub fn block_create(
     context: Context<'_, impl Kernel>,
     codec: u64,
     data_off: u32,
@@ -24,7 +24,7 @@ pub fn create(
     context.kernel.block_create(codec, data)
 }
 
-pub fn cid(
+pub fn block_link(
     context: Context<'_, impl Kernel>,
     id: u32,
     hash_fun: u64,
@@ -42,7 +42,7 @@ pub fn cid(
     context.memory.write_cid(&cid, cid_off, cid_len)
 }
 
-pub fn read(
+pub fn block_read(
     context: Context<'_, impl Kernel>,
     id: u32,
     offset: u32,
@@ -53,7 +53,7 @@ pub fn read(
     context.kernel.block_read(id, offset, data)
 }
 
-pub fn stat(context: Context<'_, impl Kernel>, id: u32) -> Result<sys::out::ipld::IpldStat> {
+pub fn block_stat(context: Context<'_, impl Kernel>, id: u32) -> Result<sys::out::ipld::IpldStat> {
     context
         .kernel
         .block_stat(id)

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -113,11 +113,11 @@ pub fn bind_syscalls(
         network::total_fil_circ_supply,
     )?;
 
-    linker.bind("ipld", "open", ipld::open)?;
-    linker.bind("ipld", "create", ipld::create)?;
-    linker.bind("ipld", "read", ipld::read)?;
-    linker.bind("ipld", "stat", ipld::stat)?;
-    linker.bind("ipld", "cid", ipld::cid)?;
+    linker.bind("ipld", "block_open", ipld::block_open)?;
+    linker.bind("ipld", "block_create", ipld::block_create)?;
+    linker.bind("ipld", "block_read", ipld::block_read)?;
+    linker.bind("ipld", "block_stat", ipld::block_stat)?;
+    linker.bind("ipld", "block_link", ipld::block_link)?;
 
     linker.bind("self", "root", sself::root)?;
     linker.bind("self", "set_root", sself::set_root)?;

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -41,7 +41,7 @@ pub fn params_raw(id: BlockId) -> SyscallResult<(Codec, Vec<u8>)> {
         return Ok((DAG_CBOR, Vec::default())); // DAG_CBOR is a lie, but we have no nil codec.
     }
     unsafe {
-        let fvm_shared::sys::out::ipld::IpldStat { codec, size } = sys::ipld::stat(id)?;
+        let fvm_shared::sys::out::ipld::IpldStat { codec, size } = sys::ipld::block_stat(id)?;
         Ok((codec, crate::ipld::get_block(id, Some(size))?))
     }
 }

--- a/sdk/src/send.rs
+++ b/sdk/src/send.rs
@@ -26,7 +26,7 @@ pub fn send(
         // Insert parameters as a block. Nil parameters is represented as the
         // NO_DATA_BLOCK_ID block ID in the FFI interface.
         let params_id = if params.len() > 0 {
-            sys::ipld::create(DAG_CBOR, params.as_ptr(), params.len() as u32)?
+            sys::ipld::block_create(DAG_CBOR, params.as_ptr(), params.len() as u32)?
         } else {
             NO_DATA_BLOCK_ID
         };
@@ -54,7 +54,7 @@ pub fn send(
                 let mut bytes = vec![0; return_size as usize];
 
                 // Now read the return data.
-                let unread = sys::ipld::read(return_id, 0, bytes.as_mut_ptr(), return_size)?;
+                let unread = sys::ipld::block_read(return_id, 0, bytes.as_mut_ptr(), return_size)?;
                 assert_eq!(0, unread);
                 RawBytes::from(bytes)
             }

--- a/sdk/src/sys/ipld.rs
+++ b/sdk/src/sys/ipld.rs
@@ -30,7 +30,7 @@ super::fvm_syscalls! {
     /// |---------------------|---------------------------------------------|
     /// | [`NotFound`]        | the target block isn't in the reachable set |
     /// | [`IllegalArgument`] | there's something wrong with the CID        |
-    pub fn open(cid: *const u8) -> Result<IpldOpen>;
+    pub fn block_open(cid: *const u8) -> Result<IpldOpen>;
 
     /// Creates a new block, returning the block's ID. The block's children must be in the reachable
     /// set. The new block isn't added to the reachable set until the CID is computed.
@@ -49,7 +49,7 @@ super::fvm_syscalls! {
     /// | [`IllegalCodec`]    | the passed codec isn't supported                        |
     /// | [`Serialization`]   | the passed block doesn't match the passed codec         |
     /// | [`IllegalArgument`] | the block isn't in memory, etc.                         |
-    pub fn create(codec: u64, data: *const u8, len: u32) -> Result<u32>;
+    pub fn block_create(codec: u64, data: *const u8, len: u32) -> Result<u32>;
 
     /// Reads the block identified by `id` into `obuf`, starting at `offset`, reading _at most_
     /// `max_len` bytes.
@@ -78,7 +78,7 @@ super::fvm_syscalls! {
     /// |---------------------|---------------------------------------------------|
     /// | [`InvalidHandle`]   | if the handle isn't known.                        |
     /// | [`IllegalArgument`] | if the passed buffer isn't valid, in memory, etc. |
-    pub fn read(id: u32, offset: u32, obuf: *mut u8, max_len: u32) -> Result<i32>;
+    pub fn block_read(id: u32, offset: u32, obuf: *mut u8, max_len: u32) -> Result<i32>;
 
     /// Returns the codec and size of the specified block.
     ///
@@ -87,7 +87,7 @@ super::fvm_syscalls! {
     /// | Error             | Reason                     |
     /// |-------------------|----------------------------|
     /// | [`InvalidHandle`] | if the handle isn't known. |
-    pub fn stat(id: u32) -> Result<IpldStat>;
+    pub fn block_stat(id: u32) -> Result<IpldStat>;
 
     // TODO: CID versions?
 
@@ -97,7 +97,7 @@ super::fvm_syscalls! {
     ///
     /// # Arguments
     ///
-    /// - `id` is ID of the block to linked.
+    /// - `id` is ID of the block to link.
     /// - `hash_fun` is the multicodec of the hash function to use.
     /// - `hash_len` is the desired length of the hash digest.
     /// - `cid` is the output buffer (in wasm memory) where the FVM will write the resulting cid.
@@ -114,7 +114,7 @@ super::fvm_syscalls! {
     /// | [`InvalidHandle`]   | if the handle isn't known.                        |
     /// | [`IllegalCid`]      | hash code and/or hash length aren't supported.    |
     /// | [`IllegalArgument`] | if the passed buffer isn't valid, in memory, etc. |
-    pub fn cid(
+    pub fn block_link(
         id: u32,
         hash_fun: u64,
         hash_len: u32,

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -344,7 +344,7 @@ where
     }
 }
 
-impl<M, C, K> BlockOps for TestKernel<K>
+impl<M, C, K> IpldBlockOps for TestKernel<K>
 where
     M: Machine,
     C: CallManager<Machine = TestMachine<M>>,


### PR DESCRIPTION
Fixes the naming consistency issues identified in #521, but does not yet address the confusion around `block_link`.