### PR TITLE
chore: release fvm v2 (alpha.2)

### DIFF
--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 2.0.0-alpha.2 [2022-08-31]
+
 - Syscalls:
     - Added `recover_secp_public_key` syscall
     - Added debug artifacts syscall (for testing).

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -50,7 +50,7 @@ actors-v7 = { version = "~7.5", package = "fil_builtin_actors_bundle" }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [dependencies.fvm]
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 path = "../../fvm"
 default-features = false
 features = ["testing"]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "2.0.0-alpha.1", path = "../../fvm", default-features = false }
+fvm = { version = "2.0.0-alpha.2", path = "../../fvm", default-features = false }
 fvm_shared = { version = "2.0.0-alpha.3", path = "../../shared" }
 fvm_ipld_hamt = { version = "0.5.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.4.2", path = "../../ipld/amt" }


### PR DESCRIPTION
This will let us cut a new fvm_integration_tests release.