### PR TITLE
Update cache action

### DIFF
--- a/.github/actions/rust-sccache/action.yml
+++ b/.github/actions/rust-sccache/action.yml
@@ -70,7 +70,9 @@ runs:
         fi
       shell: bash
     - name: Deploying cache
-      uses: env0/cache@64daede5552c68991cba51f3bc0ac2bc26945a11 # https://github.com/actions/cache/pull/489
+      # https://github.com/actions/cache/pull/489
+      # https://github.com/env0/cache
+      uses: filecoin-project/cache-action@6974ff48851b8d0259af2b7a68fedd3be53ce754 
       with:
         path: |
           ${{ env.SCCACHE_DIR }}


### PR DESCRIPTION
Uses forked version of cache that _should_ fixes macos cache restoring https://github.com/filecoin-project/cache-action/pull/1

fixes #643 
related #645 #644 #642 