### PR TITLE
chore: cleanup todos, warnings, imports, etc.

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -165,10 +165,10 @@ where
     }
 
     fn finish(mut self) -> (FinishRet, Self::Machine) {
+        // TODO: Having to check against zero here is fishy, but this is what lotus does.
         let gas_used = self.gas_tracker.gas_used().max(Gas::zero()).round_up();
 
         let inner = self.0.take().expect("call manager is poisoned");
-        // TODO: Having to check against zero here is fishy, but this is what lotus does.
         (
             FinishRet {
                 gas_used,
@@ -327,7 +327,6 @@ where
         }
 
         // Store the parametrs, and initialize the block registry for the target actor.
-        // TODO: In M2, the block registry may have some form of shared block limit.
         let mut block_registry = BlockRegistry::new();
         let params_id = if let Some(blk) = params {
             block_registry.put(blk)?

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -216,7 +216,6 @@ lazy_static! {
         .cloned()
         .collect(),
 
-        // TODO: PARAM_FINISH: this may need to be increased to account for the cost of an extern
         verify_consensus_fault: Gas::new(495422),
         verify_replica_update: Gas::new(36316136),
         verify_post_lookup: [

--- a/fvm/src/kernel/blocks.rs
+++ b/fvm/src/kernel/blocks.rs
@@ -18,7 +18,7 @@ pub struct BlockRegistry {
 pub type BlockId = u32;
 
 const FIRST_ID: BlockId = 1;
-const MAX_BLOCKS: u32 = i32::MAX as u32; // TODO: Limit
+const MAX_BLOCKS: u32 = i32::MAX as u32; // TODO(M2): Limit
 
 #[derive(Copy, Clone)]
 pub struct BlockStat {

--- a/fvm/src/kernel/error.rs
+++ b/fvm/src/kernel/error.rs
@@ -76,7 +76,6 @@ pub trait ClassifyResult: Sized {
     type Value;
     type Error;
 
-    // TODO: may need a custom trait for conversions because into will be a bit restrictive.
     fn or_fatal(self) -> Result<Self::Value>
     where
         Self::Error: Into<anyhow::Error>;
@@ -160,9 +159,6 @@ impl Context for ExecutionError {
 }
 
 // We only use this when converting to a fatal error, so we throw away the error code.
-//
-// TODO: Ideally we wouldn't implement this conversion as it's a bit dangerous.
-// FIXME: this conversion really shouldn't exist
 impl From<ExecutionError> for anyhow::Error {
     fn from(e: ExecutionError) -> Self {
         use ExecutionError::*;

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -31,7 +31,13 @@ pub enum SendResult {
     Abort(ExitCode),
 }
 
-/// The "kernel" implements
+/// The "kernel" implements the FVM interface as presented to the actors. It:
+///
+/// - Manage's the Actor's state.
+/// - Tracks and charges for IPLD & syscall-specific gas.
+///
+/// Actors may call into the kernel via the syscalls defined in the [`syscalls`][crate::syscalls]
+/// module.
 pub trait Kernel:
     ActorOps
     + IpldBlockOps

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -33,7 +33,7 @@ pub enum SendResult {
 
 /// The "kernel" implements the FVM interface as presented to the actors. It:
 ///
-/// - Manage's the Actor's state.
+/// - Manages the Actor's state.
 /// - Tracks and charges for IPLD & syscall-specific gas.
 ///
 /// Actors may call into the kernel via the syscalls defined in the [`syscalls`][crate::syscalls]

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -16,8 +16,6 @@ pub mod kernel;
 pub mod machine;
 pub mod syscalls;
 
-// TODO Public only for conformance tests.
-//  Consider exporting only behind a feature.
 pub mod gas;
 pub mod state_tree;
 

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -92,7 +92,6 @@ where
         };
 
         // Load the built-in actors manifest.
-        // TODO: Check that the actor bundle is sane for the network version.
         let (builtin_actors_cid, manifest_version) = match context.builtin_actors_override {
             Some(manifest_cid) => {
                 let (version, cid): (u32, Cid) = state_tree
@@ -176,7 +175,6 @@ where
     }
 
     /// Creates an uninitialized actor.
-    // TODO: Remove
     fn create_actor(&mut self, addr: &Address, act: ActorState) -> Result<ActorID> {
         let state_tree = self.state_tree_mut();
 

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -68,7 +68,6 @@ pub trait Machine: 'static {
     fn state_tree_mut(&mut self) -> &mut StateTree<Self::Blockstore>;
 
     /// Creates an uninitialized actor.
-    // TODO: Remove
     fn create_actor(&mut self, addr: &Address, act: ActorState) -> Result<ActorID>;
 
     /// Transfers tokens from one actor to another.

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -42,7 +42,7 @@ pub fn get_actor_code_cid(
 /// class 2 address (protocol-generated actor address). This will change in the
 /// future when we introduce class 4 addresses to accommodate larger hashes.
 ///
-/// TODO this method will be merged with create_actor in the near future.
+/// TODO(M2): this method will be merged with create_actor.
 pub fn new_actor_address(
     context: Context<'_, impl Kernel>,
     obuf_off: u32, // Address (out)

--- a/fvm/src/syscalls/bind.rs
+++ b/fvm/src/syscalls/bind.rs
@@ -10,9 +10,6 @@ use super::{charge_for_exec, update_gas_available, Context, InvocationData};
 use crate::call_manager::backtrace;
 use crate::kernel::{self, ExecutionError, Kernel, SyscallError};
 
-// TODO: we should consider implementing a proc macro attribute for syscall functions instead of
-// this type nonsense. But this was faster and will "work" for now.
-
 /// Binds syscalls to a linker, converting the returned error according to the syscall convention:
 ///
 /// 1. If the error is a syscall error, it's returned as the first return value.

--- a/fvm/src/syscalls/context.rs
+++ b/fvm/src/syscalls/context.rs
@@ -125,7 +125,6 @@ mod test {
     const SHA2_256: u64 = 0x12;
     const HASH: &[u8] = b"\x2C\x26\xB4\x6B\x68\xFF\xC6\x8F\xF9\x9B\x45\x3C\x1D\x30\x41\x34\x13\x42\x2D\x70\x64\x83\xBF\xA0\xF9\x8A\x5E\x88\x62\x66\xE7\xAE";
 
-    // TODO: move this somewhere more useful.
     macro_rules! expect_syscall_err {
         ($code:ident, $res:expr) => {
             match $res.expect_err("expected syscall to fail") {

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -1,26 +1,17 @@
-// TODO: remove this when we hookup these syscalls.
-#![allow(unused)]
-
-use std::collections::HashMap;
-use std::{cmp, iter};
+use std::cmp;
 
 use anyhow::{anyhow, Context as _};
-use cid::Cid;
-use fvm_ipld_encoding::{Cbor, DAG_CBOR};
-use fvm_shared::address::Address;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::crypto::signature::{Signature, SignatureType};
-use fvm_shared::error::ErrorNumber::IllegalArgument;
+use fvm_shared::crypto::signature::SignatureType;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, ReplicaUpdateInfo, SealVerifyInfo,
     WindowPoStVerifyInfo,
 };
-use fvm_shared::{sys, ActorID};
+use fvm_shared::sys;
 use num_traits::FromPrimitive;
 
 use super::Context;
-use crate::kernel::{BlockId, ClassifyResult, ExecutionError, Result, SyscallError};
+use crate::kernel::{ClassifyResult, Result};
 use crate::{syscall_error, Kernel};
 
 /// Verifies that a signature is valid for an address and plaintext.
@@ -30,7 +21,7 @@ use crate::{syscall_error, Kernel};
 ///  - -1: verification failed.
 #[allow(clippy::too_many_arguments)]
 pub fn verify_signature(
-    mut context: Context<'_, impl Kernel>,
+    context: Context<'_, impl Kernel>,
     sig_type: u32,
     sig_off: u32,
     sig_len: u32,
@@ -55,7 +46,7 @@ pub fn verify_signature(
 /// Hashes input data using the specified hash function, writing the digest into the provided
 /// buffer.
 pub fn hash(
-    mut context: Context<'_, impl Kernel>,
+    context: Context<'_, impl Kernel>,
     hash_code: u64,
     data_off: u32, // input
     data_len: u32,
@@ -83,7 +74,7 @@ pub fn hash(
 ///
 /// Writes the CID in the provided output buffer.
 pub fn compute_unsealed_sector_cid(
-    mut context: Context<'_, impl Kernel>,
+    context: Context<'_, impl Kernel>,
     proof_type: i64, // RegisteredSealProof,
     pieces_off: u32, // [PieceInfo]
     pieces_len: u32,
@@ -113,7 +104,7 @@ pub fn compute_unsealed_sector_cid(
 ///  - 0: verification ok.
 ///  - -1: verification failed.
 pub fn verify_seal(
-    mut context: Context<'_, impl Kernel>,
+    context: Context<'_, impl Kernel>,
     info_off: u32, // SealVerifyInfo
     info_len: u32,
 ) -> Result<i32> {
@@ -132,7 +123,7 @@ pub fn verify_seal(
 ///  - 0: verification ok.
 ///  - -1: verification failed.
 pub fn verify_post(
-    mut context: Context<'_, impl Kernel>,
+    context: Context<'_, impl Kernel>,
     info_off: u32, // WindowPoStVerifyInfo,
     info_len: u32,
 ) -> Result<i32> {
@@ -194,7 +185,7 @@ pub fn verify_consensus_fault(
 ///  - 0: verification ok.
 ///  - -1: verification failed.
 pub fn verify_aggregate_seals(
-    mut context: Context<'_, impl Kernel>,
+    context: Context<'_, impl Kernel>,
     agg_off: u32, // AggregateSealVerifyProofAndInfos
     agg_len: u32,
 ) -> Result<i32> {
@@ -211,7 +202,7 @@ pub fn verify_aggregate_seals(
 ///  - 0: verification ok.
 ///  - -1: verification failed.
 pub fn verify_replica_update(
-    mut context: Context<'_, impl Kernel>,
+    context: Context<'_, impl Kernel>,
     rep_off: u32, // ReplicaUpdateInfo
     rep_len: u32,
 ) -> Result<i32> {
@@ -229,7 +220,7 @@ pub fn verify_replica_update(
 /// When successful, this method will write a single byte back into the array at `result_off` for
 /// each result: 0 for failed, 1 for success.
 pub fn batch_verify_seals(
-    mut context: Context<'_, impl Kernel>,
+    context: Context<'_, impl Kernel>,
     batch_off: u32,
     batch_len: u32,
     result_off: u32,
@@ -243,7 +234,7 @@ pub fn batch_verify_seals(
         .try_slice_mut(result_off, batch.len() as u32)?;
 
     // Execute.
-    let mut result = context.kernel.batch_verify_seals(&batch)?;
+    let result = context.kernel.batch_verify_seals(&batch)?;
 
     // Sanity check that we got the correct number of results.
     if result.len() != batch.len() {

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -94,9 +94,6 @@ use self::error::Abort;
 
 // Binds the syscall handlers so they can handle invocations
 // from the actor code.
-//
-// TODO try to fix the static lifetime here. I want to tell the compiler that
-//  the Kernel will live as long as the Machine and the Linker.
 pub fn bind_syscalls(
     linker: &mut Linker<InvocationData<impl Kernel + 'static>>,
 ) -> anyhow::Result<()> {

--- a/fvm/src/syscalls/sself.rs
+++ b/fvm/src/syscalls/sself.rs
@@ -31,7 +31,6 @@ pub fn current_balance(context: Context<'_, impl Kernel>) -> Result<sys::TokenAm
         .or_fatal()
 }
 
-/// TODO it should be possible to consume an address without knowing its length a priori
 pub fn self_destruct(
     context: Context<'_, impl Kernel>,
     addr_off: u32,

--- a/ipld/amt/benches/amt_benchmark.rs
+++ b/ipld/amt/benches/amt_benchmark.rs
@@ -7,15 +7,20 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 const ITEM_COUNT: usize = 60;
 
-#[allow(dead_code)]
 // Struct to simulate a reasonable amount of data per value into the amt
 #[derive(Clone)]
 struct BenchData {
+    #[allow(dead_code)]
     s: String,
+    #[allow(dead_code)]
     s2: String,
+    #[allow(dead_code)]
     bz: Vec<u8>,
+    #[allow(dead_code)]
     v: u64,
+    #[allow(dead_code)]
     a: [u8; 64],
+    #[allow(dead_code)]
     a2: [u8; 64],
 }
 

--- a/ipld/bitfield/src/iter/combine.rs
+++ b/ipld/bitfield/src/iter/combine.rs
@@ -386,8 +386,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         // we repeatedly compute the next range until we find one that is non-empty
-        // TODO: use `!range.is_empty()` once it stabilizes in Rust 1.47
-        iter::from_fn(|| self.next_range()).find(|range| range.start < range.end)
+        iter::from_fn(|| self.next_range()).find(|range| !range.is_empty())
     }
 }
 

--- a/ipld/encoding/src/cbor.rs
+++ b/ipld/encoding/src/cbor.rs
@@ -8,9 +8,8 @@ use cid::{multihash, Cid};
 use serde::{Deserialize, Serialize};
 
 use super::errors::Error;
-use crate::{de, from_slice, ser, to_vec, CodecProtocol};
+use crate::{de, from_slice, ser, to_vec};
 
-// TODO find something to reference.
 pub const DAG_CBOR: u64 = 0x71;
 
 /// Cbor utility functions for serializable objects
@@ -32,12 +31,11 @@ pub trait Cbor: ser::Serialize + de::DeserializeOwned {
         const DIGEST_SIZE: u32 = 32; // TODO get from the multihash?
         let data = &self.marshal_cbor()?;
         let hash = multihash::Code::Blake2b256.digest(data);
-        if u32::from(hash.size()) != DIGEST_SIZE {
-            return Err(Error {
-                description: "Invalid multihash length".into(),
-                protocol: CodecProtocol::Cbor, // TODO this is not accurate, and not convinced about this Error type.
-            });
-        }
+        debug_assert_eq!(
+            u32::from(hash.size()),
+            DIGEST_SIZE,
+            "expected 32byte digest"
+        );
         Ok(Cid::new_v1(DAG_CBOR, hash))
     }
 }

--- a/ipld/hamt/benches/hamt_benchmark.rs
+++ b/ipld/hamt/benches/hamt_benchmark.rs
@@ -9,7 +9,6 @@ use fvm_ipld_hamt::Hamt;
 
 const ITEM_COUNT: u8 = 40;
 
-#[allow(dead_code)]
 // Struct to simulate a reasonable amount of data per value into the amt
 #[derive(Clone, Serialize_tuple, Deserialize_tuple, PartialEq)]
 struct BenchData {

--- a/ipld/hamt/src/error.rs
+++ b/ipld/hamt/src/error.rs
@@ -21,8 +21,6 @@ pub enum Error {
     /// Cid not found in store error
     #[error("Cid ({0}) did not match any in database")]
     CidNotFound(String),
-    // TODO: This should be something like "internal" or "io". And we shouldn't have both this and
-    // "other"; they serve the same purpose.
     /// Dynamic error for when the error needs to be forwarded as is.
     #[error("{0}")]
     Dynamic(anyhow::Error),

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -141,7 +141,6 @@ where
                     }
 
                     // Collect values from child nodes to collapse.
-                    #[allow(unused_mut)]
                     let mut child_vals: Vec<KeyValuePair<K, V>> = n
                         .pointers
                         .iter_mut()

--- a/sdk/src/actor.rs
+++ b/sdk/src/actor.rs
@@ -56,7 +56,7 @@ pub fn new_actor_address() -> Address {
 
 /// Creates a new actor of the specified type in the state tree, under
 /// the provided address.
-/// TODO this syscall will change to calculate the address internally.
+/// TODO(M2): this syscall will change to calculate the address internally.
 pub fn create_actor(actor_id: ActorID, code_cid: &Cid) -> SyscallResult<()> {
     let cid = code_cid.to_bytes();
     unsafe { sys::actor::create_actor(actor_id, cid.as_ptr()) }

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -14,7 +14,6 @@ use num_traits::FromPrimitive;
 use crate::{status_code_to_bool, sys, SyscallResult};
 
 /// Verifies that a signature is valid for an address and plaintext.
-#[allow(unused)]
 pub fn verify_signature(
     signature: &Signature,
     signer: &Address,
@@ -38,7 +37,6 @@ pub fn verify_signature(
 }
 
 /// Hashes input data using blake2b with 256 bit output.
-#[allow(unused)]
 pub fn hash_blake2b(data: &[u8]) -> [u8; 32] {
     const BLAKE2B_256: u64 = 0xb220;
     // This can only fail if we manage to pass in corrupted memory.
@@ -57,7 +55,6 @@ pub fn hash_blake2b(data: &[u8]) -> [u8; 32] {
 }
 
 /// Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.
-#[allow(unused)]
 pub fn compute_unsealed_sector_cid(
     proof_type: RegisteredSealProof,
     pieces: &[PieceInfo],
@@ -84,7 +81,6 @@ pub fn compute_unsealed_sector_cid(
 }
 
 /// Verifies a sector seal proof.
-#[allow(unused)]
 pub fn verify_seal(info: &SealVerifyInfo) -> SyscallResult<bool> {
     let info = info
         .marshal_cbor()
@@ -93,7 +89,6 @@ pub fn verify_seal(info: &SealVerifyInfo) -> SyscallResult<bool> {
 }
 
 /// Verifies a window proof of spacetime.
-#[allow(unused)]
 pub fn verify_post(info: &WindowPoStVerifyInfo) -> SyscallResult<bool> {
     let info = info
         .marshal_cbor()
@@ -111,7 +106,6 @@ pub fn verify_post(info: &WindowPoStVerifyInfo) -> SyscallResult<bool> {
 /// the "parent grinding fault", in which case it must be the sibling of h1 (same parent tipset) and one of the
 /// blocks in the parent of h2 (i.e. h2's grandparent).
 /// Returns None and an error if the headers don't prove a fault.
-#[allow(unused)]
 pub fn verify_consensus_fault(
     h1: &[u8],
     h2: &[u8],
@@ -143,7 +137,6 @@ pub fn verify_consensus_fault(
     }))
 }
 
-#[allow(unused)]
 pub fn verify_aggregate_seals(info: &AggregateSealVerifyProofAndInfos) -> SyscallResult<bool> {
     let info = info
         .marshal_cbor()
@@ -154,7 +147,6 @@ pub fn verify_aggregate_seals(info: &AggregateSealVerifyProofAndInfos) -> Syscal
     }
 }
 
-#[allow(unused)]
 pub fn verify_replica_update(info: &ReplicaUpdateInfo) -> SyscallResult<bool> {
     let info = info
         .marshal_cbor()
@@ -165,7 +157,6 @@ pub fn verify_replica_update(info: &ReplicaUpdateInfo) -> SyscallResult<bool> {
     }
 }
 
-#[allow(unused)]
 pub fn batch_verify_seals(batch: &[SealVerifyInfo]) -> SyscallResult<Vec<bool>> {
     let encoded = to_vec(batch).expect("failed to marshal batch seal verification input");
 

--- a/sdk/src/sys/gas.rs
+++ b/sdk/src/sys/gas.rs
@@ -7,9 +7,6 @@ use crate::sys::ErrorNumber::*;
 super::fvm_syscalls! {
     module = "gas";
 
-    // TODO: name for debugging & tracing?
-    // We could also _not_ feed that through to the outside?
-
     /// Charge gas.
     ///
     /// # Arguments

--- a/sdk/src/sys/ipld.rs
+++ b/sdk/src/sys/ipld.rs
@@ -89,8 +89,6 @@ super::fvm_syscalls! {
     /// | [`InvalidHandle`] | if the handle isn't known. |
     pub fn block_stat(id: u32) -> Result<IpldStat>;
 
-    // TODO: CID versions?
-
     /// Computes the given block's CID, writing the resulting CID into `cid`.
     ///
     /// The returned CID is added to the reachable set.

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -18,7 +18,6 @@ data-encoding = "2.3.2"
 data-encoding-macro = "0.1.12"
 lazy_static = "1.4.0"
 log = "0.4.8"
-# TODO: remove std dep once we can implement debug without it.
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec", "std"] }
 multihash = { version = "0.16.1", default-features = false, features = ["blake2b", "multihash-impl"] }
 unsigned-varint = "0.7.1"

--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -11,8 +11,7 @@ use std::hash::Hash;
 use std::str::FromStr;
 
 use data_encoding::Encoding;
-#[allow(unused_imports)]
-use data_encoding_macro::{internal_new_encoding, new_encoding};
+use data_encoding_macro::new_encoding;
 use fvm_ipld_encoding::{serde_bytes, Cbor};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 

--- a/testing/common_fuzz/fuzz/fuzz_targets/rle_ops.rs
+++ b/testing/common_fuzz/fuzz/fuzz_targets/rle_ops.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![no_main]
-#![allow(clippy::eq_op)]
 
 use fvm_ipld_bitfield::BitField;
 use libfuzzer_sys::fuzz_target;

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "1.0.0-rc.1", path = "../../fvm", default-features = false }
 fvm_shared = { version = "0.7.0", path = "../../shared" }
 fvm_ipld_hamt = { version = "0.5.1", path = "../../ipld/hamt"}
 fvm_ipld_amt = { version = "0.4.1", path = "../../ipld/amt"}
@@ -49,6 +48,12 @@ regex = { version = "1.0" }
 ittapi-rs = { version = "0.3.0", optional = true }
 actors-v7 = { version = "~7.4", package = "fil_builtin_actors_bundle" }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
+
+[dependencies.fvm]
+version = "1.0.0-rc.1"
+path = "../../fvm"
+default-features = false
+features = ["testing"]
 
 [features]
 vtune = ["wasmtime/vtune", "ittapi-rs"]

--- a/testing/conformance/benches/bench_conformance.rs
+++ b/testing/conformance/benches/bench_conformance.rs
@@ -23,6 +23,7 @@ fn bench_conformance(c: &mut Criterion) {
     pretty_env_logger::init();
 
     // TODO match globs to get whole folders?
+    // https://github.com/filecoin-project/ref-fvm/issues/298
     let (vector_results, _is_many): (Vec<PathBuf>, bool) = match var("VECTOR") {
         Ok(v) => (
             iter::once(Path::new(v.as_str()).to_path_buf()).collect(),
@@ -41,9 +42,8 @@ fn bench_conformance(c: &mut Criterion) {
 
     let engines = MultiEngine::default();
 
-    // TODO: this is 30 seconds per benchmark... yeesh! once we get the setup running faster (by cloning VMs more efficiently), we can probably bring this down.
     let mut group = c.benchmark_group("conformance-tests");
-    group.measurement_time(Duration::new(30, 0));
+    group.measurement_time(Duration::new(20, 0));
 
     for vector_path in vector_results.into_iter() {
         let message_vector = match MessageVector::from_file(&vector_path) {

--- a/testing/conformance/benches/bench_conformance_overhead.rs
+++ b/testing/conformance/benches/bench_conformance_overhead.rs
@@ -96,9 +96,8 @@ fn bench_conformance_overhead(c: &mut Criterion) {
             .unwrap(),
     };
 
-    // TODO: this is 30 seconds per benchmark... yeesh! once we get the setup running faster (by cloning VMs more efficiently/fixing wasm cache), we can probably bring this down.
     let mut group = c.benchmark_group("measurement-overhead-baselines");
-    group.measurement_time(Duration::new(30, 0));
+    group.measurement_time(Duration::new(15, 0));
     // start by getting some baselines!
 
     let engines = MultiEngine::default();

--- a/testing/conformance/benches/bench_drivers.rs
+++ b/testing/conformance/benches/bench_drivers.rs
@@ -44,7 +44,7 @@ pub fn bench_vector_variant(
             || {
                 let vector = &(*vector).clone();
                 let bs = bs.clone();
-                // TODO next few lines don't impact the benchmarks, but it might make them run waaaay more slowly... ought to make a base copy of the machine and exec and deepcopy them each time.
+                // NOTE next few lines don't impact the benchmarks.
                 let machine = TestMachine::new_for_vector(vector, variant, bs, engines);
                 // can assume this works because it passed a test before this ran
                 let exec: DefaultExecutor<TestKernel> = DefaultExecutor::new(machine);
@@ -56,14 +56,16 @@ pub fn bench_vector_variant(
     });
 }
 /// This tells `bench_vector_file` how hard to do checks on whether things succeed before running benchmark
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
 pub enum CheckStrength {
     /// making sure everything conforms before benching, for when you're benching the real vector as it came from specs-actors
+    #[allow(dead_code)]
     FullTest,
     /// use in cases where we're swapping out the messages to apply and just using the setup (overhead tests, for example)
+    #[allow(dead_code)]
     OnlyCheckSuccess,
     /// use if for some reason you want to bench something that errors (or go really fast and dangerous!)
+    #[allow(dead_code)]
     NoChecks,
 }
 

--- a/testing/conformance/src/rand.rs
+++ b/testing/conformance/src/rand.rs
@@ -31,7 +31,7 @@ impl Rand for TestFallbackRand {
 impl ReplayingRand {
     pub fn new(recorded: &[RandomnessMatch]) -> Self {
         Self {
-            recorded: Vec::from(recorded), // TODO this copies, maybe optimize
+            recorded: Vec::from(recorded),
             fallback: TestFallbackRand,
         }
     }

--- a/testing/conformance/src/vector.rs
+++ b/testing/conformance/src/vector.rs
@@ -225,22 +225,6 @@ mod base64_bytes {
         let s: Cow<'de, str> = Deserialize::deserialize(deserializer)?;
         base64::decode(s.as_ref()).map_err(de::Error::custom)
     }
-
-    pub mod vec {
-        use super::*;
-
-        #[allow(dead_code)]
-        pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Vec<u8>>, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            let v: Vec<Cow<'de, str>> = Deserialize::deserialize(deserializer)?;
-            v.into_iter()
-                .map(|s| base64::decode(s.as_ref()))
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(de::Error::custom)
-        }
-    }
 }
 
 mod message_receipt_vec {

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -79,6 +79,12 @@ impl TestMachine<Box<DefaultMachine<MemoryBlockstore, TestExterns>>> {
 
         let machine = DefaultMachine::new(&engine, &mc, blockstore, externs).unwrap();
 
+        // Preload the actors. We don't usually preload actors when testing, so we're going to do
+        // this explicitly.
+        engine
+            .preload(machine.blockstore(), machine.builtin_actors().left_values())
+            .unwrap();
+
         let price_list = machine.context().price_list.clone();
 
         TestMachine::<Box<DefaultMachine<_, _>>> {
@@ -443,7 +449,6 @@ where
     ) -> Result<Option<ConsensusFault>> {
         let charge = self.1.price_list.on_verify_consensus_fault();
         self.0.charge_gas(charge.name, charge.total())?;
-        // TODO this seems wrong, should probably be parameterized.
         Ok(None)
     }
 

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -32,7 +32,7 @@ thiserror = "1.0.30"
 [dependencies.wasmtime]
 version = "0.36.0"
 default-features = false
-features = ["cranelift", "pooling-allocator", "parallel-compilation"]
+features = ["cranelift", "parallel-compilation"]
 
 [dev-dependencies]
 wabt = "0.10.0"


### PR DESCRIPTION
Mostly just a "did we forget something" pass.

~Also hides the gas/state_tree modules unless we're "testing" (fixing a todo).~ *edit: forest is using these, and they seem reasonable to export*

Also removes a wasmtime feature we're not using.