### PR TITLE
fix: update actors to fix conformance tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "fvm",
     "sdk",

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -115,7 +115,7 @@ where
         // guarantee.
         // Skip preloading all builtin actors when testing. This results in JIT
         // bytecode to machine code compilation, and leads to faster tests.
-        #[cfg(not(feature = "testing"))]
+        #[cfg(not(any(test, feature = "testing")))]
         engine.preload(state_tree.store(), builtin_actors.left_values())?;
 
         Ok(DefaultMachine {

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -47,7 +47,7 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 walkdir = "2.3"
 regex = { version = "1.0" }
 ittapi-rs = { version = "0.1.6", optional = true }
-actors-v7 = { version = "~7.3", package = "fil_builtin_actors_bundle" }
+actors-v7 = { version = "~7.4", package = "fil_builtin_actors_bundle" }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [features]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -14,7 +14,7 @@ fvm_ipld_car = { version = "0.4.1", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.2.0", path = "../../ipld/encoding" }
 
-actors-v7 = { version = "7.1.2", package = "fil_builtin_actors_bundle" }
+actors-v7 = { version = "~7.4", package = "fil_builtin_actors_bundle" }
 anyhow = "1.0.47"
 cid = { version = "0.8.2", default-features = false }
 futures = "0.3.19"


### PR DESCRIPTION
This also sets the resolver to version 2, to avoid unifying the "testing" feature. Otherwise, the conformance tests break because the actors don't get preloaded.