### PR TITLE
Remove `target` folder from Cache

### DIFF
--- a/.github/actions/rust-sccache/action.yml
+++ b/.github/actions/rust-sccache/action.yml
@@ -77,7 +77,6 @@ runs:
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-          target/
         key: ${{ steps.cache.outputs.key }}
         restore-keys: |
           ${{ steps.cache.outputs.restore-key }}


### PR DESCRIPTION
Don't cache target folder, interferes with macos builds