### PR TITLE
Trim Ci cache before upload, rollback wasmtime to v0.37

### DIFF
--- a/.github/actions/rust-sccache/action.yml
+++ b/.github/actions/rust-sccache/action.yml
@@ -78,6 +78,9 @@ runs:
           ${{ env.SCCACHE_DIR }}
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
+          ~/.cargo/bin
+          ~/.cargo/.crates.toml
+          ~/.cargo/.crates2.json
           ~/.cargo/git/db/
           target/
         key: ${{ steps.cache.outputs.key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,11 @@ jobs:
       if: ${{ matrix.push }}
       uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
-        command: install cargo-cache
+        command: install
+        args: cargo-cache
     - name: Cleaning Cargo cache
       if: ${{ matrix.push }}
       uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
-        command: cargo cache -e -i
+        command: cache
+        args: -e -i

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,3 +129,9 @@ jobs:
       with:
         command: cache
         args: -e -i
+    - name: Getting sccache size
+      if: ${{ matrix.push }}
+      uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
+      with:
+        command: cache
+        args: sccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,13 @@ jobs:
       with:
         files: ${{ matrix.covname }}
         fail_ci_if_error: true
+    - name: Installing Cargo-Cache
+      if: ${{ matrix.push }}
+      uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
+      with:
+        command: install cargo-cache
+    - name: Cleaning Cargo cache
+      if: ${{ matrix.push }}
+      uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
+      with:
+        command: cargo cache -e -i

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,12 +123,18 @@ jobs:
       with:
         command: install
         args: cargo-cache
-    - name: Cleaning Cargo cache
+    - name: Cleaning Cargo Cache
       if: ${{ matrix.push }}
       uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
         command: cache
-        args: -e -i
+        args: --autoclean  
+    - name: Getting Cargo Cache Size
+      if: ${{ matrix.push }}
+      uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
+      with:
+        command: cache
+        args: -i
     - name: Getting sccache size
       if: ${{ matrix.push }}
       uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -46,7 +46,7 @@ arbitrary = {version = "1.1.0", optional = true, features = ["derive"]}
 pretty_assertions = "1.2.1"
 
 [dependencies.wasmtime]
-version = "0.38.0"
+version = "0.37.0"
 default-features = false
 features = ["cranelift", "pooling-allocator", "parallel-compilation"]
 

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4.14"
 byteorder = "1.4.3"
 futures = "0.3.19"
 async-std = { version = "1.9", features = ["attributes"] }
-wasmtime = { version = "0.38.0", default-features = false }
+wasmtime = { version = "0.37.0", default-features = false }
 base64 = "0.13.0"
 flate2 = { version = "1.0" }
 colored = "2"

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -30,7 +30,7 @@ serde_repr = "0.1"
 thiserror = "1.0.30"
 
 [dependencies.wasmtime]
-version = "0.38.0"
+version = "0.37.0"
 default-features = false
 features = ["cranelift", "parallel-compilation"]
 


### PR DESCRIPTION
Wasmtime v0.38 introduced a regression, causing integration test `native_overflow_somethingsomething` to run for waay to long.

Rolling back the dep brought back some CI issues I saw earlier where the cache would keep growing after each build, so now it is trimmed before upload (as well as printing out sccache and cargo cache size)