### PR TITLE
chore: deps: Update to wasmtime 0.40.1

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -47,7 +47,7 @@ pretty_assertions = "1.2.1"
 fvm = { path = ".", features = ["testing"], default-features = false }
 
 [dependencies.wasmtime]
-version = "0.37.0"
+version = "0.40.1"
 default-features = false
 features = ["cranelift", "pooling-allocator", "parallel-compilation"]
 

--- a/fvm/src/machine/engine.rs
+++ b/fvm/src/machine/engine.rs
@@ -121,7 +121,7 @@ pub fn default_wasmtime_config() -> wasmtime::Config {
     // wasmtime default: 512KiB
     // Set to something much higher than the instrumented limiter.
     // Note: This is in bytes, while the instrumented limit is in stack elements
-    c.max_wasm_stack(4 << 20).unwrap();
+    c.max_wasm_stack(4 << 20);
 
     // Execution cost accouting is done through wasm instrumentation,
     c.consume_fuel(false);

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4.14"
 byteorder = "1.4.3"
 futures = "0.3.19"
 async-std = { version = "1.9", features = ["attributes"] }
-wasmtime = { version = "0.37.0", default-features = false }
+wasmtime = { version = "0.40.1", default-features = false }
 base64 = "0.13.0"
 flate2 = { version = "1.0" }
 colored = "2"

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -31,7 +31,7 @@ serde_repr = "0.1"
 thiserror = "1.0.30"
 
 [dependencies.wasmtime]
-version = "0.37.0"
+version = "0.40.1"
 default-features = false
 features = ["cranelift", "parallel-compilation"]
 


### PR DESCRIPTION
Closes #852, assuming it doesn't break things.