### PR TITLE
add thread random generation of machine IDs 

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -41,6 +41,7 @@ blake2b_simd = "1.0.0"
 fvm-wasm-instrument = { version = "0.2.0", features = ["bulk"] }
 yastl = "0.1.2"
 arbitrary = {version = "1.1.0", optional = true, features = ["derive"]}
+rand = "0.8.5"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -137,11 +137,8 @@ where
             engine.preload(state_tree.store(), &installed_actors)?;
         }
 
-        let randomness = externs.get_chain_randomness(
-            0,
-            context.epoch,
-            context.initial_state_root.to_bytes().as_slice(),
-        )?;
+        // 16 bytes is random _enough_
+        let randomness: [u8; 16] = rand::random();
 
         Ok(DefaultMachine {
             context: context.clone(),
@@ -152,7 +149,7 @@ where
             id: format!(
                 "{}-{}",
                 context.epoch,
-                cid::multibase::encode(cid::multibase::Base::Base32Lower, &randomness[..16])
+                cid::multibase::encode(cid::multibase::Base::Base32Lower, &randomness)
             ),
         })
     }


### PR DESCRIPTION
Getting chain randomness of current epoch is not allowed. Adds `rand` dep for now till better solutions are made.