### PR TITLE
feat: add gas charges to the execution trace

### DIFF
--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -234,7 +234,7 @@ where
         msg: &Message,
         apply_kind: ApplyKind,
         raw_length: usize,
-    ) -> Result<StdResult<(ActorID, TokenAmount, GasCharge<'static>), ApplyRet>> {
+    ) -> Result<StdResult<(ActorID, TokenAmount, GasCharge), ApplyRet>> {
         msg.check().or_fatal()?;
 
         // TODO We don't like having price lists _inside_ the FVM, but passing

--- a/fvm/src/gas/charge.rs
+++ b/fvm/src/gas/charge.rs
@@ -1,20 +1,24 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::borrow::Cow;
+
 use super::Gas;
 
 /// Single gas charge in the VM. Contains information about what gas was for, as well
 /// as the amount of gas needed for computation and storage respectively.
-pub struct GasCharge<'a> {
-    pub name: &'a str,
+#[derive(Clone, Debug)]
+pub struct GasCharge {
+    pub name: Cow<'static, str>,
     /// Compute costs
     pub compute_gas: Gas,
     /// Storage costs
     pub storage_gas: Gas,
 }
 
-impl<'a> GasCharge<'a> {
-    pub fn new(name: &'a str, compute_gas: Gas, storage_gas: Gas) -> Self {
+impl GasCharge {
+    pub fn new(name: impl Into<Cow<'static, str>>, compute_gas: Gas, storage_gas: Gas) -> Self {
+        let name = name.into();
         Self {
             name,
             compute_gas,

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -420,7 +420,7 @@ pub struct WasmGasPrices {
 impl PriceList {
     /// Returns the gas required for storing a message of a given size in the chain.
     #[inline]
-    pub fn on_chain_message(&self, msg_size: usize) -> GasCharge<'static> {
+    pub fn on_chain_message(&self, msg_size: usize) -> GasCharge {
         GasCharge::new(
             "OnChainMessage",
             self.on_chain_message_compute_base,
@@ -432,7 +432,7 @@ impl PriceList {
 
     /// Returns the gas required for storing the response of a message in the chain.
     #[inline]
-    pub fn on_chain_return_value(&self, data_size: usize) -> GasCharge<'static> {
+    pub fn on_chain_return_value(&self, data_size: usize) -> GasCharge {
         GasCharge::new(
             "OnChainReturnValue",
             Zero::zero(),
@@ -442,11 +442,7 @@ impl PriceList {
 
     /// Returns the gas required when invoking a method.
     #[inline]
-    pub fn on_method_invocation(
-        &self,
-        value: &TokenAmount,
-        method_num: MethodNum,
-    ) -> GasCharge<'static> {
+    pub fn on_method_invocation(&self, value: &TokenAmount, method_num: MethodNum) -> GasCharge {
         let mut ret = self.send_base;
         if value != &TokenAmount::zero() {
             ret += self.send_transfer_funds;
@@ -461,13 +457,13 @@ impl PriceList {
     }
 
     /// Returns the gas cost to be applied on a syscall.
-    pub fn on_syscall(&self) -> GasCharge<'static> {
+    pub fn on_syscall(&self) -> GasCharge {
         GasCharge::new("OnSyscall", self.syscall_cost, Zero::zero())
     }
 
     /// Returns the gas required for creating an actor.
     #[inline]
-    pub fn on_create_actor(&self) -> GasCharge<'static> {
+    pub fn on_create_actor(&self) -> GasCharge {
         GasCharge::new(
             "OnCreateActor",
             self.create_actor_compute,
@@ -477,7 +473,7 @@ impl PriceList {
 
     /// Returns the gas required for deleting an actor.
     #[inline]
-    pub fn on_delete_actor(&self) -> GasCharge<'static> {
+    pub fn on_delete_actor(&self) -> GasCharge {
         GasCharge::new(
             "OnDeleteActor",
             Zero::zero(),
@@ -487,7 +483,7 @@ impl PriceList {
 
     /// Returns gas required for signature verification.
     #[inline]
-    pub fn on_verify_signature(&self, sig_type: SignatureType) -> GasCharge<'static> {
+    pub fn on_verify_signature(&self, sig_type: SignatureType) -> GasCharge {
         let val = match sig_type {
             SignatureType::BLS => self.bls_sig_cost,
             SignatureType::Secp256k1 => self.secp256k1_sig_cost,
@@ -497,7 +493,7 @@ impl PriceList {
 
     /// Returns gas required for hashing data.
     #[inline]
-    pub fn on_hashing(&self, _: usize) -> GasCharge<'static> {
+    pub fn on_hashing(&self, _: usize) -> GasCharge {
         GasCharge::new("OnHashing", self.hashing_base, Zero::zero())
     }
 
@@ -507,7 +503,7 @@ impl PriceList {
         &self,
         _proof: RegisteredSealProof,
         _pieces: &[PieceInfo],
-    ) -> GasCharge<'static> {
+    ) -> GasCharge {
         GasCharge::new(
             "OnComputeUnsealedSectorCid",
             self.compute_unsealed_sector_cid_base,
@@ -517,14 +513,14 @@ impl PriceList {
 
     /// Returns gas required for seal verification.
     #[inline]
-    pub fn on_verify_seal(&self, _info: &SealVerifyInfo) -> GasCharge<'static> {
+    pub fn on_verify_seal(&self, _info: &SealVerifyInfo) -> GasCharge {
         GasCharge::new("OnVerifySeal", self.verify_seal_base, Zero::zero())
     }
     #[inline]
     pub fn on_verify_aggregate_seals(
         &self,
         aggregate: &AggregateSealVerifyProofAndInfos,
-    ) -> GasCharge<'static> {
+    ) -> GasCharge {
         let proof_type = aggregate.seal_proof;
         let per_proof = *self
             .verify_aggregate_seal_per
@@ -558,7 +554,7 @@ impl PriceList {
 
     /// Returns gas required for replica verification.
     #[inline]
-    pub fn on_verify_replica_update(&self, _replica: &ReplicaUpdateInfo) -> GasCharge<'static> {
+    pub fn on_verify_replica_update(&self, _replica: &ReplicaUpdateInfo) -> GasCharge {
         GasCharge::new(
             "OnVerifyReplicaUpdate",
             self.verify_replica_update,
@@ -568,7 +564,7 @@ impl PriceList {
 
     /// Returns gas required for PoSt verification.
     #[inline]
-    pub fn on_verify_post(&self, info: &WindowPoStVerifyInfo) -> GasCharge<'static> {
+    pub fn on_verify_post(&self, info: &WindowPoStVerifyInfo) -> GasCharge {
         let p_proof = info
             .proofs
             .first()
@@ -587,7 +583,7 @@ impl PriceList {
 
     /// Returns gas required for verifying consensus fault.
     #[inline]
-    pub fn on_verify_consensus_fault(&self) -> GasCharge<'static> {
+    pub fn on_verify_consensus_fault(&self) -> GasCharge {
         GasCharge::new(
             "OnVerifyConsensusFault",
             self.extern_cost + self.verify_consensus_fault,
@@ -598,7 +594,7 @@ impl PriceList {
     /// Returns the cost of the gas required for getting randomness from the client, based on the
     /// numebr of bytes of entropy.
     #[inline]
-    pub fn on_get_randomness(&self, entropy_size: usize) -> GasCharge<'static> {
+    pub fn on_get_randomness(&self, entropy_size: usize) -> GasCharge {
         GasCharge::new(
             "OnGetRandomness",
             self.extern_cost
@@ -610,7 +606,7 @@ impl PriceList {
 
     /// Returns the base gas required for loading an object, independent of the object's size.
     #[inline]
-    pub fn on_block_open_base(&self) -> GasCharge<'static> {
+    pub fn on_block_open_base(&self) -> GasCharge {
         GasCharge::new(
             "OnBlockOpenBase",
             self.extern_cost + self.block_open_base,
@@ -620,7 +616,7 @@ impl PriceList {
 
     /// Returns the gas required for loading an object based on the size of the object.
     #[inline]
-    pub fn on_block_open_per_byte(&self, data_size: usize) -> GasCharge<'static> {
+    pub fn on_block_open_per_byte(&self, data_size: usize) -> GasCharge {
         let size = data_size as i64;
         GasCharge::new(
             "OnBlockOpenPerByte",
@@ -632,7 +628,7 @@ impl PriceList {
 
     /// Returns the gas required for reading a loaded object.
     #[inline]
-    pub fn on_block_read(&self, data_size: usize) -> GasCharge<'static> {
+    pub fn on_block_read(&self, data_size: usize) -> GasCharge {
         GasCharge::new(
             "OnBlockRead",
             self.block_read_base + (self.block_memcpy_per_byte_cost * data_size as i64),
@@ -642,7 +638,7 @@ impl PriceList {
 
     /// Returns the gas required for adding an object to the FVM cache.
     #[inline]
-    pub fn on_block_create(&self, data_size: usize) -> GasCharge<'static> {
+    pub fn on_block_create(&self, data_size: usize) -> GasCharge {
         let size = data_size as i64;
         let mem_costs = (self.block_create_memret_per_byte_cost * size)
             + (self.block_memcpy_per_byte_cost * size);
@@ -655,7 +651,7 @@ impl PriceList {
 
     /// Returns the gas required for committing an object to the state blockstore.
     #[inline]
-    pub fn on_block_link(&self, data_size: usize) -> GasCharge<'static> {
+    pub fn on_block_link(&self, data_size: usize) -> GasCharge {
         let size = data_size as i64;
         let memcpy = self.block_memcpy_per_byte_cost * size;
         GasCharge::new(
@@ -671,7 +667,7 @@ impl PriceList {
 
     /// Returns the gas required for storing an object.
     #[inline]
-    pub fn on_block_stat(&self) -> GasCharge<'static> {
+    pub fn on_block_stat(&self) -> GasCharge {
         GasCharge::new("OnBlockStat", self.block_stat_base, Zero::zero())
     }
 }

--- a/fvm/src/syscalls/bind.rs
+++ b/fvm/src/syscalls/bind.rs
@@ -96,7 +96,7 @@ macro_rules! charge_syscall_gas {
     ($kernel:expr) => {
         let charge = $kernel.price_list().on_syscall();
         $kernel
-            .charge_gas(charge.name, charge.compute_gas)
+            .charge_gas(&charge.name, charge.compute_gas)
             .map_err(Abort::from_error_as_fatal)?;
     };
 }

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -4,13 +4,19 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::{ActorID, MethodNum};
 
+use crate::gas::GasCharge;
 use crate::kernel::SyscallError;
 
 /// Execution Trace, only for informational and debugging purposes.
 pub type ExecutionTrace = Vec<ExecutionEvent>;
 
+/// An "event" that happened during execution.
+///
+/// This is marked as `non_exhaustive` so we can introduce additional event types later.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum ExecutionEvent {
+    GasCharge(GasCharge),
     Call {
         from: ActorID,
         to: Address,

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -429,14 +429,14 @@ where
     // NOT forwarded
     fn verify_seal(&mut self, vi: &SealVerifyInfo) -> Result<bool> {
         let charge = self.1.price_list.on_verify_seal(vi);
-        self.0.charge_gas(charge.name, charge.total())?;
+        self.0.charge_gas(&charge.name, charge.total())?;
         Ok(true)
     }
 
     // NOT forwarded
     fn verify_post(&mut self, vi: &WindowPoStVerifyInfo) -> Result<bool> {
         let charge = self.1.price_list.on_verify_post(vi);
-        self.0.charge_gas(charge.name, charge.total())?;
+        self.0.charge_gas(&charge.name, charge.total())?;
         Ok(true)
     }
 
@@ -448,21 +448,21 @@ where
         _extra: &[u8],
     ) -> Result<Option<ConsensusFault>> {
         let charge = self.1.price_list.on_verify_consensus_fault();
-        self.0.charge_gas(charge.name, charge.total())?;
+        self.0.charge_gas(&charge.name, charge.total())?;
         Ok(None)
     }
 
     // NOT forwarded
     fn verify_aggregate_seals(&mut self, agg: &AggregateSealVerifyProofAndInfos) -> Result<bool> {
         let charge = self.1.price_list.on_verify_aggregate_seals(agg);
-        self.0.charge_gas(charge.name, charge.total())?;
+        self.0.charge_gas(&charge.name, charge.total())?;
         Ok(true)
     }
 
     // NOT forwarded
     fn verify_replica_update(&mut self, rep: &ReplicaUpdateInfo) -> Result<bool> {
         let charge = self.1.price_list.on_verify_replica_update(rep);
-        self.0.charge_gas(charge.name, charge.total())?;
+        self.0.charge_gas(&charge.name, charge.total())?;
         Ok(true)
     }
 }


### PR DESCRIPTION
BREAKING:

- This adds a new execution event type.
- The GasCharge object is now `'static`, but internally uses a `Cow` for the name.