### PR TITLE
chore: checkout shallow submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "testing/conformance/test-vectors"]
 	path = testing/conformance/test-vectors
 	url = https://github.com/filecoin-project/fvm-test-vectors
+	shallow = 1
 [submodule "testing/fuzz-corpora"]
 	path = testing/fuzz-corpora
 	url = https://github.com/filecoin-project/ref-fvm-fuzz-corpora.git
+	shallow = 1


### PR DESCRIPTION
This will help CI, but won't help anyone else depending on ref-fvm because, unfortunately, cargo will ignore this hint.