### PR TITLE
chore: remove go interop feature from AMT

### DIFF
--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -12,14 +12,10 @@ cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] 
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 once_cell = "1.5"
-ahash = { version = "0.7", optional = true }
 itertools = "0.10"
 anyhow = "1.0.51"
 fvm_ipld_blockstore = { version = "0.1", path = "../blockstore" }
 fvm_ipld_encoding = { version = "0.2", path = "../encoding" }
-
-[features]
-go-interop = ["ahash"]
 
 [dev-dependencies]
 criterion = "0.3.1"

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -333,60 +333,17 @@ where
     /// each value, for as long as that function keeps returning `true`.
     pub fn for_each_while_mut<F>(&mut self, mut f: F) -> Result<(), Error>
     where
-        // TODO remove clone bound when go-interop doesn't require it.
-        // (If needed without, this bound can be removed by duplicating function signatures)
-        V: Clone,
         F: FnMut(u64, &mut ValueMut<'_, V>) -> anyhow::Result<bool>,
     {
-        #[cfg(not(feature = "go-interop"))]
-        {
-            self.root
-                .node
-                .for_each_while_mut(
-                    &self.block_store,
-                    self.height(),
-                    self.bit_width(),
-                    0,
-                    &mut f,
-                )
-                .map(|_| ())
-        }
-
-        // TODO remove requirement for this when/if changed in go-implementation
-        // This is not 100% compatible, because the blockstore reads/writes are not in the same
-        // order. If this is to be achieved, the for_each iteration would have to pause when
-        // a mutation occurs, set, then continue where it left off. This is a much more extensive
-        // change, and since it should not be feasibly triggered, it's left as this for now.
-        #[cfg(feature = "go-interop")]
-        {
-            let mut mutated = ahash::AHashMap::new();
-
-            self.root.node.for_each_while_mut(
+        self.root
+            .node
+            .for_each_while_mut(
                 &self.block_store,
                 self.height(),
                 self.bit_width(),
                 0,
-                &mut |idx, value| {
-                    let keep_going = f(idx, value)?;
-
-                    if value.value_changed() {
-                        // ! this is not ideal to clone and mark unchanged here, it is only done
-                        // because the go-implementation mutates the Amt as they iterate through it,
-                        // which we cannot do because it is memory unsafe (and I'm not certain we
-                        // don't have side effects from doing this unsafely)
-                        value.mark_unchanged();
-                        mutated.insert(idx, value.clone());
-                    }
-
-                    Ok(keep_going)
-                },
-            )?;
-
-            for (i, v) in mutated.into_iter() {
-                self.set(i, v)?;
-            }
-
-            Ok(())
-        }
+                &mut f,
+            )
+            .map(|_| ())
     }
 }

--- a/ipld/amt/src/value_mut.rs
+++ b/ipld/amt/src/value_mut.rs
@@ -21,13 +21,6 @@ impl<'a, V> ValueMut<'a, V> {
     pub fn value_changed(&self) -> bool {
         self.value_mutated
     }
-
-    /// Marks guard as unchanged. This should only be used when the value was updated but it is
-    /// intended to remove it. Otherwise, this function would give unexpected behaviour on flush.
-    #[cfg(feature = "go-interop")]
-    pub fn mark_unchanged(&mut self) {
-        self.value_mutated = false;
-    }
 }
 
 impl<V> Deref for ValueMut<'_, V> {


### PR DESCRIPTION
I'm not entirely sure why we needed it in the first place, but it looked related to gas usage. At this point, we can make a breaking change and simplify the code.

This will get bundled into the next actors release.