### PR TITLE
chore: release sdk 2.0.0-alpha.2

### DIFF
--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changes to the reference FVM implementation.
 
-## 2.0.0-alpha.1
+## [Unreleased]
 
 - Syscalls:
     - Added `recover_secp_public_key` syscall
@@ -10,6 +10,10 @@ Changes to the reference FVM implementation.
     - Added sha256, keccak256, ripemd160, and blake2b512 to the `hash` syscall.
 - Replaced `TokenAmount` with an actual type (was a type alias).
 - Added gas charges to the execution trace.
+
+## 2.0.0-alpha.1
+
+Bump major version for breaking changes.
 
 ## 1.1.0 [2022-06-27]
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.0-alpha.1 [2022-08-29]
+## 2.0.0-alpha.2 [2022-08-29]
 
 - Change randomness return value to a fixed-sized byte array.
 - Remove builtin blake2b hashing.
@@ -8,6 +8,10 @@
     - Removes `Cbor::cid`.
 - Remove actor `Type` enum. Instead, use u32 to identify actor types.
 - Add a `recover_secp_public_key` syscall.
+
+## 2.0.0-alpha.1
+
+Bump major version for breaking changes.
 
 ## 1.0.0 [2022-06-23]
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"

--- a/testing/integration/tests/fil-hello-world-actor/Cargo.toml
+++ b/testing/integration/tests/fil-hello-world-actor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fvm_sdk = { version = "2.0.0-alpha.1", path = "../../../../sdk" }
+fvm_sdk = { version = "2.0.0-alpha.2", path = "../../../../sdk" }
 fvm_shared = { version = "2.0.0-alpha.1", path = "../../../../shared" }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fvm_sdk = { version = "2.0.0-alpha.1", path = "../../../../sdk" }
+fvm_sdk = { version = "2.0.0-alpha.2", path = "../../../../sdk" }
 fvm_shared = { version = "2.0.0-alpha.1", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../../../ipld/blockstore" }

--- a/testing/integration/tests/fil-ipld-actor/Cargo.toml
+++ b/testing/integration/tests/fil-ipld-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "2.0.0-alpha.1", path = "../../../../sdk" }
+fvm_sdk = { version = "2.0.0-alpha.2", path = "../../../../sdk" }
 fvm_shared = { version = "2.0.0-alpha.1", path = "../../../../shared" }
 minicov = {version = "0.2", optional = true}
 

--- a/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fvm_sdk = { version = "2.0.0-alpha.1", path = "../../../../sdk" }
+fvm_sdk = { version = "2.0.0-alpha.2", path = "../../../../sdk" }
 fvm_shared = { version = "2.0.0-alpha.1", path = "../../../../shared" }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fvm_sdk = { version = "2.0.0-alpha.1", path = "../../../../sdk" }
+fvm_sdk = { version = "2.0.0-alpha.2", path = "../../../../sdk" }
 fvm_shared = { version = "2.0.0-alpha.1", path = "../../../../shared" }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-syscall-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "2.0.0-alpha.1", path = "../../../../sdk" }
+fvm_sdk = { version = "2.0.0-alpha.2", path = "../../../../sdk" }
 fvm_shared = { version = "2.0.0-alpha.1", path = "../../../../shared" }
 minicov = {version = "0.2", optional = true}
 multihash = "0.16.3"


### PR DESCRIPTION
Looks like I released alpha 1 when we bumped the FVM, so on to alpha 2?