### PR TITLE
fix: remove invocation results from execution trace

### DIFF
--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -1,9 +1,9 @@
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
 use fvm_shared::{ActorID, MethodNum};
 
-use crate::call_manager::InvocationResult;
 use crate::kernel::SyscallError;
 
 /// Execution Trace, only for informational and debugging purposes.
@@ -11,15 +11,14 @@ pub type ExecutionTrace = Vec<ExecutionEvent>;
 
 #[derive(Clone, Debug)]
 pub enum ExecutionEvent {
-    Call(SendParams),
-    Return(Result<InvocationResult, SyscallError>),
-}
-
-#[derive(Clone, Debug)]
-pub struct SendParams {
-    pub from: ActorID,
-    pub to: Address,
-    pub method: MethodNum,
-    pub params: RawBytes,
-    pub value: TokenAmount,
+    Call {
+        from: ActorID,
+        to: Address,
+        method: MethodNum,
+        params: RawBytes,
+        value: TokenAmount,
+    },
+    CallReturn(RawBytes),
+    CallAbort(ExitCode),
+    CallError(SyscallError),
 }


### PR DESCRIPTION
Unfortunately, these now include RC-ed blocks, which can't cross thread boundaries.