### PR TITLE
Move the builtin Type enum out of the SDK

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -12,36 +12,38 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["lib"]
 
 [dependencies]
-anyhow = "1.0.47"
-thiserror = "1.0.30"
-num-traits = "0.2"
-derive_builder = "0.11.2"
-num-derive = "0.3.3"
-cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] }
-multihash = { version = "0.16.1", default-features = false }
 fvm_shared = { version = "0.9.0", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.5.1", path = "../ipld/hamt"}
 fvm_ipld_amt = { version = "0.4.2", path = "../ipld/amt"}
 fvm_ipld_blockstore = { version = "0.1.1", path = "../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.2.2", path = "../ipld/encoding" }
-serde = { version = "1.0", features = ["derive"] }
-serde_tuple = "0.5"
-serde_repr = "0.1"
-lazy_static = "1.4.0"
-derive-getters = "0.2.0"
-derive_more = "0.99.17"
-replace_with = "0.1.7"
-filecoin-proofs-api = { version = "12", default-features = false }
-rayon = "1"
-num_cpus = "1.13.0"
-log = "0.4.14"
-byteorder = "1.4.3"
+
+anyhow = "1.0.47"
 anymap = "0.12.1"
-blake2b_simd = "1.0.0"
-fvm-wasm-instrument = { version = "0.2.0", features = ["bulk"] }
-yastl = "0.1.2"
 arbitrary = {version = "1.1.0", optional = true, features = ["derive"]}
+bimap = { version = "0.6.2", features = ["serde"] }
+blake2b_simd = "1.0.0"
+byteorder = "1.4.3"
+cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] }
+derive-getters = "0.2.0"
+derive_builder = "0.11.2"
+derive_more = "0.99.17"
+filecoin-proofs-api = { version = "12", default-features = false }
+fvm-wasm-instrument = { version = "0.2.0", features = ["bulk"] }
+lazy_static = "1.4.0"
+log = "0.4.14"
+multihash = { version = "0.16.1", default-features = false }
+num-derive = "0.3.3"
+num-traits = "0.2"
+num_cpus = "1.13.0"
 rand = "0.8.5"
+rayon = "1"
+replace_with = "0.1.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_repr = "0.1"
+serde_tuple = "0.5"
+thiserror = "1.0.30"
+yastl = "0.1.2"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/fvm/src/builtins.rs
+++ b/fvm/src/builtins.rs
@@ -10,6 +10,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Identifies the builtin actor types for usage with the
 /// actor::resolve_builtin_actor_type syscall.
+/// This is a copy of the Type enum in the built-in actors repo, and must be kept
+/// in sync for type-related syscalls to work correctly.
 #[derive(
     PartialEq,
     Eq,
@@ -56,15 +58,7 @@ impl Type {
     pub fn is_account_actor(&self) -> bool {
         self == &Type::Account
     }
-
-    /// Tests whether an actor type represents an actor that can be an external
-    /// principal: i.e. an account or multisig.
-    pub fn is_principal(&self) -> bool {
-        self == &Type::Account || self == &Type::Multisig
-    }
 }
-
-pub const CALLER_TYPES_SIGNABLE: &[Type] = &[Type::Account, Type::Multisig];
 
 impl TryFrom<&str> for Type {
     type Error = String;

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Context};
 use derive_more::{Deref, DerefMut};
 use fvm_ipld_encoding::{to_vec, RawBytes, DAG_CBOR};
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::{Address, Protocol};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
@@ -10,6 +9,7 @@ use fvm_shared::{ActorID, MethodNum, METHOD_SEND};
 use num_traits::Zero;
 
 use super::{Backtrace, CallManager, InvocationResult, NO_DATA_BLOCK_ID};
+use crate::builtins::Type;
 use crate::call_manager::backtrace::Frame;
 use crate::call_manager::FinishRet;
 use crate::gas::{Gas, GasTracker};

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -4,7 +4,6 @@ use std::result::Result as StdResult;
 use anyhow::{anyhow, Result};
 use cid::Cid;
 use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::{BigInt, Sign};
 use fvm_shared::econ::TokenAmount;
@@ -15,6 +14,7 @@ use fvm_shared::ActorID;
 use num_traits::Zero;
 
 use super::{ApplyFailure, ApplyKind, ApplyRet, Executor};
