### PR TITLE
feat: avoid importing the bundle into the integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
     "testing/conformance",
     "testing/integration",
     "ipld/*",
-    "testing/integration/tests/*"
+    "testing/integration/tests/*-actor"
 ]
 
 [profile.actor]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -14,8 +14,6 @@ fvm_ipld_car = { version = "0.5.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.2.2", path = "../../ipld/encoding" }
 
-actors-v10 = { version = "10.0.0-alpha.1", package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
-
 anyhow = "1.0.47"
 cid = { version = "0.8.5", default-features = false }
 futures = "0.3.19"
@@ -44,6 +42,8 @@ fil_ipld_actor = { path = 'tests/fil-ipld-actor' }
 fil_malformed_syscall_actor = { path = "tests/fil-malformed-syscall-actor" }
 fil_integer_overflow_actor = { path = "tests/fil-integer-overflow-actor" }
 fil_syscall_actor = { path = "tests/fil-syscall-actor" }
+
+actors-v10 = { version = "10.0.0-alpha.1", package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 
 [features]
 default = ["fvm/testing", "fvm_shared/testing"]

--- a/testing/integration/examples/integration.rs
+++ b/testing/integration/examples/integration.rs
@@ -1,4 +1,5 @@
 use fvm::executor::{ApplyKind, Executor};
+use fvm_integration_tests::bundle;
 use fvm_integration_tests::dummy::DummyExterns;
 use fvm_integration_tests::tester::{Account, Tester};
 use fvm_ipld_blockstore::MemoryBlockstore;
@@ -27,12 +28,10 @@ struct State {
 
 pub fn main() {
     // Instantiate tester
-    let mut tester = Tester::new(
-        NetworkVersion::V15,
-        StateTreeVersion::V4,
-        MemoryBlockstore::default(),
-    )
-    .unwrap();
+    let bs = MemoryBlockstore::default();
+    let bundle_root = bundle::import_bundle(&bs, actors_v10::BUNDLE_CAR).unwrap();
+    let mut tester =
+        Tester::new(NetworkVersion::V15, StateTreeVersion::V4, bundle_root, bs).unwrap();
 
     let sender: [Account; 1] = tester.create_accounts().unwrap();
 

--- a/testing/integration/src/bundle.rs
+++ b/testing/integration/src/bundle.rs
@@ -1,0 +1,13 @@
+use anyhow::anyhow;
+use cid::Cid;
+use futures::executor::block_on;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_car::load_car_unchecked;
+
+// Import built-in actors
+pub fn import_bundle(blockstore: &impl Blockstore, bundle: &[u8]) -> anyhow::Result<Cid> {
+    match &*block_on(async { load_car_unchecked(blockstore, bundle).await })? {
+        [root] => Ok(*root),
+        _ => Err(anyhow!("multiple root CIDs in bundle")),
+    }
+}

--- a/testing/integration/src/error.rs
+++ b/testing/integration/src/error.rs
@@ -1,13 +1,8 @@
 use cid::Cid;
-use fvm_shared::version::NetworkVersion;
 
 #[derive(thiserror::Error, Debug)]
 /// Util errors for the intergration test framework.
 pub(crate) enum Error {
-    #[error("multiple root cid for network: {0}")]
-    MultipleRootCid(NetworkVersion),
-    #[error("no root cid for network: {0}")]
-    NoRootCid(NetworkVersion),
     #[error("could not find manifest information for cid: {0}")]
     NoManifestInformation(Cid),
     #[error("could not load builtin manifest")]

--- a/testing/integration/src/lib.rs
+++ b/testing/integration/src/lib.rs
@@ -1,4 +1,5 @@
 mod builtin;
+pub mod bundle;
 pub mod dummy;
 pub mod error;
 pub mod tester;

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -16,10 +16,8 @@ use fvm_shared::{ActorID, IPLD_RAW};
 use libsecp256k1::{PublicKey, SecretKey};
 use multihash::Code;
 
-use crate::builtin::{
-    fetch_builtin_code_cid, import_builtin_actors, set_init_actor, set_sys_actor,
-};
-use crate::error::Error::{FailedToFlushTree, NoManifestInformation, NoRootCid};
+use crate::builtin::{fetch_builtin_code_cid, set_init_actor, set_sys_actor};
+use crate::error::Error::{FailedToFlushTree, NoManifestInformation};
 
 const DEFAULT_BASE_FEE: u64 = 100;
 
@@ -50,13 +48,12 @@ where
     B: Blockstore,
     E: Externs,
 {
-    pub fn new(nv: NetworkVersion, stv: StateTreeVersion, blockstore: B) -> Result<Self> {
-        // Load the builtin actors bundles into the blockstore.
-        let nv_actors = import_builtin_actors(&blockstore)?;
-
-        // Get the builtin actors index for the concrete network version.
-        let builtin_actors = *nv_actors.get(&nv).ok_or(NoRootCid(nv))?;
-
+    pub fn new(
+        nv: NetworkVersion,
+        stv: StateTreeVersion,
+        builtin_actors: Cid,
+        blockstore: B,
+    ) -> Result<Self> {
         let (manifest_version, manifest_data_cid): (u32, Cid) =
             match blockstore.get_cbor(&builtin_actors)? {
                 Some((manifest_version, manifest_data)) => (manifest_version, manifest_data),

--- a/testing/integration/tests/bundles/mod.rs
+++ b/testing/integration/tests/bundles/mod.rs
@@ -1,0 +1,29 @@
+use std::collections::BTreeMap;
+
+use anyhow::Context;
+use fvm::externs::Externs;
+use fvm_integration_tests::bundle;
+use fvm_integration_tests::tester::Tester;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_shared::state::StateTreeVersion;
+use fvm_shared::version::NetworkVersion;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref BUNDLES: BTreeMap<NetworkVersion, &'static [u8]> = [
+        (NetworkVersion::V15, actors_v10::BUNDLE_CAR),
+        (NetworkVersion::V16, actors_v10::BUNDLE_CAR), // todo bad hack
+    ].into_iter().collect();
+}
+
+pub fn new_tester<B: Blockstore, E: Externs>(
+    nv: NetworkVersion,
+    stv: StateTreeVersion,
+    blockstore: B,
+) -> anyhow::Result<Tester<B, E>> {
+    let bundle = BUNDLES
+        .get(&nv)
+        .with_context(|| format!("unsupported network version {nv}"))?;
+    let root = bundle::import_bundle(&blockstore, bundle)?;
+    Tester::new(nv, stv, root, blockstore)
+}

--- a/testing/integration/tests/fil_integer_overflow.rs
+++ b/testing/integration/tests/fil_integer_overflow.rs
@@ -13,6 +13,9 @@ use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use num_traits::Zero;
 
+mod bundles;
+use bundles::*;
+
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug, Default)]
 pub struct State {
     pub value: i64,
@@ -21,7 +24,7 @@ pub struct State {
 // Utility function to instantiation integration tester
 fn instantiate_tester() -> (Account, Tester<MemoryBlockstore, DummyExterns>, Address) {
     // Instantiate tester
-    let mut tester = Tester::new(
+    let mut tester = new_tester(
         NetworkVersion::V15,
         StateTreeVersion::V4,
         MemoryBlockstore::default(),

--- a/testing/integration/tests/fil_syscall.rs
+++ b/testing/integration/tests/fil_syscall.rs
@@ -15,6 +15,9 @@ use fvm_shared::version::NetworkVersion;
 use num_traits::Zero;
 use wabt::wat2wasm;
 
+mod bundles;
+use bundles::*;
+
 const WAT_UNKNOWN_SYSCALL: &str = r#"
     (module
         (type $t0 (func))
@@ -39,7 +42,7 @@ fn instantiate_tester(
     wasm_bin: &[u8],
 ) -> (Account, Tester<MemoryBlockstore, DummyExterns>, Address) {
     // Instantiate tester
-    let mut tester = Tester::new(
+    let mut tester = new_tester(
         NetworkVersion::V15,
         StateTreeVersion::V4,
         MemoryBlockstore::default(),

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -1,6 +1,3 @@
-mod fil_integer_overflow;
-mod fil_syscall;
-
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
@@ -13,7 +10,7 @@ use fil_stack_overflow_actor::WASM_BINARY as OVERFLOW_BINARY;
 use fil_syscall_actor::WASM_BINARY as SYSCALL_BINARY;
 use fvm::executor::{ApplyKind, Executor, ThreadedExecutor};
 use fvm_integration_tests::dummy::DummyExterns;
-use fvm_integration_tests::tester::{Account, IntegrationExecutor, Tester};
+use fvm_integration_tests::tester::{Account, IntegrationExecutor};
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
@@ -25,6 +22,9 @@ use fvm_shared::version::NetworkVersion;
 use num_traits::Zero;
 use wabt::wat2wasm;
 
+mod bundles;
+use bundles::*;
+
 /// The state object.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug, Default)]
 pub struct State {
@@ -34,7 +34,7 @@ pub struct State {
 #[test]
 fn hello_world() {
     // Instantiate tester
-    let mut tester = Tester::new(
+    let mut tester = new_tester(
         NetworkVersion::V15,
         StateTreeVersion::V4,
         MemoryBlockstore::default(),
@@ -80,7 +80,7 @@ fn hello_world() {
 #[test]
 fn ipld() {
     // Instantiate tester
-    let mut tester = Tester::new(
+    let mut tester = new_tester(
         NetworkVersion::V15,
         StateTreeVersion::V4,
         MemoryBlockstore::default(),
@@ -132,7 +132,7 @@ fn ipld() {
 #[test]
 fn syscalls() {
     // Instantiate tester
-    let mut tester = Tester::new(
+    let mut tester = new_tester(
         NetworkVersion::V16,
         StateTreeVersion::V4,
         MemoryBlockstore::default(),
@@ -184,7 +184,7 @@ fn syscalls() {
 #[test]
 fn native_stack_overflow() {
     // Instantiate tester
-    let mut tester = Tester::new(
+    let mut tester = new_tester(
         NetworkVersion::V16,
         StateTreeVersion::V4,
         MemoryBlockstore::default(),
@@ -249,7 +249,7 @@ fn native_stack_overflow() {
 
 fn test_exitcode(wat: &str, code: ExitCode) {
     // Instantiate tester
-    let mut tester = Tester::new(
+    let mut tester = new_tester(
         NetworkVersion::V16,
         StateTreeVersion::V4,
         MemoryBlockstore::default(),
@@ -405,7 +405,7 @@ fn backtraces() {
     };
 
     // Instantiate tester
-    let mut tester = Tester::new(
+    let mut tester = new_tester(
         NetworkVersion::V16,
         StateTreeVersion::V4,
         blockstore.clone(),


### PR DESCRIPTION
This change:

- Moves the actor "bundle" dependency to the dev dependencies.
- Makes the `Tester` take a "bundle root cid".
- Exports a helper function for importing a bundle into a blockstore.

That way:

1. Users can instantiate integration tests with their _own_ bundle.
2. We can publish the integration testing _framework_ while testing against a dev bundle locally.