### PR TITLE
fix: machine config: disable async even with feature enabled

### DIFF
--- a/fvm/src/machine/engine.rs
+++ b/fvm/src/machine/engine.rs
@@ -134,6 +134,9 @@ pub fn default_wasmtime_config() -> wasmtime::Config {
     c.guard_before_linear_memory(true);
     c.parallel_compilation(true);
 
+    #[cfg(feature = "wasmtime/async")]
+    c.async_support(false);
+
     // Doesn't seem to have significant impact on the time it takes to load code
     // todo(M2): make sure this is guaranteed to run in linear time.
     c.cranelift_opt_level(Speed);


### PR DESCRIPTION
Might fix the `wasm stack size cannot exceed the async stack size` issue @karim-agha is seeing