### PR TITLE
Move multihash table from shared to fvm and replace with simple enum

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -13,7 +13,6 @@ use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Protocol;
 use fvm_shared::bigint::Zero;
 use fvm_shared::consensus::ConsensusFault;
-use fvm_shared::crypto::hash::SupportedHashes;
 use fvm_shared::crypto::signature;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
@@ -27,6 +26,7 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIter
 
 use super::blocks::{Block, BlockRegistry};
 use super::error::Result;
+use super::hash::SupportedHashes;
 use super::*;
 use crate::call_manager::{CallManager, InvocationResult, NO_DATA_BLOCK_ID};
 use crate::externs::{Consensus, Rand};

--- a/fvm/src/kernel/hash.rs
+++ b/fvm/src/kernel/hash.rs
@@ -1,0 +1,20 @@
+use multihash::derive::Multihash;
+use multihash::{Blake2b256, Blake2b512, Keccak256, Ripemd160, Sha2_256};
+
+#[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
+#[mh(alloc_size = 64)]
+/// Codes and hashers supported by FVM.
+/// You _can_ use this hash directly inside of your actor,
+/// but it will very likely be more performant with the `hash` syscall
+pub enum SupportedHashes {
+    #[mh(code = 0x12, hasher = Sha2_256)]
+    Sha2_256,
+    #[mh(code = 0xb220, hasher = Blake2b256)]
+    Blake2b256,
+    #[mh(code = 0xb240, hasher = Blake2b512)]
+    Blake2b512,
+    #[mh(code = 0x1b, hasher = Keccak256)]
+    Keccak256,
+    #[mh(code = 0x1053, hasher = Ripemd160)]
+    Ripemd160,
+}

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -17,6 +17,8 @@ use fvm_shared::sector::{
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{actor, ActorID, MethodNum};
 
+mod hash;
+
 mod blocks;
 pub mod default;
 

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -72,7 +72,7 @@ pub fn hash(hasher: SupportedHashes, data: &[u8]) -> Vec<u8> {
 
     unsafe {
         let written = sys::crypto::hash(
-            hasher.into(),
+            hasher as u64,
             data.as_ptr(),
             data.len() as u32,
             ret.as_mut_ptr(),

--- a/shared/src/crypto/hash.rs
+++ b/shared/src/crypto/hash.rs
@@ -1,20 +1,9 @@
-use multihash::derive::Multihash;
-use multihash::{Blake2b256, Blake2b512, Keccak256, Ripemd160, Sha2_256};
-
-#[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
-#[mh(alloc_size = 64)]
-/// Codes and hashers supported by FVM.
-/// You _can_ use this hash directly inside of your actor,
-/// but it will very likely be more performant with the `hash` syscall
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u64)]
 pub enum SupportedHashes {
-    #[mh(code = 0x12, hasher = Sha2_256)]
-    Sha2_256,
-    #[mh(code = 0xb220, hasher = Blake2b256)]
-    Blake2b256,
-    #[mh(code = 0xb240, hasher = Blake2b512)]
-    Blake2b512,
-    #[mh(code = 0x1b, hasher = Keccak256)]
-    Keccak256,
-    #[mh(code = 0x1053, hasher = Ripemd160)]
-    Ripemd160,
+    Sha2_256 = 0x12,
+    Blake2b256 = 0xb220,
+    Blake2b512 = 0xb240,
+    Keccak256 = 0x1b,
+    Ripemd160 = 0x1053,
 }


### PR DESCRIPTION
Avoid pulling in hasher implementations into actors

Also adds blake2b512 to integration tests