### PR TITLE
Expose serde from fvm_ipld_encoding

### DIFF
--- a/ipld/encoding/CHANGELOG.md
+++ b/ipld/encoding/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to the FVM's shared encoding utilities.
 
 ## [Unreleased]
 
+Publicly use `serde` to expose it when developing actors.
+
 ## 0.2.2 [2022-06-13]
 
 Change the hash length assert into an actual check, just in case.

--- a/ipld/encoding/src/lib.rs
+++ b/ipld/encoding/src/lib.rs
@@ -8,7 +8,7 @@ mod errors;
 mod vec;
 use std::io;
 
-pub use serde::{de, ser};
+pub use serde::{self, de, ser};
 pub use serde_bytes;
 
 pub use self::bytes::*;


### PR DESCRIPTION
When developing an actor, using `Deserialize_tuple` and `Serialize_tuple` from the `fvm_iplf_encoding` crate it would be useful to also have the `serde crate exported. It would also help with consistency of `serde` versioning between actors and the crate in the future. 

Discussed with @raulk during check-in for FVM EBP on Thursday 07/14