### PR TITLE
Revert "track both the origin ID and on-chain message address."

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -32,9 +32,8 @@ pub struct InnerDefaultCallManager<M> {
     machine: M,
     /// The gas tracker.
     gas_tracker: GasTracker,
-    /// The ActorID and the address of the original sender of the chain message that initiated
-    /// this call stack. The Address is the address as provided in the chain message.
-    origin: (ActorID, Address),
+    /// The original sender of the chain message that initiated this call stack.
+    origin: ActorID,
     /// The nonce of the chain message that initiated this call stack.
     nonce: u64,
     /// Number of actors created in this call stack.
@@ -71,7 +70,7 @@ where
 {
     type Machine = M;
 
-    fn new(machine: M, gas_limit: i64, origin: (ActorID, Address), nonce: u64) -> Self {
+    fn new(machine: M, gas_limit: i64, origin: ActorID, nonce: u64) -> Self {
         let mut gas_tracker = GasTracker::new(Gas::new(gas_limit), Gas::zero());
         if machine.context().tracing {
             gas_tracker.enable_tracing()
@@ -220,8 +219,8 @@ where
 
     // Other accessor methods
 
-    fn origin(&self) -> (ActorID, &Address) {
-        (self.origin.0, &self.origin.1)
+    fn origin(&self) -> ActorID {
+        self.origin
     }
 
     fn nonce(&self) -> u64 {

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -42,7 +42,7 @@ pub trait CallManager: 'static {
     type Machine: Machine;
 
     /// Construct a new call manager.
-    fn new(machine: Self::Machine, gas_limit: i64, origin: (ActorID, Address), nonce: u64) -> Self;
+    fn new(machine: Self::Machine, gas_limit: i64, origin: ActorID, nonce: u64) -> Self;
 
     /// Send a message. The type parameter `K` specifies the the _kernel_ on top of which the target
     /// actor should execute.
@@ -75,7 +75,7 @@ pub trait CallManager: 'static {
     fn gas_tracker_mut(&mut self) -> &mut GasTracker;
 
     /// Getter for origin actor.
-    fn origin(&self) -> (ActorID, &Address);
+    fn origin(&self) -> ActorID;
 
     /// Getter for message nonce.
     fn nonce(&self) -> u64;

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -66,8 +66,7 @@ where
         // Apply the message.
         let (res, gas_used, mut backtrace, exec_trace) = self.map_machine(|machine| {
             // We're processing a chain message, so the sender is the origin of the call stack.
-            let mut cm =
-                K::CallManager::new(machine, msg.gas_limit, (sender_id, msg.from), msg.sequence);
+            let mut cm = K::CallManager::new(machine, msg.gas_limit, sender_id, msg.sequence);
             // This error is fatal because it should have already been accounted for inside
             // preflight_message.
             if let Err(e) = cm.charge_gas(inclusion_cost) {

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -363,7 +363,7 @@ where
         self.caller
     }
 
-    fn msg_origin(&self) -> (ActorID, &Address) {
+    fn msg_origin(&self) -> ActorID {
         self.call_manager.origin()
     }
 
@@ -729,9 +729,8 @@ where
 
     // TODO(M2) merge new_actor_address and create_actor into a single syscall.
     fn new_actor_address(&mut self) -> Result<Address> {
-        let origin_addr = *self.call_manager.origin().1;
         let oa = self
-            .resolve_to_key_addr(&origin_addr, false)
+            .resolve_to_key_addr(&Address::new_id(self.call_manager.origin()), false)
             // This is already an execution error, but we're _making_ it fatal.
             .or_fatal()?;
 
@@ -844,7 +843,7 @@ where
             let dir: PathBuf = [
                 dir,
                 self.call_manager.machine().machine_id(),
-                &self.call_manager.origin().0.to_string(),
+                &self.call_manager.origin().to_string(),
                 &self.call_manager.nonce().to_string(),
                 &self.actor_id.to_string(),
                 &self.call_manager.invocation_count().to_string(),

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -102,7 +102,7 @@ pub trait MessageOps {
     fn msg_caller(&self) -> ActorID;
 
     /// The origin actor
-    fn msg_origin(&self) -> (ActorID, &Address);
+    fn msg_origin(&self) -> ActorID;
 
     /// The receiving actor (this actor) (constant).
     fn msg_receiver(&self) -> ActorID;

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -53,7 +53,7 @@ pub fn context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<Invoc
 
     Ok(InvocationContext {
         caller: context.kernel.msg_caller(),
-        origin: context.kernel.msg_origin().0,
+        origin: context.kernel.msg_origin(),
         receiver: context.kernel.msg_receiver(),
         method_number: context.kernel.msg_method_number(),
         value_received: context

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -166,7 +166,7 @@ impl Machine for DummyMachine {
 pub struct DummyCallManager {
     pub machine: DummyMachine,
     pub gas_tracker: GasTracker,
-    pub origin: (ActorID, Address),
+    pub origin: ActorID,
     pub nonce: u64,
     pub test_data: Rc<RefCell<TestData>>,
 }
@@ -186,7 +186,7 @@ impl DummyCallManager {
             Self {
                 machine: DummyMachine::new_stub().unwrap(),
                 gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0)),
-                origin: (0, Address::new_actor(&[])),
+                origin: 0,
                 nonce: 0,
                 test_data: rc,
             },
@@ -203,7 +203,7 @@ impl DummyCallManager {
             Self {
                 machine: DummyMachine::new_stub().unwrap(),
                 gas_tracker,
-                origin: (0, Address::new_actor(&[])),
+                origin: 0,
                 nonce: 0,
                 test_data: rc,
             },
@@ -215,12 +215,7 @@ impl DummyCallManager {
 impl CallManager for DummyCallManager {
     type Machine = DummyMachine;
 
-    fn new(
-        machine: Self::Machine,
-        _gas_limit: i64,
-        origin: (ActorID, Address),
-        nonce: u64,
-    ) -> Self {
+    fn new(machine: Self::Machine, _gas_limit: i64, origin: ActorID, nonce: u64) -> Self {
         let rc = Rc::new(RefCell::new(TestData {
             charge_gas_calls: 0,
         }));
@@ -288,8 +283,8 @@ impl CallManager for DummyCallManager {
         self.gas_tracker_mut().apply_charge(charge)
     }
 
-    fn origin(&self) -> (ActorID, &Address) {
-        (self.origin.0, &self.origin.1)
+    fn origin(&self) -> ActorID {
+        self.origin
     }
 
     fn nonce(&self) -> u64 {

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -187,7 +187,7 @@ where
 {
     type Machine = C::Machine;
 
-    fn new(machine: Self::Machine, gas_limit: i64, origin: (ActorID, Address), nonce: u64) -> Self {
+    fn new(machine: Self::Machine, gas_limit: i64, origin: ActorID, nonce: u64) -> Self {
         TestCallManager(C::new(machine, gas_limit, origin, nonce))
     }
 
@@ -241,7 +241,7 @@ where
         self.0.gas_tracker_mut()
     }
 
-    fn origin(&self) -> (ActorID, &Address) {
+    fn origin(&self) -> ActorID {
         self.0.origin()
     }
 
@@ -547,7 +547,7 @@ where
         self.0.msg_caller()
     }
 
-    fn msg_origin(&self) -> (ActorID, &Address) {
+    fn msg_origin(&self) -> ActorID {
         self.0.msg_origin()
     }
 


### PR DESCRIPTION
Ideally, we should try to avoid adding in hacks to appease limitations in our testing system. Hopefully, we'll be able to track down the issue with the conformance tests.