### PR TITLE
chore: audit errors

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -114,7 +114,7 @@ where
             .state_tree()
             .get_actor(addr)?
             .context("state tree doesn't contain actor")
-            .or_illegal_argument()?;
+            .or_error(ErrorNumber::NotFound)?;
 
         let is_account = self
             .call_manager
@@ -125,6 +125,8 @@ where
             .unwrap_or(false);
 
         if !is_account {
+            // TODO: this is wrong. Maybe some InvalidActor type?
+            // The argument is syntactically correct, but semantically wrong.
             return Err(syscall_error!(IllegalArgument; "target actor is not an account").into());
         }
 
@@ -226,12 +228,10 @@ where
             let beneficiary_id = self
                 .resolve_address(beneficiary)?
                 .context("beneficiary doesn't exist")
-                .or_error(ErrorNumber::IllegalArgument)?;
+                .or_error(ErrorNumber::NotFound)?;
 
             if beneficiary_id == self.actor_id {
-                return Err(
-                    syscall_error!(IllegalArgument, "benefactor cannot be beneficiary").into(),
-                );
+                return Err(syscall_error!(Forbidden, "benefactor cannot be beneficiary").into());
             }
 
             // Transfer the entirety of funds to beneficiary.
@@ -309,11 +309,13 @@ where
             return Err(syscall_error!(IllegalCid; "invalid hash length: {}", hash_len).into());
         }
         let k = Cid::new_v1(block.codec(), hash.truncate(hash_len as u8));
-        // TODO: for now, we _put_ the block here. In the future, we should put it into a write
-        // cache, then flush it later.
+        // TODO: in M2, we need to write to a "write set" here, only flushing when updating the
+        // root.
         self.call_manager
             .blockstore()
             .put_keyed(&k, block.data())
+            // TODO: This is really "super fatal". It means we failed to store state, and should
+            // probably abort the entire block.
             .or_fatal()?;
         Ok(k)
     }
@@ -784,6 +786,7 @@ where
         )?;
 
         // TODO: Check error code
+        // Specifically, lookback length?
         self.call_manager
             .externs()
             .get_chain_randomness(personalization, rand_epoch, entropy)
@@ -804,6 +807,7 @@ where
         )?;
 
         // TODO: Check error code
+        // Specifically, lookback length?
         self.call_manager
             .externs()
             .get_beacon_randomness(personalization, rand_epoch, entropy)
