### PR TITLE
add ordering to address

### DIFF
--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -67,7 +67,7 @@ pub const NETWORK_DEFAULT: Network = Network::Mainnet;
 
 /// Address is the struct that defines the protocol and data payload conversion from either
 /// a public key or value
-#[derive(PartialEq, Eq, Clone, Debug, Hash, Copy)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "testing", derive(Default))]
 #[cfg_attr(feature = "arb", derive(arbitrary::Arbitrary))]
 pub struct Address {

--- a/shared/src/address/network.rs
+++ b/shared/src/address/network.rs
@@ -4,7 +4,7 @@
 use super::{MAINNET_PREFIX, TESTNET_PREFIX};
 
 /// Network defines the preconfigured networks to use with address encoding
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arb", derive(arbitrary::Arbitrary))]
 pub enum Network {
     Mainnet = 0,

--- a/shared/src/address/payload.rs
+++ b/shared/src/address/payload.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::ActorID;
 
 /// A "delegated" (f4) address.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DelegatedAddress {
     namespace: ActorID,
     length: usize,
@@ -60,7 +60,7 @@ impl DelegatedAddress {
 }
 
 /// Payload is the data of the Address. Variants are the supported Address protocols.
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arb", derive(arbitrary::Arbitrary))]
 pub enum Payload {
     /// f0: ID protocol address.


### PR DESCRIPTION
add ordering to address so they can be used as keys in BTreeMaps #894 