### PR TITLE
Debug artifacts syscall + integration test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,19 @@ jobs:
           - name: integration
             key: v3
             command: test
-            args: --package fvm_integration_tests --package "*actor"
+            args: --package fvm_integration_tests --features wasm-coverage --package "*actor"
           - name: conformance
             key: v3
             command: test
             args: --package fvm_conformance_tests
             submodules: true
+          # Overrides
+          # skip generating wasm coverage on mac
+          - os: macos-latest 
+            name: integration
+            key: v3
+            command: test
+            args: --package fvm_integration_tests --package "*actor"
         exclude:
           - os: macos-latest
             name: check-clippy

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ Cargo.lock
 !testing/integration/tests/assets/*
 .idea/
 lcov.info
-testing/integration/artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 !testing/integration/tests/assets/*
 .idea/
 lcov.info
+testing/integration/artifacts

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -46,7 +46,7 @@ arbitrary = {version = "1.1.0", optional = true, features = ["derive"]}
 pretty_assertions = "1.2.1"
 
 [dependencies.wasmtime]
-version = "0.38.0"
+version = "0.37.0"
 default-features = false
 features = ["cranelift", "pooling-allocator", "parallel-compilation"]
 

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -45,7 +45,7 @@ pub struct InnerDefaultCallManager<M> {
     backtrace: Backtrace,
     /// The current execution trace.
     exec_trace: ExecutionTrace,
-    /// Current invocation count
+    /// Number of actors that have been invoked in this message execution.
     invocation_count: u64,
 }
 

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -45,6 +45,8 @@ pub struct InnerDefaultCallManager<M> {
     backtrace: Backtrace,
     /// The current execution trace.
     exec_trace: ExecutionTrace,
+    /// Current invocation count
+    invocation_count: u64,
 }
 
 #[doc(hidden)]
@@ -79,6 +81,7 @@ where
             call_stack_depth: 0,
             backtrace: Backtrace::default(),
             exec_trace: vec![],
+            invocation_count: 0,
         })))
     }
 
@@ -217,6 +220,10 @@ where
         self.num_actors_created += 1;
         ret
     }
+
+    fn invocation_count(&self) -> u64 {
+        self.invocation_count
+    }
 }
 
 impl<M> DefaultCallManager<M>
@@ -336,6 +343,9 @@ where
         } else {
             NO_DATA_BLOCK_ID
         };
+
+        // Increment invocation count
+        self.invocation_count += 1;
 
         // This is a cheap operation as it doesn't actually clone the struct,
         // it returns a referenced copy.

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -84,7 +84,7 @@ pub trait CallManager: 'static {
     fn next_actor_idx(&mut self) -> u64;
 
     // TODO: should this be ActorID instead?
-    /// Gets the call-stack actor creation index (aka current total created actors)
+    /// Gets the total invocations done on this call stack.
     fn invocation_count(&self) -> u64;
 
     /// Returns the current price list.

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -83,6 +83,10 @@ pub trait CallManager: 'static {
     /// Gets and increment the call-stack actor creation index.
     fn next_actor_idx(&mut self) -> u64;
 
+    // TODO: should this be ActorID instead?
+    /// Gets the call-stack actor creation index (aka current total created actors)
+    fn invocation_count(&self) -> u64;
+
     /// Returns the current price list.
     fn price_list(&self) -> &PriceList {
         self.machine().context().price_list

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -83,7 +83,6 @@ pub trait CallManager: 'static {
     /// Gets and increment the call-stack actor creation index.
     fn next_actor_idx(&mut self) -> u64;
 
-    // TODO: should this be ActorID instead?
     /// Gets the total invocations done on this call stack.
     fn invocation_count(&self) -> u64;
 

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -793,7 +793,7 @@ where
         self.call_manager.context().actor_debugging
     }
 
-    fn store_artifact(&self, name: &str, data: &[u8]) -> Result<()>{
+    fn store_artifact(&self, name: &str, data: &[u8]) -> Result<()> {
         // Ensure well formed artifact name
         {
             if name.len() > 256 {
@@ -818,12 +818,14 @@ where
         if let Ok(dir) = std::env::var(ENV_ARTIFACT_DIR) {
             let dir: PathBuf = [
                 dir,
-                self.call_manager.machine().machine_id().to_string(),
+                self.call_manager.machine().machine_id(),
                 self.call_manager.origin().to_string(),
                 self.call_manager.nonce().to_string(),
                 self.actor_id.to_string(),
                 self.call_manager.invocation_count().to_string(),
-            ].iter().collect();
+            ]
+            .iter()
+            .collect();
 
             if let Err(e) = std::fs::create_dir_all(dir.clone()) {
                 log::error!("failed to make directory to store debug artifacts {}", e);

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -39,6 +39,7 @@ lazy_static! {
 
 const BLAKE2B_256: u64 = 0xb220;
 const ENV_ARTIFACT_DIR: &str = "FVM_STORE_ARTIFACT_DIR";
+const MAX_ARTIFACT_NAME_LEN: usize = 256;
 
 /// The "default" [`Kernel`] implementation.
 pub struct DefaultKernel<C> {
@@ -796,7 +797,7 @@ where
     fn store_artifact(&self, name: &str, data: &[u8]) -> Result<()> {
         // Ensure well formed artifact name
         {
-            if name.len() > 256 {
+            if name.len() > MAX_ARTIFACT_NAME_LEN {
                 Err("debug artifact name should not exceed 256 bytes")
             } else if name.chars().any(std::path::is_separator) {
                 Err("debug artifact name should not include any path separators")
@@ -815,14 +816,14 @@ where
         .or_error(fvm_shared::error::ErrorNumber::IllegalArgument)?;
 
         // Write to disk
-        if let Ok(dir) = std::env::var(ENV_ARTIFACT_DIR) {
+        if let Ok(dir) = std::env::var(ENV_ARTIFACT_DIR).as_deref() {
             let dir: PathBuf = [
                 dir,
                 self.call_manager.machine().machine_id(),
-                self.call_manager.origin().to_string(),
-                self.call_manager.nonce().to_string(),
-                self.actor_id.to_string(),
-                self.call_manager.invocation_count().to_string(),
+                &self.call_manager.origin().to_string(),
+                &self.call_manager.nonce().to_string(),
+                &self.actor_id.to_string(),
+                &self.call_manager.invocation_count().to_string(),
             ]
             .iter()
             .collect();

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -793,7 +793,6 @@ where
         self.call_manager.context().actor_debugging
     }
 
-    // TODO: scope artifacts into subdirectories
     fn store_artifact(&self, name: &str, data: &[u8]) {
         if let Ok(dir) = std::env::var(ENV_ARTIFACT_DIR) {
             let mut dir = PathBuf::from(dir);

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -793,11 +793,17 @@ where
         self.call_manager.context().actor_debugging
     }
 
-    // TODO: scope artifacts into subdirectories 
+    // TODO: scope artifacts into subdirectories
     fn store_artifact(&self, name: &str, data: &[u8]) {
-
         if let Ok(dir) = std::env::var(ENV_ARTIFACT_DIR) {
-            let dir = PathBuf::from(dir);
+            let mut dir = PathBuf::from(dir);
+
+            dir.push(self.call_manager.machine().machine_id().to_string());
+            dir.push(self.call_manager.origin().to_string());
+            dir.push(self.call_manager.nonce().to_string());
+            dir.push(self.actor_id.to_string());
+            dir.push(self.call_manager.invocation_count().to_string());
+
             if let Err(e) = std::fs::create_dir_all(dir.clone()) {
                 log::error!("failed to make directory to store debug artifacts {}", e);
             } else if let Err(e) = std::fs::write(dir.join(name), data) {

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -322,6 +322,7 @@ pub trait DebugOps {
     /// Returns whether debug mode is enabled.
     fn debug_enabled(&self) -> bool;
 
-    /// Store an artifact
-    fn store_artifact(&self, name: &str, data: &[u8]);
+    /// Store an artifact. 
+    /// Returns error on malformed name, returns Ok and logs the error on system/os errors.
+    fn store_artifact(&self, name: &str, data: &[u8]) -> Result<()>;
 }

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -321,4 +321,7 @@ pub trait DebugOps {
 
     /// Returns whether debug mode is enabled.
     fn debug_enabled(&self) -> bool;
+
+    /// Store an artifact
+    fn store_artifact(&self, name: &str, data: &[u8]);
 }

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -322,7 +322,7 @@ pub trait DebugOps {
     /// Returns whether debug mode is enabled.
     fn debug_enabled(&self) -> bool;
 
-    /// Store an artifact. 
+    /// Store an artifact.
     /// Returns error on malformed name, returns Ok and logs the error on system/os errors.
     fn store_artifact(&self, name: &str, data: &[u8]) -> Result<()>;
 }

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -74,7 +74,10 @@ mod test {
             _round: fvm_shared::clock::ChainEpoch,
             _entropy: &[u8],
         ) -> anyhow::Result<[u8; 32]> {
-            todo!()
+            let msg = "mel was here".as_bytes();
+            let mut out = [0u8; 32];
+            out[..msg.len()].copy_from_slice(msg);
+            Ok(out)
         }
 
         fn get_beacon_randomness(

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -70,7 +70,7 @@ impl<M: Machine> Machine for Box<M> {
     }
 
     #[inline(always)]
-    fn machine_id(&self) -> String {
+    fn machine_id(&self) -> &str {
         (&**self).machine_id()
     }
 }

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -4,7 +4,7 @@ use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::ActorID;
 
-use super::{Engine, Machine, MachineContext};
+use super::{Engine, Machine, MachineContext, MachineId};
 use crate::kernel::Result;
 use crate::state_tree::{ActorState, StateTree};
 
@@ -67,5 +67,10 @@ impl<M: Machine> Machine for Box<M> {
     #[inline(always)]
     fn flush(&mut self) -> Result<Cid> {
         (**self).flush()
+    }
+
+    #[inline(always)]
+    fn machine_id(&self) -> &MachineId {
+        (&**self).machine_id()
     }
 }

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -4,7 +4,7 @@ use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::ActorID;
 
-use super::{Engine, Machine, MachineContext, MachineId};
+use super::{Engine, Machine, MachineContext};
 use crate::kernel::Result;
 use crate::state_tree::{ActorState, StateTree};
 
@@ -70,7 +70,7 @@ impl<M: Machine> Machine for Box<M> {
     }
 
     #[inline(always)]
-    fn machine_id(&self) -> &MachineId {
+    fn machine_id(&self) -> String {
         (&**self).machine_id()
     }
 }

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -13,7 +13,7 @@ use fvm_shared::ActorID;
 use log::debug;
 use num_traits::Signed;
 
-use super::{Engine, Machine, MachineContext, MachineId};
+use super::{Engine, Machine, MachineContext};
 use crate::blockstore::BufferedBlockstore;
 use crate::externs::Externs;
 use crate::kernel::{ClassifyResult, Context as _, Result};
@@ -39,7 +39,7 @@ pub struct DefaultMachine<B, E> {
     builtin_actors: Manifest,
     /// Somewhat unique ID of the machine consisting of (epoch, randomness)
     /// randomness is generated with `initial_state_root`
-    id: MachineId,
+    id: String,
 }
 
 impl<B, E> DefaultMachine<B, E>
@@ -132,7 +132,12 @@ where
             externs,
             state_tree,
             builtin_actors,
-            id: MachineId::new(context.epoch, randomness),
+            id: format_args!(
+                "{}-{}",
+                context.epoch,
+                cid::multibase::encode(cid::multibase::Base::Base58Btc, &randomness[..16])
+            )
+            .to_string(),
         })
     }
 }
@@ -245,7 +250,7 @@ where
         self.state_tree.into_store()
     }
 
-    fn machine_id(&self) -> &MachineId {
-        &self.id
+    fn machine_id(&self) -> String {
+        self.id.clone()
     }
 }

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -135,7 +135,7 @@ where
             id: format!(
                 "{}-{}",
                 context.epoch,
-                cid::multibase::encode(cid::multibase::Base::Base58Btc, &randomness[..16])
+                cid::multibase::encode(cid::multibase::Base::Base32Lower, &randomness[..16])
             ),
         })
     }

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -125,7 +125,7 @@ where
             context.epoch,
             context.initial_state_root.to_bytes().as_slice(),
         )?;
-        
+
         Ok(DefaultMachine {
             context: context.clone(),
             engine: engine.clone(),

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -132,12 +132,11 @@ where
             externs,
             state_tree,
             builtin_actors,
-            id: format_args!(
+            id: format!(
                 "{}-{}",
                 context.epoch,
                 cid::multibase::encode(cid::multibase::Base::Base58Btc, &randomness[..16])
-            )
-            .to_string(),
+            ),
         })
     }
 }
@@ -250,7 +249,7 @@ where
         self.state_tree.into_store()
     }
 
-    fn machine_id(&self) -> String {
-        self.id.clone()
+    fn machine_id(&self) -> &str {
+        &self.id
     }
 }

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -85,7 +85,7 @@ pub trait Machine: 'static {
     fn into_store(self) -> Self::Blockstore;
 
     /// Returns a generated ID of a machine
-    fn machine_id(&self) -> String;
+    fn machine_id(&self) -> &str;
 }
 
 /// Network-level settings. Except when testing locally, changing any of these likely requires a

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -83,6 +83,10 @@ pub trait Machine: 'static {
 
     /// Consumes the machine and returns the owned blockstore.
     fn into_store(self) -> Self::Blockstore;
+
+    /// Returns a generated ID of a machine
+    /// TODO: do we note Machine ID isnt gaurenteed to be unique? 
+    fn machine_id(&self) -> &MachineId;
 }
 
 /// Network-level settings. Except when testing locally, changing any of these likely requires a
@@ -216,5 +220,34 @@ impl MachineContext {
     pub fn enable_tracing(&mut self) -> &mut Self {
         self.tracing = true;
         self
+    }
+}
+
+/// Somewhat unique ID for a machine
+#[derive(Debug)]
+pub struct MachineId(ChainEpoch, [u8; 32]);
+
+impl MachineId {
+    pub fn new(epoch: ChainEpoch, randomness: [u8; 32]) -> Self {
+        Self(epoch, randomness)
+    }
+
+    pub fn epoch(&self) -> ChainEpoch {
+        self.0
+    }
+
+    pub fn randomness(&self) -> [u8; 32] {
+        self.1
+    }
+}
+
+impl ToString for MachineId {
+    fn to_string(&self) -> String {
+        format_args!(
+            "{}-{}",
+            self.0,
+            cid::multibase::encode(cid::multibase::Base::Base58Btc, &self.1[..16])
+        )
+        .to_string()
     }
 }

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -85,7 +85,7 @@ pub trait Machine: 'static {
     fn into_store(self) -> Self::Blockstore;
 
     /// Returns a generated ID of a machine
-    /// TODO: do we note Machine ID isnt gaurenteed to be unique? 
+    /// TODO: do we note Machine ID isnt gaurenteed to be unique?
     fn machine_id(&self) -> &MachineId;
 }
 

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -85,8 +85,7 @@ pub trait Machine: 'static {
     fn into_store(self) -> Self::Blockstore;
 
     /// Returns a generated ID of a machine
-    /// TODO: do we note Machine ID isnt gaurenteed to be unique?
-    fn machine_id(&self) -> &MachineId;
+    fn machine_id(&self) -> String;
 }
 
 /// Network-level settings. Except when testing locally, changing any of these likely requires a
@@ -220,34 +219,5 @@ impl MachineContext {
     pub fn enable_tracing(&mut self) -> &mut Self {
         self.tracing = true;
         self
-    }
-}
-
-/// Somewhat unique ID for a machine
-#[derive(Debug)]
-pub struct MachineId(ChainEpoch, [u8; 32]);
-
-impl MachineId {
-    pub fn new(epoch: ChainEpoch, randomness: [u8; 32]) -> Self {
-        Self(epoch, randomness)
-    }
-
-    pub fn epoch(&self) -> ChainEpoch {
-        self.0
-    }
-
-    pub fn randomness(&self) -> [u8; 32] {
-        self.1
-    }
-}
-
-impl ToString for MachineId {
-    fn to_string(&self) -> String {
-        format_args!(
-            "{}-{}",
-            self.0,
-            cid::multibase::encode(cid::multibase::Base::Base58Btc, &self.1[..16])
-        )
-        .to_string()
     }
 }

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -1,3 +1,5 @@
+use std::fs::DirBuilder;
+
 use crate::kernel::{ClassifyResult, Result};
 use crate::syscalls::context::Context;
 use crate::Kernel;
@@ -20,4 +22,34 @@ pub fn enabled(context: Context<'_, impl Kernel>) -> Result<i32> {
     } else {
         -1
     })
+}
+
+// TODO: make output path more configurable, maybe add extra gaurds/limitations
+pub fn capture_artifact(
+    context: Context<'_, impl Kernel>,
+    name_off: u32,
+    name_len: u32,
+    data_off: u32,
+    data_len: u32,
+) -> Result<()> {
+    // No-op if disabled.
+    if !context.kernel.debug_enabled() {
+        return Ok(());
+    }
+    let src_dir = std::env::current_dir()
+        .or_fatal()?
+        .canonicalize()
+        .or_fatal()?
+        .join("artifacts");
+    DirBuilder::new().create(src_dir.clone()).or_fatal()?;
+
+    let data = context.memory.try_slice(data_off, data_len)?;
+    let name = context.memory.try_slice(name_off, name_len)?;
+    let name = String::from_utf8(name.to_owned())
+        .or_error(fvm_shared::error::ErrorNumber::IllegalArgument)?;
+        
+    println!("writing artifact: {} to {:?}", name, src_dir);
+    std::fs::write(src_dir.join(name), data).or_fatal()?;
+
+    Ok(())
 }

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -39,27 +39,7 @@ pub fn store_artifact(
     let name =
         std::str::from_utf8(name).or_error(fvm_shared::error::ErrorNumber::IllegalArgument)?;
 
-    // Ensure well formed artifact name
-    {
-        if name.len() > 256 {
-            Err("debug artifact name should not exceed 256 bytes")
-        } else if name.chars().any(std::path::is_separator) {
-            Err("debug artifact name should not include any path separators")
-        } else if name
-            .chars()
-            .next()
-            .ok_or("debug artifact name should be at least one character")
-            .or_error(fvm_shared::error::ErrorNumber::IllegalArgument)?
-            == '.'
-        {
-            Err("debug artifact name should not start with a decimal '.'")
-        } else {
-            Ok(())
-        }
-    }
-    .or_error(fvm_shared::error::ErrorNumber::IllegalArgument)?;
-
-    context.kernel.store_artifact(name, data);
+    context.kernel.store_artifact(name, data)?;
 
     Ok(())
 }

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -41,13 +41,16 @@ pub fn capture_artifact(
         .canonicalize()
         .or_fatal()?
         .join("artifacts");
-    DirBuilder::new().recursive(true).create(src_dir.clone()).or_fatal()?;
+    DirBuilder::new()
+        .recursive(true)
+        .create(src_dir.clone())
+        .or_fatal()?;
 
     let data = context.memory.try_slice(data_off, data_len)?;
     let name = context.memory.try_slice(name_off, name_len)?;
     let name = String::from_utf8(name.to_owned())
         .or_error(fvm_shared::error::ErrorNumber::IllegalArgument)?;
-        
+
     println!("writing artifact: {} to {:?}", name, src_dir);
     std::fs::write(src_dir.join(name), data).or_fatal()?;
 

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -25,7 +25,7 @@ pub fn enabled(context: Context<'_, impl Kernel>) -> Result<i32> {
 }
 
 // TODO: make output path more configurable, maybe add extra gaurds/limitations
-pub fn capture_artifact(
+pub fn store_artifact(
     context: Context<'_, impl Kernel>,
     name_off: u32,
     name_len: u32,

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -41,7 +41,7 @@ pub fn capture_artifact(
         .canonicalize()
         .or_fatal()?
         .join("artifacts");
-    DirBuilder::new().create(src_dir.clone()).or_fatal()?;
+    DirBuilder::new().recursive(true).create(src_dir.clone()).or_fatal()?;
 
     let data = context.memory.try_slice(data_off, data_len)?;
     let name = context.memory.try_slice(name_off, name_len)?;

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -26,7 +26,7 @@ pub fn enabled(context: Context<'_, impl Kernel>) -> Result<i32> {
     })
 }
 
-// TODO: make output path more configurable, maybe add extra gaurds/limitations
+// TODO: scope artifacts into subdirectories
 pub fn store_artifact(
     context: Context<'_, impl Kernel>,
     name_off: u32,

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -169,6 +169,7 @@ pub fn bind_syscalls(
 
     linker.bind("debug", "log", debug::log)?;
     linker.bind("debug", "enabled", debug::enabled)?;
+    linker.bind("debug", "capture_artifact", debug::capture_artifact)?;
 
     Ok(())
 }

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -169,7 +169,7 @@ pub fn bind_syscalls(
 
     linker.bind("debug", "log", debug::log)?;
     linker.bind("debug", "enabled", debug::enabled)?;
-    linker.bind("debug", "capture_artifact", debug::capture_artifact)?;
+    linker.bind("debug", "store_artifact", debug::store_artifact)?;
 
     Ok(())
 }

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -157,7 +157,7 @@ impl Machine for DummyMachine {
         self.state_tree.into_store()
     }
 
-    fn machine_id(&self) -> String {
+    fn machine_id(&self) -> &str {
         todo!()
     }
 }

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -157,7 +157,7 @@ impl Machine for DummyMachine {
         self.state_tree.into_store()
     }
 
-    fn machine_id(&self) -> &fvm::machine::MachineId {
+    fn machine_id(&self) -> String {
         todo!()
     }
 }

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -156,6 +156,10 @@ impl Machine for DummyMachine {
     fn into_store(self) -> Self::Blockstore {
         self.state_tree.into_store()
     }
+
+    fn machine_id(&self) -> &fvm::machine::MachineId {
+        todo!()
+    }
 }
 
 /// Minimal *pseudo-functional* implementation CallManager
@@ -288,6 +292,10 @@ impl CallManager for DummyCallManager {
     }
 
     fn next_actor_idx(&mut self) -> u64 {
+        todo!()
+    }
+
+    fn invocation_count(&self) -> u64 {
         todo!()
     }
 }

--- a/sdk/src/debug.rs
+++ b/sdk/src/debug.rs
@@ -40,7 +40,6 @@ mod inner {
 
     /// Saves an artifact to the host env. New artifacts with the same name will overwrite old ones
     pub fn store_artifact(name: impl AsRef<str>, data: impl AsRef<[u8]>) {
-        // this &str or String?
         let name = name.as_ref();
         let data = data.as_ref();
         unsafe {

--- a/sdk/src/debug.rs
+++ b/sdk/src/debug.rs
@@ -39,9 +39,10 @@ mod inner {
     }
 
     /// Saves an artifact to the host env. New artifacts with the same name will overwrite old ones
-    pub fn store_artifact(name: impl AsRef<str>, data: Vec<u8>) {
+    pub fn store_artifact(name: impl AsRef<str>, data: impl AsRef<[u8]>) {
         // this &str or String?
         let name = name.as_ref();
+        let data = data.as_ref();
         unsafe {
             sys::debug::store_artifact(
                 name.as_ptr(),

--- a/sdk/src/debug.rs
+++ b/sdk/src/debug.rs
@@ -38,6 +38,20 @@ mod inner {
         }
     }
 
+    pub fn capture_artifact(name: impl AsRef<str>, data: Vec<u8>) {
+        // this &str or String?
+        let name = name.as_ref();
+        unsafe {
+            sys::debug::capture_artifact(
+                name.as_ptr(),
+                name.len() as u32,
+                data.as_ptr(),
+                data.len() as u32,
+            )
+            .unwrap();
+        }
+    }
+
     /// Returns whether debug mode is enabled.
     #[inline(always)]
     pub fn enabled() -> bool {

--- a/sdk/src/debug.rs
+++ b/sdk/src/debug.rs
@@ -39,11 +39,11 @@ mod inner {
     }
 
     /// Saves an artifact to the host env. New artifacts with the same name will overwrite old ones
-    pub fn capture_artifact(name: impl AsRef<str>, data: Vec<u8>) {
+    pub fn store_artifact(name: impl AsRef<str>, data: Vec<u8>) {
         // this &str or String?
         let name = name.as_ref();
         unsafe {
-            sys::debug::capture_artifact(
+            sys::debug::store_artifact(
                 name.as_ptr(),
                 name.len() as u32,
                 data.as_ptr(),

--- a/sdk/src/debug.rs
+++ b/sdk/src/debug.rs
@@ -38,6 +38,7 @@ mod inner {
         }
     }
 
+    /// Saves an artifact to the host env. New artifacts with the same name will overwrite old ones
     pub fn capture_artifact(name: impl AsRef<str>, data: Vec<u8>) {
         // this &str or String?
         let name = name.as_ref();

--- a/sdk/src/sys/debug.rs
+++ b/sdk/src/sys/debug.rs
@@ -10,7 +10,6 @@ super::fvm_syscalls! {
     /// Logs a message on the node.
     pub fn log(message: *const u8, message_len: u32) -> Result<()>;
 
-    /// TODO: this technically lets anyone store whatever data they want on the node's filesystem, this should *not* be enabled on an actual network until proper gaurds are in place
     /// Save data as a debug artifact on the node.
     pub fn store_artifact(name_off: *const u8, name_len: u32, data_off: *const u8, data_len: u32) -> Result<()>;
 }

--- a/sdk/src/sys/debug.rs
+++ b/sdk/src/sys/debug.rs
@@ -10,7 +10,7 @@ super::fvm_syscalls! {
     /// Logs a message on the node.
     pub fn log(message: *const u8, message_len: u32) -> Result<()>;
 
-    /// TODO: this technically lets anyone store whatever data they want on the node's filesystem, this *not* be enabled on an actual network until proper gaurds are in place
+    /// TODO: this technically lets anyone store whatever data they want on the node's filesystem, this should *not* be enabled on an actual network until proper gaurds are in place
     /// Save data as a debug artifact on the node.
     pub fn capture_artifact(name_off: *const u8, name_len: u32, data_off: *const u8, data_len: u32) -> Result<()>;
 }

--- a/sdk/src/sys/debug.rs
+++ b/sdk/src/sys/debug.rs
@@ -12,5 +12,5 @@ super::fvm_syscalls! {
 
     /// TODO: this technically lets anyone store whatever data they want on the node's filesystem, this should *not* be enabled on an actual network until proper gaurds are in place
     /// Save data as a debug artifact on the node.
-    pub fn capture_artifact(name_off: *const u8, name_len: u32, data_off: *const u8, data_len: u32) -> Result<()>;
+    pub fn store_artifact(name_off: *const u8, name_len: u32, data_off: *const u8, data_len: u32) -> Result<()>;
 }

--- a/sdk/src/sys/debug.rs
+++ b/sdk/src/sys/debug.rs
@@ -9,4 +9,8 @@ super::fvm_syscalls! {
 
     /// Logs a message on the node.
     pub fn log(message: *const u8, message_len: u32) -> Result<()>;
+
+    /// TODO: this technically lets anyone store whatever data they want on the node's filesystem, this *not* be enabled on an actual network until proper gaurds are in place
+    /// Save data as a debug artifact on the node.
+    pub fn capture_artifact(name_off: *const u8, name_len: u32, data_off: *const u8, data_len: u32) -> Result<()>;
 }

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4.14"
 byteorder = "1.4.3"
 futures = "0.3.19"
 async-std = { version = "1.9", features = ["attributes"] }
-wasmtime = { version = "0.38.0", default-features = false }
+wasmtime = { version = "0.37.0", default-features = false }
 base64 = "0.13.0"
 flate2 = { version = "1.0" }
 colored = "2"

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -164,7 +164,7 @@ where
         self.machine.flush()
     }
 
-    fn machine_id(&self) -> &fvm::machine::MachineId {
+    fn machine_id(&self) -> String {
         self.machine.machine_id()
     }
 }
@@ -489,7 +489,7 @@ where
         self.0.debug_enabled()
     }
 
-    fn store_artifact(&self, name: &str, data: &[u8]) {
+    fn store_artifact(&self, name: &str, data: &[u8]) -> Result<()> {
         self.0.store_artifact(name, data)
     }
 }

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -164,7 +164,7 @@ where
         self.machine.flush()
     }
 
-    fn machine_id(&self) -> String {
+    fn machine_id(&self) -> &str {
         self.machine.machine_id()
     }
 }

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -163,6 +163,10 @@ where
     fn flush(&mut self) -> Result<Cid> {
         self.machine.flush()
     }
+
+    fn machine_id(&self) -> &fvm::machine::MachineId {
+        self.machine.machine_id()
+    }
 }
 
 /// A CallManager that wraps kernels in an InterceptKernel.
@@ -269,6 +273,10 @@ where
 
     fn charge_gas(&mut self, charge: fvm::gas::GasCharge) -> Result<()> {
         self.0.charge_gas(charge)
+    }
+
+    fn invocation_count(&self) -> u64 {
+        self.0.invocation_count()
     }
 }
 
@@ -479,6 +487,10 @@ where
 
     fn debug_enabled(&self) -> bool {
         self.0.debug_enabled()
+    }
+
+    fn store_artifact(&self, name: &str, data: &[u8]) {
+        self.0.store_artifact(name, data)
     }
 }
 

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -45,3 +45,4 @@ fil_integer_overflow_actor = { path = "tests/fil-integer-overflow-actor", versio
 
 [features]
 default = ["fvm/testing", "fvm_shared/testing"]
+wasm-coverage = ["fil_ipld_actor/coverage"]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -30,7 +30,7 @@ serde_repr = "0.1"
 thiserror = "1.0.30"
 
 [dependencies.wasmtime]
-version = "0.38.0"
+version = "0.37.0"
 default-features = false
 features = ["cranelift", "parallel-compilation"]
 

--- a/testing/integration/README.md
+++ b/testing/integration/README.md
@@ -21,9 +21,9 @@ at test time.
 2. Some testing and examples should be added to demonstrate how the framework works.
 
 TODO: (hack to get coverage reports from actors + integration tests) 
-```shell
+```bash
 cargo build -p "*actor"
-export SKIP_WASM_BUILD true
-export FVM_STORE_ARTIFACT_DIR ../../target/llvm-cov-target/
+export SKIP_WASM_BUILD=true
+export FVM_STORE_ARTIFACT_DIR=../../target/llvm-cov-target/
 cargo llvm-cov -p fvm_integration_tests --lcov
 ```

--- a/testing/integration/README.md
+++ b/testing/integration/README.md
@@ -22,9 +22,9 @@ at test time.
 
 TODO: (hack to get coverage reports from actors + integration tests) 
 ```shell
-cargo build -p fvm_integration_tests
+cargo build -p "*actor"
 export SKIP_WASM_BUILD true
-cargo llvm-cov -p fvm_integration_tests
-cp testing/integration/artifacts/*.profraw target/llvm-cov-target
+export FVM_STORE_ARTIFACT_DIR ../../target/llvm-cov-target/
+cargo llvm-cov -p fvm_integration_tests --lcov
 cargo llvm-cov --no-run --lcov
 ```

--- a/testing/integration/README.md
+++ b/testing/integration/README.md
@@ -19,3 +19,5 @@ The following flow has been defined as a default usage:
 1. Wasm bytecode is now expected to be received through a binary type (`&[u8]`). This be upgraded to work Rust module compiled
 at test time.
 2. Some testing and examples should be added to demonstrate how the framework works.
+
+TODO: `export SKIP_WASM_BUILD true` when generating coverage, then copy `artifacts/*.profraw` over to build dir, then `cargo llvm-cov --no-run --lcov`

--- a/testing/integration/README.md
+++ b/testing/integration/README.md
@@ -20,4 +20,11 @@ The following flow has been defined as a default usage:
 at test time.
 2. Some testing and examples should be added to demonstrate how the framework works.
 
-TODO: `export SKIP_WASM_BUILD true` when generating coverage, then copy `artifacts/*.profraw` over to build dir, then `cargo llvm-cov --no-run --lcov`
+TODO: (hack to get coverage reports from actors + integration tests) 
+```shell
+cargo build -p fvm_integration_tests
+export SKIP_WASM_BUILD true
+cargo llvm-cov -p fvm_integration_tests
+cp testing/integration/artifacts/*.profraw target/llvm-cov-target
+cargo llvm-cov --no-run --lcov
+```

--- a/testing/integration/README.md
+++ b/testing/integration/README.md
@@ -26,5 +26,4 @@ cargo build -p "*actor"
 export SKIP_WASM_BUILD true
 export FVM_STORE_ARTIFACT_DIR ../../target/llvm-cov-target/
 cargo llvm-cov -p fvm_integration_tests --lcov
-cargo llvm-cov --no-run --lcov
 ```

--- a/testing/integration/src/dummy.rs
+++ b/testing/integration/src/dummy.rs
@@ -11,7 +11,10 @@ impl Rand for DummyExterns {
         _round: fvm_shared::clock::ChainEpoch,
         _entropy: &[u8],
     ) -> anyhow::Result<[u8; 32]> {
-        todo!()
+        let msg = "mel was here".as_bytes();
+        let mut out = [0u8; 32];
+        out[..msg.len()].copy_from_slice(msg);
+        Ok(out)
     }
 
     fn get_beacon_randomness(

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -178,6 +178,8 @@ where
 
         let mut nc = NetworkConfig::new(self.nv);
         nc.override_actors(self.builtin_actors);
+        // TODO: maybe cfg flag this?
+        nc.enable_actor_debugging();
 
         let mut mc = nc.for_epoch(0, state_root);
         mc.set_base_fee(TokenAmount::from(DEFAULT_BASE_FEE));

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -178,7 +178,6 @@ where
 
         let mut nc = NetworkConfig::new(self.nv);
         nc.override_actors(self.builtin_actors);
-        // TODO: maybe cfg flag this?
         nc.enable_actor_debugging();
 
         let mut mc = nc.for_epoch(0, state_root);

--- a/testing/integration/tests/fil-ipld-actor/Cargo.toml
+++ b/testing/integration/tests/fil-ipld-actor/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "1.0.0-rc.3", path = "../../../../sdk" }
 fvm_shared = { version = "0.8.0", path = "../../../../shared" }
+minicov = "0.2"
+
 
 
 [build-dependencies]

--- a/testing/integration/tests/fil-ipld-actor/Cargo.toml
+++ b/testing/integration/tests/fil-ipld-actor/Cargo.toml
@@ -7,9 +7,12 @@ edition = "2021"
 fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "1.0.0-rc.3", path = "../../../../sdk" }
 fvm_shared = { version = "0.8.0", path = "../../../../shared" }
-minicov = "0.2"
+minicov = {version = "0.2", optional = true}
 
 
 
 [build-dependencies]
 wasm-builder = "3.0.1"
+
+[features]
+coverage = ["minicov"]

--- a/testing/integration/tests/fil-ipld-actor/build.rs
+++ b/testing/integration/tests/fil-ipld-actor/build.rs
@@ -8,5 +8,8 @@ fn main() {
         .append_to_rust_flags("-Coverflow-checks=true")
         .append_to_rust_flags("-Clto=true")
         .append_to_rust_flags("-Copt-level=z")
+        .append_to_rust_flags("-Zinstrument-coverage")
+        .append_to_rust_flags("-Zno-profiler-runtime")
+        .append_to_rust_flags("-Clink-dead-code")
         .build()
 }

--- a/testing/integration/tests/fil-ipld-actor/src/lib.rs
+++ b/testing/integration/tests/fil-ipld-actor/src/lib.rs
@@ -13,6 +13,7 @@ pub fn invoke(_: u32) -> u32 {
 
     test_read_block();
 
+    #[cfg(coverage)]
     sdk::debug::store_artifact("ipld_actor.profraw", minicov::capture_coverage());
     0
 }

--- a/testing/integration/tests/fil-ipld-actor/src/lib.rs
+++ b/testing/integration/tests/fil-ipld-actor/src/lib.rs
@@ -12,6 +12,8 @@ pub fn invoke(_: u32) -> u32 {
     }));
 
     test_read_block();
+
+    sdk::debug::capture_artifact("ipld_actor.profraw", minicov::capture_coverage());
     0
 }
 

--- a/testing/integration/tests/fil-ipld-actor/src/lib.rs
+++ b/testing/integration/tests/fil-ipld-actor/src/lib.rs
@@ -13,7 +13,7 @@ pub fn invoke(_: u32) -> u32 {
 
     test_read_block();
 
-    sdk::debug::capture_artifact("ipld_actor.profraw", minicov::capture_coverage());
+    sdk::debug::store_artifact("ipld_actor.profraw", minicov::capture_coverage());
     0
 }
 

--- a/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 fvm_sdk = { version = "1.0.0-rc.3", path = "../../../../sdk" }
 fvm_shared = { version = "0.8.0", path = "../../../../shared" }
 
+
 [build-dependencies]
 wasm-builder = "3.0.1"

--- a/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2021"
 fvm_sdk = { version = "1.0.0-rc.3", path = "../../../../sdk" }
 fvm_shared = { version = "0.8.0", path = "../../../../shared" }
 
-
 [build-dependencies]
 wasm-builder = "3.0.1"


### PR DESCRIPTION
adds a new syscall under `debug` to save artifacts to a folder ~~in current dir `artifacts/` which is somewhat horrible and should probably be something else, but it works and adding the ability to modify that sort of thing is easy enough, just need to get a consensus on how it should be done.~~ defined by env var `FVM_STORE_ARTIFACT_DIR`

ATM this doesn't do any CI as I think CI should be heavily refactored anyways and adding this coverage can be added during then (ref https://github.com/filecoin-project/ref-fvm/issues/609)


