### PR TITLE
chore: explicitly enable anyhow backtrace feature

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["lib"]
 
 [dependencies]
-anyhow = "1.0.47"
+anyhow = { version = "1.0.47", features = ["backtrace"] }
 thiserror = "1.0.30"
 num-traits = "0.2"
 derive_builder = "0.11.2"


### PR DESCRIPTION
Otherwise, compilation fails. It looks like some other crate was transitively enabling this feature, but not anymore.