### PR TITLE
chore: Remove blake2b hashing which was moved to builtin-actors

### DIFF
--- a/ipld/encoding/src/cbor.rs
+++ b/ipld/encoding/src/cbor.rs
@@ -4,7 +4,6 @@
 use std::ops::Deref;
 use std::rc::Rc;
 
-use cid::{multihash, Cid};
 use serde::{Deserialize, Serialize};
 
 use super::errors::Error;
@@ -22,21 +21,6 @@ pub trait Cbor: ser::Serialize + de::DeserializeOwned {
     /// Unmarshals cbor encoded bytes to object
     fn unmarshal_cbor(bz: &[u8]) -> Result<Self, Error> {
         from_slice(bz)
-    }
-
-    /// Returns the content identifier of the raw block of data
-    /// Default is Blake2b256 hash
-    fn cid(&self) -> Result<Cid, Error> {
-        use multihash::MultihashDigest;
-        const DIGEST_SIZE: u32 = 32; // TODO get from the multihash?
-        let data = &self.marshal_cbor()?;
-        let hash = multihash::Code::Blake2b256.digest(data);
-        debug_assert_eq!(
-            u32::from(hash.size()),
-            DIGEST_SIZE,
-            "expected 32byte digest"
-        );
-        Ok(Cid::new_v1(DAG_CBOR, hash))
     }
 }
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -19,7 +19,7 @@ data-encoding-macro = "0.1.12"
 lazy_static = "1.4.0"
 log = "0.4.8"
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec", "std"] }
-multihash = { version = "0.16.3", default-features = false, features = ["blake2b", "multihash-impl", "sha2", "sha3", "ripemd"] }
+multihash = { version = "0.16.3", default-features = false, features = ["multihash-impl", "sha2", "sha3", "ripemd"] }
 unsigned-varint = "0.7.1"
 anyhow = "1.0.51"
 bimap = { version = "0.6.2", features = ["serde"] }
@@ -43,7 +43,7 @@ byteorder = "1.4.3"
 rand = "0.8"
 rand_chacha = "0.3"
 serde_json = "1.0.56"
-multihash = { version = "0.16.3", default-features = false, features = ["blake2b", "multihash-impl", "sha2", "sha3", "ripemd"] }
+multihash = { version = "0.16.3", default-features = false, features = ["multihash-impl", "sha2", "sha3", "ripemd"] }
 
 [features]
 default = []

--- a/shared/src/message.rs
+++ b/shared/src/message.rs
@@ -30,13 +30,6 @@ pub struct Message {
 impl Cbor for Message {}
 
 impl Message {
-    /// Helper function to convert the message into signing bytes.
-    /// This function returns the message `Cid` bytes.
-    pub fn to_signing_bytes(&self) -> Vec<u8> {
-        // Safe to unwrap here, unsigned message cannot fail to serialize.
-        self.cid().unwrap().to_bytes()
-    }
-
     /// Does some basic checks on the Message to see if the fields are valid.
     pub fn check(self: &Message) -> anyhow::Result<()> {
         if self.gas_limit == 0 {


### PR DESCRIPTION
Relates to https://github.com/filecoin-project/builtin-actors/issues/91 and https://github.com/filecoin-project/builtin-actors/pull/577