### PR TITLE
deps: update serde_ipld_dagcbor to 0.2.2.

### DIFF
--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
-serde_ipld_dagcbor = "0.2.1"
+serde_ipld_dagcbor = "0.2.2"
 serde_tuple = "0.5"
 serde_repr = "0.1"
 cid = { version = "0.8.2", default-features = false, features = ["serde-codec", "std"] }


### PR DESCRIPTION
This fixes https://github.com/ipld/serde_ipld_dagcbor/pull/3.