### PR TITLE
chore: update wasmtime

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -46,7 +46,7 @@ arbitrary = {version = "1.1.0", optional = true, features = ["derive"]}
 pretty_assertions = "1.2.1"
 
 [dependencies.wasmtime]
-version = "0.37.0"
+version = "0.38.0"
 default-features = false
 features = ["cranelift", "pooling-allocator", "parallel-compilation"]
 

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4.14"
 byteorder = "1.4.3"
 futures = "0.3.19"
 async-std = { version = "1.9", features = ["attributes"] }
-wasmtime = { version = "0.37.0", default-features = false }
+wasmtime = { version = "0.38.0", default-features = false }
 base64 = "0.13.0"
 flate2 = { version = "1.0" }
 colored = "2"

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -30,7 +30,7 @@ serde_repr = "0.1"
 thiserror = "1.0.30"
 
 [dependencies.wasmtime]
-version = "0.37.0"
+version = "0.38.0"
 default-features = false
 features = ["cranelift", "parallel-compilation"]
 


### PR DESCRIPTION
Removes the need for https://github.com/filecoin-project/filecoin-ffi/pull/287

Also introduces some nice optimizations, apparently.