### PR TITLE
fix: avoid plucking integration test actors from target

### DIFF
--- a/testing/integration/tests/fil-malformed-syscall-actor/src/lib.rs
+++ b/testing/integration/tests/fil-malformed-syscall-actor/src/lib.rs
@@ -1,5 +1,7 @@
 use fvm_sdk::sys::crypto::compute_unsealed_sector_cid;
 
+include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+
 #[no_mangle]
 pub fn invoke(_: u32) -> u32 {
     let piece: Vec<u8> = vec![];

--- a/testing/integration/tests/fil_integer_overflow.rs
+++ b/testing/integration/tests/fil_integer_overflow.rs
@@ -1,3 +1,4 @@
+use fil_integer_overflow_actor::WASM_BINARY as OVERFLOW_BINARY;
 use fvm::executor::{ApplyKind, Executor};
 use fvm_integration_tests::dummy::DummyExterns;
 use fvm_integration_tests::tester::{Account, Tester};
@@ -11,9 +12,6 @@ use fvm_shared::message::Message;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use num_traits::Zero;
-
-const WASM_COMPILED_PATH: &str =
-    "../../target/debug/wbuild/fil_integer_overflow_actor/fil_integer_overflow_actor.compact.wasm";
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug, Default)]
 pub struct State {
@@ -40,16 +38,10 @@ fn instantiate_tester() -> (Account, Tester<MemoryBlockstore, DummyExterns>, Add
     let actor_address = Address::new_id(10000);
 
     // Get wasm bin
-    let wasm_path = std::env::current_dir()
-        .unwrap()
-        .join(WASM_COMPILED_PATH)
-        .canonicalize()
-        .unwrap();
-
-    let wasm_bin = std::fs::read(wasm_path).expect("Unable to read file");
+    let wasm_bin = OVERFLOW_BINARY.unwrap();
 
     tester
-        .set_actor_from_bin(&wasm_bin, state_cid, actor_address, TokenAmount::zero())
+        .set_actor_from_bin(wasm_bin, state_cid, actor_address, TokenAmount::zero())
         .unwrap();
 
     (sender[0], tester, actor_address)

--- a/testing/integration/tests/fil_syscall.rs
+++ b/testing/integration/tests/fil_syscall.rs
@@ -1,3 +1,4 @@
+use fil_malformed_syscall_actor::WASM_BINARY as MALFORMED_ACTOR_BINARY;
 use fvm::call_manager::backtrace::Cause;
 use fvm::executor::{ApplyFailure, ApplyKind, Executor};
 use fvm_integration_tests::dummy::DummyExterns;
@@ -27,9 +28,6 @@ const WAT_UNKNOWN_SYSCALL: &str = r#"
         (global $__data_end (export "__data_end") i32 (i32.const 1048576))
         (global $__heap_base (export "__heap_base") i32 (i32.const 1048576)))
     "#;
-
-const WASM_COMPILED_PATH: &str =
-    "../../target/debug/wbuild/fil_malformed_syscall_actor/fil_malformed_syscall_actor.compact.wasm";
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug, Default)]
 pub struct State {
@@ -123,16 +121,10 @@ fn non_existing_syscall() {
 #[test]
 fn malformed_syscall_parameter() {
     // Get wasm bin
-    let wasm_path = std::env::current_dir()
-        .unwrap()
-        .join(WASM_COMPILED_PATH)
-        .canonicalize()
-        .unwrap();
-
-    let wasm_bin = std::fs::read(wasm_path).expect("Unable to read file");
+    let wasm_bin = MALFORMED_ACTOR_BINARY.unwrap();
 
     // Instantiate tester
-    let (sender, mut tester, actor_address) = instantiate_tester(&wasm_bin);
+    let (sender, mut tester, actor_address) = instantiate_tester(wasm_bin);
 
     // Instantiate machine
     tester.instantiate_machine(DummyExterns).unwrap();


### PR DESCRIPTION
Instead, use the WASM_BINARY const exported by wasm-builder.