### PR TITLE
shared: add EVM built-in actor type.

### DIFF
--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -497,7 +497,7 @@ impl PriceList {
 
     /// Returns gas required for recovering signer pubkey from signature
     #[inline]
-    pub fn on_recover_secp_public_key(&self) -> GasCharge<'static> {
+    pub fn on_recover_secp_public_key(&self) -> GasCharge {
         GasCharge::new(
             "OnRecoverSecpPublicKey",
             self.secp256k1_recover_cost,

--- a/shared/src/actor/builtin.rs
+++ b/shared/src/actor/builtin.rs
@@ -36,6 +36,7 @@ pub enum Type {
     Multisig = 9,
     Reward = 10,
     VerifiedRegistry = 11,
+    EVM = 12, // TODO revisit name
 }
 
 impl Type {
@@ -81,6 +82,7 @@ impl TryFrom<&str> for Type {
             "multisig" => Type::Multisig,
             "reward" => Type::Reward,
             "verifiedregistry" => Type::VerifiedRegistry,
+            "evm" => Type::EVM, // TODO revisit name
             _ => return Err(String::from("unrecognized actor type")),
         };
         Ok(ret)
@@ -101,6 +103,7 @@ impl From<&Type> for String {
             Type::Multisig => "multisig",
             Type::Reward => "reward",
             Type::VerifiedRegistry => "verifiedregistry",
+            Type::EVM => "evm", // TODO revisit name
         }
         .to_string()
     }


### PR DESCRIPTION
Note: there's an active proposal to remove the type token entirely in #712. However, for the reasons outlined in the discussion, we need to retain it for now, unless we find a better indirection for actor typing (or we extinguish the need for it altogether).

This is needed to add the EVM actor (https://github.com/filecoin-project/builtin-actors/pull/517) to the built-in actors bundle.