### PR TITLE
Unit Tests for Default kernel `GasOps`

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -42,6 +42,9 @@ fvm-wasm-instrument = { version = "0.2.0", features = ["bulk"] }
 yastl = "0.1.2"
 arbitrary = {version = "1.1.0", optional = true, features = ["derive"]}
 
+[dev-dependencies]
+pretty_assertions = "1.2.1"
+
 [dependencies.wasmtime]
 version = "0.37.0"
 default-features = false

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -272,16 +272,16 @@ lazy_static! {
     };
 }
 
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub(crate) struct ScalingCost {
     flat: Gas,
     scale: Gas,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct StepCost(Vec<Step>);
 
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub(crate) struct Step {
     start: i64,
     cost: Gas,
@@ -306,7 +306,7 @@ impl StepCost {
 
 /// Provides prices for operations in the VM.
 /// All costs are in milligas.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PriceList {
     /// Storage gas charge multiplier
     pub(crate) storage_gas_multiplier: i64,

--- a/fvm/tests/default_kernel/mod.rs
+++ b/fvm/tests/default_kernel/mod.rs
@@ -22,3 +22,13 @@ pub fn build_inspecting_test() -> anyhow::Result<(TestingKernel, Rc<RefCell<Test
     let kern = TestingKernel::new(call_manager, BlockRegistry::default(), 0, 0, 0, 0.into());
     Ok((kern, test_data))
 }
+
+/// function to reduce a bit of boilerplate
+pub fn build_inspecting_gas_test(gas_tracker: fvm::gas::GasTracker) -> anyhow::Result<(TestingKernel, Rc<RefCell<TestData>>)> {
+    // call_manager is not dropped till the end of the function
+    let (call_manager, test_data) = dummy::DummyCallManager::new_with_gas(gas_tracker);
+    // variable for value inspection, only upgrade after done mutating to avoid panic
+
+    let kern = TestingKernel::new(call_manager, BlockRegistry::default(), 0, 0, 0, 0.into());
+    Ok((kern, test_data))
+}

--- a/fvm/tests/default_kernel/mod.rs
+++ b/fvm/tests/default_kernel/mod.rs
@@ -13,7 +13,7 @@ use super::*;
 
 type TestingKernel = DefaultKernel<DummyCallManager>;
 
-/// function to reduce a bit of boilerplate
+/// build a kernel for testing
 pub fn build_inspecting_test() -> anyhow::Result<(TestingKernel, Rc<RefCell<TestData>>)> {
     // call_manager is not dropped till the end of the function
     let (call_manager, test_data) = dummy::DummyCallManager::new_stub();
@@ -23,8 +23,10 @@ pub fn build_inspecting_test() -> anyhow::Result<(TestingKernel, Rc<RefCell<Test
     Ok((kern, test_data))
 }
 
-/// function to reduce a bit of boilerplate
-pub fn build_inspecting_gas_test(gas_tracker: fvm::gas::GasTracker) -> anyhow::Result<(TestingKernel, Rc<RefCell<TestData>>)> {
+/// build a kernel with a GasTracker
+pub fn build_inspecting_gas_test(
+    gas_tracker: fvm::gas::GasTracker,
+) -> anyhow::Result<(TestingKernel, Rc<RefCell<TestData>>)> {
     // call_manager is not dropped till the end of the function
     let (call_manager, test_data) = dummy::DummyCallManager::new_with_gas(gas_tracker);
     // variable for value inspection, only upgrade after done mutating to avoid panic

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -451,6 +451,8 @@ mod gas {
 
     use super::*;
 
+    use super::*;
+
     #[test]
     fn used() -> anyhow::Result<()> {
         let used = Gas::new(123456);
@@ -484,8 +486,6 @@ mod gas {
     #[test]
     fn price_list() -> anyhow::Result<()> {
         let (kern, _) = build_inspecting_test()?;
-
-        // compare raw pointers since PriceList is &'static
 
         let expected_list = price_list_by_network_version(NetworkVersion::V15);
         assert_eq!(kern.price_list(), expected_list);

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -441,3 +441,53 @@ mod ipld {
         Ok(())
     }
 }
+
+mod gas {
+    use super::*;
+    use fvm::{gas::*, kernel::GasOps};
+    use fvm_shared::version::NetworkVersion;
+
+    #[test]
+    fn used() -> anyhow::Result<()> {
+        let used = Gas::new(123456);
+        let gas_tracker = GasTracker::new(Gas::new(i64::MAX), used);
+
+        let (kern, _) = build_inspecting_gas_test(gas_tracker)?;
+
+        assert_eq!(kern.gas_used(), used);
+
+        Ok(())
+    }
+
+    #[test]
+    fn available() -> anyhow::Result<()> {
+        let avaliable = Gas::new(123456);
+        let gas_tracker = GasTracker::new(avaliable, Gas::new(0));
+
+        let (kern, _) = build_inspecting_gas_test(gas_tracker)?;
+
+        assert_eq!(kern.gas_available(), avaliable);
+
+        Ok(())
+    }
+
+    #[test]
+    fn charge() -> anyhow::Result<()> {
+        todo!()
+    }
+
+    #[test]
+    fn price_list() -> anyhow::Result<()> {
+        let (kern, _) = build_inspecting_test()?;
+
+        // compare raw pointers since PriceList is &'static
+
+        let expected_list = price_list_by_network_version(NetworkVersion::V15);
+        assert!(kern.price_list() as *const _ == expected_list as *const _);
+
+        let unexpected_list = price_list_by_network_version(NetworkVersion::V16);
+        assert!(kern.price_list() as *const _ != unexpected_list as *const _);
+
+        Ok(())
+    }
+}

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -443,9 +443,11 @@ mod ipld {
 }
 
 mod gas {
-    use super::*;
-    use fvm::{gas::*, kernel::GasOps};
+    use fvm::gas::*;
+    use fvm::kernel::GasOps;
     use fvm_shared::version::NetworkVersion;
+
+    use super::*;
 
     #[test]
     fn used() -> anyhow::Result<()> {
@@ -472,6 +474,7 @@ mod gas {
     }
 
     #[test]
+    #[ignore = "TODO"]
     fn charge() -> anyhow::Result<()> {
         todo!()
     }
@@ -483,10 +486,10 @@ mod gas {
         // compare raw pointers since PriceList is &'static
 
         let expected_list = price_list_by_network_version(NetworkVersion::V15);
-        assert!(kern.price_list() as *const _ == expected_list as *const _);
+        assert!(std::ptr::eq(kern.price_list(), expected_list));
 
         let unexpected_list = price_list_by_network_version(NetworkVersion::V16);
-        assert!(kern.price_list() as *const _ != unexpected_list as *const _);
+        assert!(!std::ptr::eq(kern.price_list(), unexpected_list));
 
         Ok(())
     }

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -9,9 +9,9 @@ mod ipld {
     use fvm_ipld_encoding::DAG_CBOR;
     use fvm_shared::error::ErrorNumber;
     use multihash::MultihashDigest;
+    use pretty_assertions::{assert_eq, assert_ne};
 
     use super::*;
-    use pretty_assertions::{assert_eq, assert_ne};
 
     #[test]
     fn roundtrip() -> anyhow::Result<()> {
@@ -447,9 +447,9 @@ mod gas {
     use fvm::gas::*;
     use fvm::kernel::GasOps;
     use fvm_shared::version::NetworkVersion;
+    use pretty_assertions::{assert_eq, assert_ne};
 
     use super::*;
-    use pretty_assertions::{assert_eq, assert_ne};
 
     #[test]
     fn used() -> anyhow::Result<()> {

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -11,6 +11,7 @@ mod ipld {
     use multihash::MultihashDigest;
 
     use super::*;
+    use pretty_assertions::{assert_eq, assert_ne};
 
     #[test]
     fn roundtrip() -> anyhow::Result<()> {
@@ -448,6 +449,7 @@ mod gas {
     use fvm_shared::version::NetworkVersion;
 
     use super::*;
+    use pretty_assertions::{assert_eq, assert_ne};
 
     #[test]
     fn used() -> anyhow::Result<()> {
@@ -486,10 +488,10 @@ mod gas {
         // compare raw pointers since PriceList is &'static
 
         let expected_list = price_list_by_network_version(NetworkVersion::V15);
-        assert!(std::ptr::eq(kern.price_list(), expected_list));
+        assert_eq!(kern.price_list(), expected_list);
 
         let unexpected_list = price_list_by_network_version(NetworkVersion::V16);
-        assert!(!std::ptr::eq(kern.price_list(), unexpected_list));
+        assert_ne!(kern.price_list(), unexpected_list);
 
         Ok(())
     }

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -478,9 +478,24 @@ mod gas {
     }
 
     #[test]
-    #[ignore = "TODO"]
     fn charge() -> anyhow::Result<()> {
-        todo!()
+        let test_gas = Gas::new(123456);
+        let gas_tracker = GasTracker::new(test_gas, Gas::new(0));
+
+        let (mut kern, _) = build_inspecting_gas_test(gas_tracker)?;
+
+        // charge exactly as much as avaliable
+        kern.charge_gas("test test 123", test_gas)?;
+        assert_eq!(kern.gas_used(), test_gas);
+
+        // carge more than avaliable
+
+        // over by 1
+        kern.charge_gas("give more!", Gas::new(1))
+            .expect_err("charging 1 more gas than avaliable should error");
+
+        // TODO how should negative gas charges be tested?
+        Ok(())
     }
 
     #[test]
@@ -488,7 +503,11 @@ mod gas {
         let (kern, _) = build_inspecting_test()?;
 
         let expected_list = price_list_by_network_version(NetworkVersion::V15);
-        assert_eq!(kern.price_list(), expected_list);
+        assert_eq!(
+            kern.price_list(),
+            expected_list,
+            "price list should be the same as network version 15"
+        );
 
         let unexpected_list = price_list_by_network_version(NetworkVersion::V16);
         assert_ne!(kern.price_list(), unexpected_list);

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -276,9 +276,7 @@ impl CallManager for DummyCallManager {
 
     fn charge_gas(&mut self, charge: GasCharge) -> kernel::Result<()> {
         self.test_data.borrow_mut().charge_gas_calls += 1;
-
-        self.gas_tracker_mut().apply_charge(charge)?;
-        Ok(())
+        self.gas_tracker_mut().apply_charge(charge)
     }
 
     fn origin(&self) -> Address {

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -189,6 +189,23 @@ impl DummyCallManager {
             cell_ref,
         )
     }
+
+    pub fn new_with_gas(gas_tracker: GasTracker) -> (Self, Rc<RefCell<TestData>>) {
+        let rc = Rc::new(RefCell::new(TestData {
+            charge_gas_calls: 0,
+        }));
+        let cell_ref = rc.clone();
+        (
+            Self {
+                machine: DummyMachine::new_stub().unwrap(),
+                gas_tracker,
+                origin: Address::new_actor(&[]),
+                nonce: 0,
+                test_data: rc,
+            },
+            cell_ref,
+        )
+    }
 }
 
 impl CallManager for DummyCallManager {

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -17,7 +17,7 @@ use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use multihash::Code;
 
-const STUB_NETWORK_VER: NetworkVersion = NetworkVersion::V15;
+pub const STUB_NETWORK_VER: NetworkVersion = NetworkVersion::V15;
 
 /// Unimplemented and empty `Externs` impl
 pub struct DummyExterns;
@@ -181,7 +181,7 @@ impl DummyCallManager {
         (
             Self {
                 machine: DummyMachine::new_stub().unwrap(),
-                gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0)), // TODO this will need to be modified for gas limit testing
+                gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0)),
                 origin: Address::new_actor(&[]),
                 nonce: 0,
                 test_data: rc,
@@ -217,7 +217,7 @@ impl CallManager for DummyCallManager {
         }));
         Self {
             machine,
-            gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0)), // TODO this will need to be modified for gas limit testing
+            gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0)),
             origin,
             nonce,
             test_data: rc,

--- a/fvm/tests/fvm.rs
+++ b/fvm/tests/fvm.rs
@@ -2,3 +2,4 @@ mod default_kernel;
 mod dummy;
 
 use dummy::*;
+

--- a/fvm/tests/fvm.rs
+++ b/fvm/tests/fvm.rs
@@ -2,4 +2,3 @@ mod default_kernel;
 mod dummy;
 
 use dummy::*;
-


### PR DESCRIPTION
Also adds `pretty_assertions` as a dev dependency since trying to find what is wrong with large structs using the default is near impossible.