+use crate::builtins::Type;
 use crate::call_manager::{backtrace, CallManager, InvocationResult};
 use crate::gas::{Gas, GasCharge, GasOutputs};
 use crate::kernel::{Block, ClassifyResult, Context as _, ExecutionError, Kernel};

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -9,7 +9,6 @@ use cid::Cid;
 use filecoin_proofs_api::{self as proofs, ProverId, PublicReplicaInfo, SectorId};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{bytes_32, from_slice, to_vec};
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Protocol;
 use fvm_shared::bigint::{BigInt, Zero};
 use fvm_shared::consensus::ConsensusFault;
@@ -26,6 +25,7 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIter
 use super::blocks::{Block, BlockRegistry};
 use super::error::Result;
 use super::*;
+use crate::builtins::Type;
 use crate::call_manager::{CallManager, InvocationResult, NO_DATA_BLOCK_ID};
 use crate::externs::{Consensus, Rand};
 use crate::gas::GasCharge;
@@ -780,7 +780,7 @@ where
         )
     }
 
-    fn get_builtin_actor_type(&self, code_cid: &Cid) -> Option<actor::builtin::Type> {
+    fn get_builtin_actor_type(&self, code_cid: &Cid) -> Option<Type> {
         self.call_manager
             .machine()
             .builtin_actors()
@@ -788,7 +788,7 @@ where
             .cloned()
     }
 
-    fn get_code_cid_for_type(&self, typ: actor::builtin::Type) -> Result<Cid> {
+    fn get_code_cid_for_type(&self, typ: Type) -> Result<Cid> {
         self.call_manager
             .machine()
             .builtin_actors()

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -15,7 +15,7 @@ use fvm_shared::sector::{
     WindowPoStVerifyInfo,
 };
 use fvm_shared::version::NetworkVersion;
-use fvm_shared::{actor, ActorID, MethodNum};
+use fvm_shared::{ActorID, MethodNum};
 
 mod blocks;
 pub mod default;
@@ -186,10 +186,10 @@ pub trait ActorOps {
     fn install_actor(&mut self, code_cid: Cid) -> Result<()>;
 
     /// Returns whether the supplied code_cid belongs to a known built-in actor type.
-    fn get_builtin_actor_type(&self, code_cid: &Cid) -> Option<actor::builtin::Type>;
+    fn get_builtin_actor_type(&self, code_cid: &Cid) -> Option<crate::builtins::Type>;
 
     /// Returns the CodeCID for the supplied built-in actor type.
-    fn get_code_cid_for_type(&self, typ: actor::builtin::Type) -> Result<Cid>;
+    fn get_code_cid_for_type(&self, typ: crate::builtins::Type) -> Result<Cid>;
 }
 
 /// Operations to send messages to other actors.

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -35,6 +35,7 @@ pub mod init_actor;
 #[cfg(feature = "testing")]
 pub mod system_actor;
 
+pub mod builtins;
 pub mod trace;
 
 use cid::multihash::{Code, MultihashDigest};
@@ -53,10 +54,10 @@ lazy_static::lazy_static! {
 mod test {
     use fvm_ipld_blockstore::MemoryBlockstore;
     use fvm_ipld_encoding::CborStore;
-    use fvm_shared::actor::builtin::Manifest;
     use fvm_shared::state::StateTreeVersion;
     use multihash::Code;
 
+    use crate::builtins::Manifest;
     use crate::call_manager::DefaultCallManager;
     use crate::externs::{Consensus, Externs, Rand};
     use crate::machine::{DefaultMachine, Engine, NetworkConfig};

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -1,10 +1,10 @@
 use cid::Cid;
-use fvm_shared::actor::builtin::Manifest;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::ActorID;
 
 use super::{Engine, Machine, MachineContext};
+use crate::builtins::Manifest;
 use crate::kernel::Result;
 use crate::state_tree::{ActorState, StateTree};
 

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -4,7 +4,6 @@ use anyhow::{anyhow, Context as _};
 use cid::Cid;
 use fvm_ipld_blockstore::{Blockstore, Buffered};
 use fvm_ipld_encoding::CborStore;
-use fvm_shared::actor::builtin::{load_manifest, Manifest};
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
@@ -15,6 +14,7 @@ use num_traits::Signed;
 
 use super::{Engine, Machine, MachineContext};
 use crate::blockstore::BufferedBlockstore;
+use crate::builtins::{load_manifest, Manifest};
 use crate::externs::Externs;
 #[cfg(feature = "m2-native")]
 use crate::init_actor::State as InitActorState;

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -1,7 +1,6 @@
 use cid::Cid;
 use derive_more::{Deref, DerefMut};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_shared::actor::builtin::Manifest;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
@@ -9,6 +8,7 @@ use fvm_shared::version::NetworkVersion;
 use fvm_shared::ActorID;
 use num_traits::Zero;
 
+use crate::builtins::Manifest;
 use crate::externs::Externs;
 use crate::gas::{price_list_by_network_version, PriceList};
 use crate::kernel::Result;

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -1,8 +1,8 @@
 use anyhow::anyhow;
-use fvm_shared::actor::builtin::Type;
 use num_traits::FromPrimitive;
 
 use super::Context;
+use crate::builtins::Type;
 use crate::kernel::{ClassifyResult, Result};
 use crate::{syscall_error, Kernel};
 

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -3,6 +3,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use anyhow::Context;
+use fvm::builtins::Manifest;
 use fvm::call_manager::{Backtrace, CallManager, FinishRet, InvocationResult};
 use fvm::externs::{Consensus, Externs, Rand};
 use fvm::gas::{Gas, GasCharge, GasTracker};
@@ -11,7 +12,6 @@ use fvm::state_tree::{ActorState, StateTree};
 use fvm::{kernel, Kernel};
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::CborStore;
-use fvm_shared::actor::builtin::Manifest;
 use fvm_shared::address::Address;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;

--- a/sdk/src/actor.rs
+++ b/sdk/src/actor.rs
@@ -1,11 +1,9 @@
 use core::option::Option; // no_std
 
 use cid::Cid;
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::{Address, Payload};
 use fvm_shared::error::ErrorNumber;
-use fvm_shared::{actor, ActorID, MAX_CID_LEN};
-use num_traits::FromPrimitive;
+use fvm_shared::{ActorID, MAX_CID_LEN};
 
 use crate::{sys, SyscallResult, MAX_ACTOR_ADDR_LEN};
 
@@ -72,25 +70,18 @@ pub fn install_actor(code_cid: &Cid) -> SyscallResult<()> {
 
 /// Determines whether the supplied CodeCID belongs to a built-in actor type,
 /// and to which.
-pub fn get_builtin_actor_type(code_cid: &Cid) -> Option<actor::builtin::Type> {
+pub fn get_builtin_actor_type(code_cid: &Cid) -> Option<i32> {
     let cid = code_cid.to_bytes();
-    unsafe {
-        let res = sys::actor::get_builtin_actor_type(cid.as_ptr())
-            .expect("failed to determine if CID belongs to builtin actor");
-        // The zero value represents "unknown" and is not modelled in the enum,
-        // so it'll be converted to a None.
-        FromPrimitive::from_i32(res)
-    }
+    unsafe { sys::actor::get_builtin_actor_type(cid.as_ptr()).ok() }
 }
 
 /// Returns the CodeCID for a built-in actor type. Aborts with IllegalArgument
 /// if the supplied type is invalid.
-pub fn get_code_cid_for_type(typ: Type) -> Cid {
+pub fn get_code_cid_for_type(typ: i32) -> Cid {
     let mut buf = [0u8; MAX_CID_LEN];
     unsafe {
-        let len =
-            sys::actor::get_code_cid_for_type(typ as i32, buf.as_mut_ptr(), MAX_CID_LEN as u32)
-                .expect("failed to get CodeCID for type");
+        let len = sys::actor::get_code_cid_for_type(typ, buf.as_mut_ptr(), MAX_CID_LEN as u32)
+            .expect("failed to get CodeCID for type");
         Cid::read_bytes(&buf[..len as usize]).expect("invalid cid returned")
     }
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -8,28 +8,28 @@ authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin C
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
+fvm_ipld_blockstore = { version = "0.1", path = "../ipld/blockstore" }
+fvm_ipld_encoding = { version = "0.2", path = "../ipld/encoding" }
+
+anyhow = "1.0.51"
+arbitrary = { version = "1.1", optional = true, features = ["derive"]}
 blake2b_simd = "1.0.0"
-thiserror = "1.0"
-num-traits = "0.2"
-num-derive = "0.3"
-num-bigint = "0.4"
-num-integer = "0.1"
+cid = { version = "0.8.5", default-features = false, features = ["serde-codec", "std"] }
 data-encoding = "2.3.2"
 data-encoding-macro = "0.1.12"
 lazy_static = "1.4.0"
 log = "0.4.8"
-cid = { version = "0.8.5", default-features = false, features = ["serde-codec", "std"] }
 multihash = { version = "0.16.1", default-features = false, features = ["blake2b", "multihash-impl"] }
-unsigned-varint = "0.7.1"
-anyhow = "1.0.51"
-bimap = { version = "0.6.2", features = ["serde"] }
-fvm_ipld_blockstore = { version = "0.1", path = "../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.2", path = "../ipld/encoding" }
+num-bigint = "0.4"
+num-derive = "0.3"
+num-integer = "0.1"
+num-traits = "0.2"
 serde = { version = "1", default-features = false }
-serde_tuple = "0.5"
-serde_repr = "0.1"
 serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
-arbitrary = { version = "1.1", optional = true, features = ["derive"]}
+serde_repr = "0.1"
+serde_tuple = "0.5"
+thiserror = "1.0"
+unsigned-varint = "0.7.1"
 
 ## non-wasm dependencies; these dependencies and the respective code is
 ## only activated through non-default features, which the Kernel enables, but

--- a/shared/src/actor/mod.rs
+++ b/shared/src/actor/mod.rs
@@ -1,1 +1,0 @@
-pub mod builtin;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -8,7 +8,6 @@ use address::Address;
 use clock::ChainEpoch;
 use num_bigint::BigInt;
 
-pub mod actor;
 pub mod address;
 pub mod bigint;
 pub mod clock;

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -3,6 +3,7 @@ use std::convert::TryFrom;
 
 use cid::Cid;
 use futures::executor::block_on;
+use fvm::builtins::Manifest;
 use fvm::call_manager::{CallManager, DefaultCallManager, FinishRet, InvocationResult};
 use fvm::gas::{Gas, GasTracker, PriceList};
 use fvm::kernel::*;
@@ -11,7 +12,6 @@ use fvm::state_tree::{ActorState, StateTree};
 use fvm::DefaultKernel;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_car::load_car_unchecked;
-use fvm_shared::actor::builtin::Manifest;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
@@ -27,7 +27,7 @@ use fvm_shared::sector::{
     WindowPoStVerifyInfo,
 };
 use fvm_shared::version::NetworkVersion;
-use fvm_shared::{actor, ActorID, MethodNum, TOTAL_FILECOIN};
+use fvm_shared::{ActorID, MethodNum, TOTAL_FILECOIN};
 
 use crate::externs::TestExterns;
 use crate::vector::{MessageVector, Variant};
@@ -351,11 +351,11 @@ where
         self.0.create_actor(code_id, actor_id)
     }
 
-    fn get_builtin_actor_type(&self, code_cid: &Cid) -> Option<actor::builtin::Type> {
+    fn get_builtin_actor_type(&self, code_cid: &Cid) -> Option<fvm::builtins::Type> {
         self.0.get_builtin_actor_type(code_cid)
     }
 
-    fn get_code_cid_for_type(&self, typ: actor::builtin::Type) -> Result<Cid> {
+    fn get_code_cid_for_type(&self, typ: fvm::builtins::Type) -> Result<Cid> {
         self.0.get_code_cid_for_type(typ)
     }
 

--- a/testing/integration/src/builtin.rs
+++ b/testing/integration/src/builtin.rs
@@ -3,12 +3,12 @@ use std::collections::BTreeMap;
 use anyhow::{Context, Result};
 use cid::Cid;
 use futures::executor::block_on;
+use fvm::builtins::{load_manifest, Type};
 use fvm::state_tree::{ActorState, StateTree};
 use fvm::{init_actor, system_actor};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_car::load_car_unchecked;
 use fvm_ipld_encoding::CborStore;
-use fvm_shared::actor::builtin::{load_manifest, Type};
 use fvm_shared::version::NetworkVersion;
 use multihash::Code;
 

--- a/testing/integration/src/error.rs
+++ b/testing/integration/src/error.rs
@@ -1,5 +1,5 @@
 use cid::Cid;
-use fvm_shared::actor::builtin::Type;
+use fvm::builtins::Type;
 use fvm_shared::version::NetworkVersion;
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
The built-in `Type` enum has been copied into the built-in actors repo, so no longer needs to be part of fvm_shared.

- [x] Wait for https://github.com/filecoin-project/builtin-actors/pull/547 to be approved and merged first

Closes #712