### PR TITLE
Recover public key FVM syscall

### DIFF
--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changes to the reference FVM implementation.
 
+## 1.1.0 [in-progress]
+
+
+
 ## Unreleased
 
 ...

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to the reference FVM implementation.
 
 ## 1.1.0 [in-progress]
 
-
+- Added `recover_public_key` syscall
 
 ## Unreleased
 

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "1.0.0-rc.2"
+version = "1.1.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -41,6 +41,7 @@ lazy_static! {
 
         bls_sig_cost: Gas::new(16598605),
         secp256k1_sig_cost: Gas::new(1637292),
+        secp256k1_recover_cost: Gas::new(1637292),
 
         hashing_base: Gas::new(31355),
         compute_unsealed_sector_cid_base: Gas::new(98647),
@@ -166,6 +167,7 @@ lazy_static! {
 
         bls_sig_cost: Gas::new(16598605),
         secp256k1_sig_cost: Gas::new(1637292),
+        secp256k1_recover_cost: Gas::new(1637292),
 
         hashing_base: Gas::new(31355),
         compute_unsealed_sector_cid_base: Gas::new(98647),
@@ -362,6 +364,9 @@ pub struct PriceList {
     /// Gas cost for verifying secp256k1 signature
     pub(crate) secp256k1_sig_cost: Gas,
 
+    /// Gas cost for recovering secp256k1 signer public key
+    pub(crate) secp256k1_recover_cost: Gas,
+
     pub(crate) hashing_base: Gas,
 
     pub(crate) compute_unsealed_sector_cid_base: Gas,
@@ -493,6 +498,15 @@ impl PriceList {
             SignatureType::Secp256k1 => self.secp256k1_sig_cost,
         };
         GasCharge::new("OnVerifySignature", val, Zero::zero())
+    }
+
+    #[inline]
+    pub fn on_recover_public_key(&self) -> GasCharge<'static> {
+        GasCharge::new(
+            "OnRecoverPublicKey",
+            self.secp256k1_recover_cost,
+            Zero::zero(),
+        )
     }
 
     /// Returns gas required for hashing data.

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -460,6 +460,21 @@ where
         })
     }
 
+    fn recover_public_key(
+        &mut self,
+        hash: &[u8; MESSAGE_SIZE],
+        signature: &[u8; SECP_SIG_LEN],
+    ) -> Result<[u8; SECP_PUB_LEN]> {
+        self.call_manager
+            .charge_gas(self.call_manager.price_list().on_recover_public_key())?;
+
+        signature::ops::recover_public_key(hash, signature)
+            .map(|pubkey| pubkey.serialize())
+            .map_err(|e| {
+                syscall_error!(IllegalArgument; "public key recovery failed: {}", e).into()
+            })
+    }
+
     fn hash(&mut self, code: u64, data: &[u8]) -> Result<[u8; 32]> {
         self.call_manager
             .charge_gas(self.call_manager.price_list().on_hashing(data.len()))?;

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -3,7 +3,7 @@ use cid::Cid;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
-use fvm_shared::crypto::signature::SignatureType;
+use fvm_shared::crypto::signature::{SignatureType, MESSAGE_SIZE, SECP_PUB_LEN, SECP_SIG_LEN};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PieceInfo;
@@ -236,6 +236,13 @@ pub trait CryptoOps {
         signer: &Address,
         plaintext: &[u8],
     ) -> Result<bool>;
+
+    /// Given a message hash and its signature, recovers the public key of the signer.
+    fn recover_public_key(
+        &mut self,
+        hash: &[u8; MESSAGE_SIZE],
+        signature: &[u8; SECP_SIG_LEN],
+    ) -> Result<[u8; SECP_PUB_LEN]>;
 
     /// Hashes input `data_in` using with the specified hash function, writing the output to
     /// `digest_out`, returning the size of the digest written to `digest_out`. If `digest_out` is

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -1,7 +1,7 @@
 use std::cmp;
 
 use anyhow::{anyhow, Context as _};
-use fvm_shared::crypto::signature::SignatureType;
+use fvm_shared::crypto::signature::{SignatureType, SECP_PUB_LEN};
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, ReplicaUpdateInfo, SealVerifyInfo,
@@ -41,6 +41,28 @@ pub fn verify_signature(
         .kernel
         .verify_signature(sig_type, sig_bytes, &addr, plaintext)
         .map(|v| if v { 0 } else { -1 })
+}
+
+pub fn recover_public_key(
+    context: Context<'_, impl Kernel>,
+    hash_off: u32,
+    hash_len: u32,
+    sig_off: u32,
+    sig_len: u32,
+) -> Result<[u8; SECP_PUB_LEN]> {
+    let hash_bytes = context
+        .memory
+        .try_slice(hash_off, hash_len)?
+        .try_into()
+        .or_illegal_argument()?;
+
+    let sig_bytes = context
+        .memory
+        .try_slice(sig_off, sig_len)?
+        .try_into()
+        .or_illegal_argument()?;
+
+    context.kernel.recover_public_key(&hash_bytes, &sig_bytes)
 }
 
 /// Hashes input data using the specified hash function, writing the digest into the provided

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -134,6 +134,7 @@ pub fn bind_syscalls(
     )?;
 
     linker.bind("crypto", "verify_signature", crypto::verify_signature)?;
+    linker.bind("crypto", "recover_public_key", crypto::recover_public_key)?;
     linker.bind("crypto", "hash", crypto::hash)?;
     linker.bind("crypto", "verify_seal", crypto::verify_seal)?;
     linker.bind("crypto", "verify_post", crypto::verify_post)?;

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "1.0.0-rc.2"
+version = "1.1.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -2,7 +2,7 @@ use cid::Cid;
 use fvm_ipld_encoding::{to_vec, Cbor};
 use fvm_shared::address::Address;
 use fvm_shared::consensus::ConsensusFault;
-use fvm_shared::crypto::signature::Signature;
+use fvm_shared::crypto::signature::{Signature, MESSAGE_SIZE, SECP_PUB_LEN, SECP_SIG_LEN};
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, ReplicaUpdateInfo, SealVerifyInfo,
@@ -33,6 +33,21 @@ pub fn verify_signature(
             plaintext.len() as u32,
         )
         .map(status_code_to_bool)
+    }
+}
+
+/// Recovers the signer public key from the message hash and signature.
+pub fn recover_public_key(
+    hash: &[u8; MESSAGE_SIZE],
+    signature: &[u8; SECP_SIG_LEN],
+) -> SyscallResult<[u8; SECP_PUB_LEN]> {
+    unsafe {
+        sys::crypto::recover_public_key(
+            hash.as_ptr(),
+            hash.len() as u32,
+            signature.as_ptr(),
+            signature.len() as u32,
+        )
     }
 }
 

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -1,5 +1,6 @@
 //! Syscalls for cryptographic operations.
 
