### PR TITLE
feat: add a flush method to the executor trait

### DIFF
--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -201,6 +201,12 @@ where
             }),
         }
     }
+
+    /// Flush the state-tree to the underlying blockstore.
+    fn flush(&mut self) -> anyhow::Result<Cid> {
+        let k = (&mut **self).flush()?;
+        Ok(k)
+    }
 }
 
 impl<K> DefaultExecutor<K>
@@ -210,12 +216,6 @@ where
     /// Create a new [`DefaultExecutor`] for executing messages on the [`Machine`].
     pub fn new(m: <K::CallManager as CallManager>::Machine) -> Self {
         Self(Some(m))
-    }
-
-    /// Flush the state-tree to the underlying blockstore.
-    pub fn flush(&mut self) -> anyhow::Result<Cid> {
-        let k = (&mut **self).flush()?;
-        Ok(k)
     }
 
     /// Consume consumes the executor and returns the Machine. If the Machine had

--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -3,6 +3,7 @@ mod threaded;
 
 use std::fmt::Display;
 
+use cid::Cid;
 pub use default::DefaultExecutor;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::bigint::{BigInt, Sign};
@@ -38,6 +39,9 @@ pub trait Executor {
         apply_kind: ApplyKind,
         raw_length: usize,
     ) -> anyhow::Result<ApplyRet>;
+
+    /// Flushes the state-tree, returning the new root CID.
+    fn flush(&mut self) -> anyhow::Result<Cid>;
 }
 
 /// A description of some failure encountered when applying a message.

--- a/fvm/src/executor/threaded.rs
+++ b/fvm/src/executor/threaded.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use cid::Cid;
 use fvm_shared::message::Message;
 use lazy_static::lazy_static;
 
@@ -42,5 +43,9 @@ where
         });
 
         ret
+    }
+
+    fn flush(&mut self) -> anyhow::Result<Cid> {
+        self.0.flush()
     }
 }


### PR DESCRIPTION
This lets us call flush on a top-level ThreadedExecutor.