### PR TITLE
fix: correct coverage features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           - name: integration
             key: v3
             command: test
-            args: --package fvm_integration_tests --features wasm-coverage --package "*actor"
+            args: --package fvm_integration_tests --package "*actor"
           - name: conformance
             key: v3
             command: test

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -47,5 +47,4 @@ fil_syscall_actor = { path = "tests/fil-syscall-actor" }
 
 [features]
 default = ["fvm/testing", "fvm_shared/testing"]
-wasm-coverage = ["fil_ipld_actor/coverage"]
 m2-native = []

--- a/testing/integration/tests/fil-ipld-actor/Cargo.toml
+++ b/testing/integration/tests/fil-ipld-actor/Cargo.toml
@@ -8,10 +8,9 @@ publish = false
 fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0-alpha.1", path = "../../../../sdk" }
 fvm_shared = { version = "3.0.0-alpha.1", path = "../../../../shared" }
-minicov = {version = "0.2", optional = true}
 
-[features]
-coverage = ["minicov"]
+[target.'cfg(coverage)'.dependencies]
+minicov = "0.2"
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"


### PR DESCRIPTION
- 'coverage' is not actually a feature, and should not be used as such.
- 'wasm-coverage' wasn't used anywhere, as far as I could tell.

This caused problems on publish because the `fil_ipld_actor` is a dev dependency, and features can't apply to dev dependencies like that.