+use fvm_shared::crypto::signature::SECP_PUB_LEN;
 #[doc(inline)]
 pub use fvm_shared::sys::out::crypto::*;
 
@@ -35,6 +36,27 @@ super::fvm_syscalls! {
         plaintext_off: *const u8,
         plaintext_len: u32,
     ) -> Result<i32>;
+
+    /// Recovers the signer public key from a signed message hash and its signature.
+    ///
+    /// Returns the public key in uncompressed 65 bytes form.
+    ///
+    /// # Arguments
+    ///
+    /// - `hash_off` and `hash_len` specify location and length of the message hash.
+    /// - `sig_off` and `sig_len` specify location and length of signature.
+    ///
+    /// # Errors
+    ///
+    /// | Error               | Reason                                               |
+    /// |---------------------|------------------------------------------------------|
+    /// | [`IllegalArgument`] | signature or hash buffers are invalid                |
+    pub fn recover_public_key(
+        hash_off: *const u8,
+        hash_len: u32,
+        sig_off: *const u8,
+        sig_len: u32
+    ) -> Result<[u8; SECP_PUB_LEN]>;
 
     /// Hashes input data using the specified hash function. The digest is written to the passed
     /// digest buffer and truncated to `digest_len`.

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -50,7 +50,7 @@ actors-v7 = { version = "~7.5", package = "fil_builtin_actors_bundle" }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [dependencies.fvm]
-version = "1.0.0-rc.2"
+version = "1.1.0"
 path = "../../fvm"
 default-features = false
 features = ["testing"]

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -16,7 +16,7 @@ use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
-use fvm_shared::crypto::signature::SignatureType;
+use fvm_shared::crypto::signature::{SignatureType, MESSAGE_SIZE, SECP_PUB_LEN, SECP_SIG_LEN};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
@@ -419,6 +419,15 @@ where
     ) -> Result<bool> {
         self.0
             .verify_signature(sig_type, signature, signer, plaintext)
+    }
+
+    // forwarded
+    fn recover_public_key(
+        &mut self,
+        hash: &[u8; MESSAGE_SIZE],
+        signature: &[u8; SECP_SIG_LEN],
+    ) -> Result<[u8; SECP_PUB_LEN]> {
+        self.0.recover_public_key(hash, signature)
     }
 
     // NOT forwarded

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "1.0.0-rc.2", path = "../../fvm", default-features = false }
+fvm = { version = "1.1.0", path = "../../fvm", default-features = false }
 fvm_shared = { version = "0.7.1", path = "../../shared" }
-fvm_ipld_hamt = { version = "0.5.1", path = "../../ipld/hamt"}
-fvm_ipld_amt = { version = "0.4.1", path = "../../ipld/amt"}
+fvm_ipld_hamt = { version = "0.5.1", path = "../../ipld/hamt" }
+fvm_ipld_amt = { version = "0.4.1", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.4.1", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.2.1", path = "../../ipld/encoding" }

--- a/testing/integration/tests/fil-hello-world-actor/Cargo.toml
+++ b/testing/integration/tests/fil-hello-world-actor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fvm_sdk = { version = "1.0.0-rc.2", path = "../../../../sdk" }
+fvm_sdk = { version = "1.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "0.7.1", path = "../../../../shared" }
 
 

--- a/testing/integration/tests/fil-ipld-actor/Cargo.toml
+++ b/testing/integration/tests/fil-ipld-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 fvm_ipld_encoding = { version = "0.2.1", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "1.0.0-rc.2", path = "../../../../sdk" }
+fvm_sdk = { version = "1.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "0.7.1", path = "../../../../shared" }
 
 

--- a/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fvm_sdk = { version = "1.0.0-rc.2", path = "../../../../sdk" }
+fvm_sdk = { version = "1.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "0.7.1", path = "../../../../shared" }
 
 


### PR DESCRIPTION
Adding new syscall to FVM that allows recovery of signer's public key from a message hash and a signature.

Issue: https://github.com/filecoin-project/ref-fvm/issues/617