### PR TITLE
Add new proofs version type

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -31,7 +31,7 @@ lazy_static = "1.4.0"
 derive-getters = "0.2.0"
 derive_more = "0.99.17"
 replace_with = "0.1.7"
-filecoin-proofs-api = { version = "11", default-features = false }
+filecoin-proofs-api = { version = "~11.1", default-features = false }
 rayon = "1"
 num_cpus = "1.13.0"
 log = "0.4.14"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -34,7 +34,7 @@ arbitrary = { version = "1.1", optional = true, features = ["derive"]}
 ## non-wasm dependencies; these dependencies and the respective code is
 ## only activated through non-default features, which the Kernel enables, but
 ## not the actors.
-filecoin-proofs-api = { version = "11", default_features = false, optional = true }
+filecoin-proofs-api = { version = "~11.1", default_features = false, optional = true }
 libsecp256k1 = { version = "0.7", optional = true }
 bls-signatures = { version = "0.11", default-features = false, optional = true }
 byteorder = "1.4.3"
@@ -54,4 +54,3 @@ blst = ["bls-signatures/blst"]
 pairing = ["bls-signatures/pairing"]
 testing = []
 arb = ["arbitrary"]
-

--- a/shared/src/sector/registered_proof.rs
+++ b/shared/src/sector/registered_proof.rs
@@ -265,6 +265,7 @@ impl RegisteredSealProof {
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 pub enum RegisteredAggregateProof {
     SnarkPackV1,
+    SnarkPackV2,
     Invalid(i64),
 }
 
@@ -332,6 +333,7 @@ i64_conversion! {
 i64_conversion! {
     RegisteredAggregateProof;
     SnarkPackV1 => 0,
+    SnarkPackV2 => 1,
 }
 
 i64_conversion! {
@@ -349,6 +351,7 @@ impl TryFrom<RegisteredAggregateProof> for filecoin_proofs_api::RegisteredAggreg
         use RegisteredAggregateProof::*;
         match p {
             SnarkPackV1 => Ok(Self::SnarkPackV1),
+            SnarkPackV2 => Ok(Self::SnarkPackV2),
             Invalid(i) => Err(format!("unsupported aggregate proof type: {}", i)),
         }
     }


### PR DESCRIPTION
Bumps to filecoin-proofs-api v11.1