### PR TITLE
fix: AMT: correctly return whether found in batch_delete

### DIFF
--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -249,8 +249,8 @@ where
 
         // Iterate sorted indices. Sorted to safely optimize later.
         for i in sorted(iter) {
-            let found = self.delete(i)?.is_none();
-            if strict && found {
+            let found = self.delete(i)?.is_some();
+            if strict && !found {
                 return Err(anyhow!("no such index {} in Amt for batch delete", i).into());
             }
             modified |= found;


### PR DESCRIPTION
Thanks to @WadeAlexC for the catch!