### PR TITLE
chore: remove version specifier from bundle dev-dependency

### DIFF
--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -45,7 +45,7 @@ fil_malformed_syscall_actor = { path = "tests/fil-malformed-syscall-actor" }
 fil_integer_overflow_actor = { path = "tests/fil-integer-overflow-actor" }
 fil_syscall_actor = { path = "tests/fil-syscall-actor" }
 
-actors-v10 = { version = "10.0.0-alpha.1", package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
+actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 
 [features]
 default = ["fvm/testing", "fvm_shared/testing"]


### PR DESCRIPTION
Otherwise, crates.io will reject a publish of this crate.