@@ -852,18 +856,17 @@ where
     fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<()> {
         let typ = self
             .get_builtin_actor_type(&code_id)
-            .ok_or_else(|| syscall_error!(IllegalArgument; "can only create built-in actors"))?;
+            .ok_or_else(|| syscall_error!(Forbidden; "can only create built-in actors"))?;
 
         if typ.is_singleton_actor() {
             return Err(
-                syscall_error!(IllegalArgument; "can only have one instance of singleton actors")
-                    .into(),
+                syscall_error!(Forbidden; "can only have one instance of singleton actors").into(),
             );
         };
 
         let state_tree = self.call_manager.state_tree();
         if let Ok(Some(_)) = state_tree.get_actor_id(actor_id) {
-            return Err(syscall_error!(IllegalArgument; "Actor address already exists").into());
+            return Err(syscall_error!(Forbidden; "Actor address already exists").into());
         }
 
         self.call_manager

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -11,7 +11,7 @@ use fvm_shared::error::ErrorNumber;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::ActorID;
 use log::debug;
-use num_traits::{Signed, Zero};
+use num_traits::Signed;
 
 use super::{Engine, Machine, MachineContext};
 use crate::blockstore::BufferedBlockstore;
@@ -207,7 +207,7 @@ where
             .context("cannot transfer from non-existent sender")
             .or_error(ErrorNumber::InsufficientFunds)?;
 
-        if &from_actor.balance < &value {
+        if &from_actor.balance < value {
             return Err(syscall_error!(InsufficientFunds; "sender does not have funds to transfer (balance {}, transfer {})", &from_actor.balance, value).into());
         }
 

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -193,84 +193,42 @@ where
     }
 
     fn transfer(&mut self, from: ActorID, to: ActorID, value: &TokenAmount) -> Result<()> {
-        if self.context.network_version >= NetworkVersion::V15 {
-            if value.is_negative() {
-                return Err(syscall_error!(IllegalArgument;
+        if value.is_negative() {
+            return Err(syscall_error!(IllegalArgument;
                 "attempted to transfer negative transfer value {}", value)
-                .into());
-            }
-
-            // If the from actor doesn't exist, we return "insufficient funds" to distinguish between
-            // that and the case where the _receiving_ actor doesn't exist.
-            let mut from_actor = self
-                .state_tree
-                .get_actor_id(from)?
-                .context("cannot transfer from non-existent sender")
-                .or_error(ErrorNumber::InsufficientFunds)?;
-
-            if from_actor.balance.lt(value) {
-                return Err(syscall_error!(InsufficientFunds; "sender does not have funds to transfer (balance {}, transfer {})", &from_actor.balance, value).into());
-            }
-
-            if from == to {
-                debug!("attempting to self-transfer: noop (from/to: {})", from);
-                return Ok(());
-            }
-
-            let mut to_actor = self
-                .state_tree
-                .get_actor_id(to)?
-                .context("cannot transfer to non-existent receiver")
-                .or_error(ErrorNumber::NotFound)?;
-
-            from_actor.deduct_funds(value).map_err(|e| {
-                syscall_error!(InsufficientFunds;
-                           "transfer failed when deducting funds ({}) from balance ({}): {}",
-                           value, &from_actor.balance, e)
-            })?;
-            to_actor.deposit_funds(value);
-
-            self.state_tree.set_actor_id(from, from_actor)?;
-            self.state_tree.set_actor_id(to, to_actor)?;
-
-            log::trace!("transferred {} from {} to {}", value, from, to);
-        } else {
-            if from == to || value.is_zero() {
-                return Ok(());
-            }
-
-            if value.is_negative() {
-                return Err(syscall_error!(IllegalArgument;
-                "attempted to transfer negative transfer value {}", value)
-                .into());
-            }
-
-            // If the from actor doesn't exist, we return "insufficient funds" to distinguish between
-            // that and the case where the _receiving_ actor doesn't exist.
-            let mut from_actor = self
-                .state_tree
-                .get_actor_id(from)?
-                .context("cannot transfer from non-existent sender")
-                .or_error(ErrorNumber::InsufficientFunds)?;
-
-            let mut to_actor = self
-                .state_tree
-                .get_actor_id(to)?
-                .context("cannot transfer to non-existent receiver")
-                .or_error(ErrorNumber::NotFound)?;
-
-            from_actor.deduct_funds(value).map_err(|e| {
-                syscall_error!(InsufficientFunds;
-                           "transfer failed when deducting funds ({}) from balance ({}): {}",
-                           value, &from_actor.balance, e)
-            })?;
-            to_actor.deposit_funds(value);
-
-            self.state_tree.set_actor_id(from, from_actor)?;
-            self.state_tree.set_actor_id(to, to_actor)?;
-
-            log::trace!("transfered {} from {} to {}", value, from, to);
+            .into());
         }
+
+        // If the from actor doesn't exist, we return "insufficient funds" to distinguish between
+        // that and the case where the _receiving_ actor doesn't exist.
+        let mut from_actor = self
+            .state_tree
+            .get_actor_id(from)?
+            .context("cannot transfer from non-existent sender")
+            .or_error(ErrorNumber::InsufficientFunds)?;
+
+        if &from_actor.balance < &value {
+            return Err(syscall_error!(InsufficientFunds; "sender does not have funds to transfer (balance {}, transfer {})", &from_actor.balance, value).into());
+        }
+
+        if from == to {
+            debug!("attempting to self-transfer: noop (from/to: {})", from);
+            return Ok(());
+        }
+
+        let mut to_actor = self
+            .state_tree
+            .get_actor_id(to)?
+            .context("cannot transfer to non-existent receiver")
+            .or_error(ErrorNumber::NotFound)?;
+
+        from_actor.deduct_funds(value)?;
+        to_actor.deposit_funds(value);
+
+        self.state_tree.set_actor_id(from, from_actor)?;
+        self.state_tree.set_actor_id(to, to_actor)?;
+
+        log::trace!("transferred {} from {} to {}", value, from, to);
 
         Ok(())
     }

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -537,10 +537,11 @@ impl ActorState {
         }
     }
     /// Safely deducts funds from an Actor
-    /// TODO return a system error with exit code "insufficient funds"
     pub fn deduct_funds(&mut self, amt: &TokenAmount) -> Result<()> {
         if &self.balance < amt {
-            return Err(syscall_error!(InsufficientFunds; "not enough funds").into());
+            return Err(
+                syscall_error!(InsufficientFunds; "when deducting funds ({}) from balance ({})", amt, self.balance).into(),
+            );
         }
         self.balance -= amt;
 

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -3,6 +3,11 @@ use crate::syscalls::context::Context;
 use crate::Kernel;
 
 pub fn log(context: Context<'_, impl Kernel>, msg_off: u32, msg_len: u32) -> Result<()> {
+    // No-op if disabled.
+    if context.kernel.debug_enabled() {
+        return Ok(());
+    }
+
     let msg = context.memory.try_slice(msg_off, msg_len)?;
     let msg = String::from_utf8(msg.to_owned()).or_illegal_argument()?;
     context.kernel.log(msg);

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -24,6 +24,7 @@ super::fvm_syscalls! {
     ///
     /// | Error               | Reason                                               |
     /// |---------------------|------------------------------------------------------|
+    /// | [`NotFound`]        | the signer's address could not be resolved           |
     /// | [`IllegalArgument`] | signature, address, or plaintext buffers are invalid |
     pub fn verify_signature(
         sig_type: u32,


### PR DESCRIPTION
1. If we fail to create an account due to a serialization error, treat it as an illegal argument and move on rather than failing.
2. Return NotFound if we fail to find an actor when resolving an address to a key.
3. Return NotFound (as documented) if the beneficiary doesn't exist on delete.
4. Return Forbidden (as documented) if the beneficiary is self on delete.
5. Remove nv14 support from `transfer`, and simplify some error handling.
6. Avoid logging when debugging is enabled.
7. Return Forbidden for various actor creation errors, instead of IllegalArgument.

Unresolved: `resolve_to_key_addr` (called when verifying a signature), returns IllegalArgument if the "signer" address is not an account. The thing is, IllegalArgument usually means that the caller "should have known better" (e.g., they passed a negative number when the docs specified a positive number). In this case, the caller is passing a valid address, it just isn't an address of an account.