### PR TITLE
feat: f4 address class, embryo actors, and lookup_address

### DIFF
--- a/fvm/src/account_actor.rs
+++ b/fvm/src/account_actor.rs
@@ -7,15 +7,9 @@
 //! eliminated. Refer to https://github.com/filecoin-project/fvm/issues/229 for
 //! details.
 
-use cid::Cid;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
-use fvm_shared::econ::TokenAmount;
-use num_traits::Zero;
-
-use crate::state_tree::ActorState;
-use crate::EMPTY_ARR_CID;
 
 pub const SYSTEM_ACTOR_ID: u64 = 0;
 
@@ -23,16 +17,6 @@ pub const SYSTEM_ACTOR_ID: u64 = 0;
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct State {
     pub address: Address,
-}
-
-/// Returns an ActorState representing a brand new account with no balance.
-pub fn zero_state(code_cid: Cid) -> ActorState {
-    ActorState {
-        code: code_cid,
-        state: *EMPTY_ARR_CID,
-        sequence: 0,
-        balance: TokenAmount::zero(),
-    }
 }
 
 impl Cbor for State {}

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -278,7 +278,7 @@ where
         // Create the actor in the state tree.
         let id = {
             let code_cid = self.builtin_actors().get_account_code();
-            let state = ActorState::new_empty(*code_cid);
+            let state = ActorState::new_empty(*code_cid, Some(*addr));
             self.create_actor(addr, state)?
         };
 
@@ -314,7 +314,7 @@ where
         // Create the actor in the state tree, but don't call any constructor.
         let code_cid = self.builtin_actors().get_embryo_code();
 
-        let state = ActorState::new_empty(*code_cid);
+        let state = ActorState::new_empty(*code_cid, Some(*addr));
         self.create_actor(addr, state)
     }
 

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -31,7 +31,7 @@ use crate::call_manager::{CallManager, InvocationResult, NO_DATA_BLOCK_ID};
 use crate::externs::{Consensus, Rand};
 use crate::gas::GasCharge;
 use crate::state_tree::ActorState;
-use crate::{syscall_error, EMPTY_ARR_CID};
+use crate::syscall_error;
 
 lazy_static! {
     static ref NUM_CPUS: usize = num_cpus::get();
@@ -796,19 +796,34 @@ where
             );
         }
 
-        let state_tree = self.call_manager.state_tree();
-        if let Ok(Some(_)) = state_tree.get_actor_id(actor_id) {
-            return Err(syscall_error!(Forbidden; "Actor address already exists").into());
-        }
+        // Check to make sure the actor doesn't exist, or is an embryo.
+        let actor = match self.call_manager.state_tree().get_actor_id(actor_id)? {
+            // Replace the embryo
+            Some(mut act)
+                if self
+                    .call_manager
+                    .machine()
+                    .builtin_actors()
+                    .is_embryo_actor(&act.code) =>
+            {
+                act.code = code_id;
+                act
+            }
+            // Don't replace anything else.
+            Some(_) => {
+                return Err(syscall_error!(Forbidden; "Actor address already exists").into());
+            }
+            // Create a new actor.
+            None => {
+                self.call_manager
+                    .charge_gas(self.call_manager.price_list().on_create_actor())?;
+                ActorState::new_empty(code_id)
+            }
+        };
 
         self.call_manager
-            .charge_gas(self.call_manager.price_list().on_create_actor())?;
-
-        let state_tree = self.call_manager.state_tree_mut();
-        state_tree.set_actor_id(
-            actor_id,
-            ActorState::new(code_id, *EMPTY_ARR_CID, TokenAmount::zero(), 0),
-        )
+            .state_tree_mut()
+            .set_actor_id(actor_id, actor)
     }
 
     fn get_builtin_actor_type(&self, code_cid: &Cid) -> u32 {

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -190,6 +190,9 @@ pub trait ActorOps {
     /// If the argument is an ID address it is returned directly.
     fn resolve_address(&self, address: &Address) -> Result<ActorID>;
 
+    /// Looks-up the "predictable" address of the specified actor, if any.
+    fn lookup_address(&self, actor_id: ActorID) -> Result<Option<Address>>;
+
     /// Look up the code CID of an actor.
     fn get_actor_code_cid(&self, id: ActorID) -> Result<Cid>;
 
@@ -199,9 +202,14 @@ pub trait ActorOps {
     /// Always an ActorExec address.
     fn new_actor_address(&mut self) -> Result<Address>;
 
-    /// Creates an actor with code `code_cid` and id `actor_id`, with empty state.
-    /// May only be called by Init actor.
-    fn create_actor(&mut self, code_cid: Cid, actor_id: ActorID) -> Result<()>;
+    /// Creates an actor with given `code_cid`, `actor_id`, `predictable_address` (if specified),
+    /// and an empty state.
+    fn create_actor(
+        &mut self,
+        code_cid: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) -> Result<()>;
 
     /// Installs actor code pointed by cid
     #[cfg(feature = "m2-native")]

--- a/fvm/src/machine/manifest.rs
+++ b/fvm/src/machine/manifest.rs
@@ -18,10 +18,12 @@ const SINGLETON_ACTOR_NAMES: &[&str] = &[
 const ACCOUNT_ACTOR_NAME: &str = "account";
 const INIT_ACTOR_NAME: &str = "init";
 const SYSTEM_ACTOR_NAME: &str = "system";
+const EMBRYO_ACTOR_NAME: &str = "embryo";
 
 /// A mapping of builtin actor CIDs to their respective types.
 pub struct Manifest {
     account_code: Cid,
+    embryo_code: Cid,
     system_code: Cid,
     init_code: Cid,
     singletons: HashSet<Cid>,
@@ -62,6 +64,7 @@ impl Manifest {
         ("init", id_cid(b"fil/test/init")),
         ("cron", id_cid(b"fil/test/cron")),
         ("account", id_cid(b"fil/test/account")),
+        ("embryo", id_cid(b"fil/test/embryo")),
     ];
 
     #[cfg(any(feature = "testing", test))]
@@ -117,10 +120,15 @@ impl Manifest {
             .get(INIT_ACTOR_NAME)
             .context("manifest missing init actor")?;
 
+        let embryo_code = *by_name
+            .get(EMBRYO_ACTOR_NAME)
+            .context("manifest missing embryo actor")?;
+
         Ok(Self {
             account_code,
             system_code,
             init_code,
+            embryo_code,
             singletons,
             by_id,
             by_code,
@@ -140,6 +148,11 @@ impl Manifest {
     /// Returns true id the passed code CID is the account actor.
     pub fn is_account_actor(&self, cid: &Cid) -> bool {
         &self.account_code == cid
+    }
+
+    /// Returns true id the passed code CID is the embryo actor.
+    pub fn is_embryo_actor(&self, cid: &Cid) -> bool {
+        &self.embryo_code == cid
     }
 
     /// Returns true id the passed code is a singleton actor.
@@ -164,5 +177,10 @@ impl Manifest {
     /// Returns the code CID for the system actor.
     pub fn get_system_code(&self) -> &Cid {
         &self.system_code
+    }
+
+    /// Returns the code CID for the system actor.
+    pub fn get_embryo_code(&self) -> &Cid {
+        &self.embryo_code
     }
 }

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -520,26 +520,38 @@ pub struct ActorState {
     pub sequence: u64,
     /// Tokens available to the actor.
     pub balance: TokenAmount,
+    /// The actor's "predictable" address, if assigned.
+    ///
+    /// This field is set on actor creation and never modified.
+    pub address: Option<Address>,
 }
 
 impl ActorState {
     /// Constructor for actor state
-    pub fn new(code: Cid, state: Cid, balance: TokenAmount, sequence: u64) -> Self {
+    pub fn new(
+        code: Cid,
+        state: Cid,
+        balance: TokenAmount,
+        sequence: u64,
+        address: Option<Address>,
+    ) -> Self {
         Self {
             code,
             state,
             sequence,
             balance,
+            address,
         }
     }
 
     /// Construct a new empty actor with the specified code.
-    pub fn new_empty(code: Cid) -> Self {
+    pub fn new_empty(code: Cid, address: Option<Address>) -> Self {
         ActorState {
             code,
             state: *EMPTY_ARR_CID,
             sequence: 0,
             balance: TokenAmount::zero(),
+            address,
         }
     }
 
@@ -673,8 +685,8 @@ mod tests {
 
     #[test]
     fn get_set_cache() {
-        let act_s = ActorState::new(empty_cid(), empty_cid(), Default::default(), 1);
-        let act_a = ActorState::new(empty_cid(), empty_cid(), Default::default(), 2);
+        let act_s = ActorState::new(empty_cid(), empty_cid(), Default::default(), 1, None);
+        let act_a = ActorState::new(empty_cid(), empty_cid(), Default::default(), 2, None);
         let addr = Address::new_id(1);
         let store = MemoryBlockstore::default();
         let mut tree = StateTree::new(&store, StateTreeVersion::V3).unwrap();
@@ -697,7 +709,7 @@ mod tests {
         let mut tree = StateTree::new(&store, StateTreeVersion::V3).unwrap();
 
         let addr = Address::new_id(3);
-        let act_s = ActorState::new(empty_cid(), empty_cid(), Default::default(), 1);
+        let act_s = ActorState::new(empty_cid(), empty_cid(), Default::default(), 1, None);
         tree.set_actor(&addr, act_s.clone()).unwrap();
         assert_eq!(tree.get_actor(&addr).unwrap(), Some(act_s));
         tree.delete_actor(&addr).unwrap();
@@ -716,7 +728,13 @@ mod tests {
             .map_err(|e| e.to_string())
             .unwrap();
 
-        let act_s = ActorState::new(*DUMMY_INIT_ACTOR_CODE_ID, state_cid, Default::default(), 1);
+        let act_s = ActorState::new(
+            *DUMMY_INIT_ACTOR_CODE_ID,
+            state_cid,
+            Default::default(),
+            1,
+            None,
+        );
 
         tree.begin_transaction();
         tree.set_actor(&INIT_ACTOR_ADDR, act_s).unwrap();
@@ -734,7 +752,8 @@ mod tests {
                 code: *DUMMY_INIT_ACTOR_CODE_ID,
                 state: state_cid,
                 balance: Default::default(),
-                sequence: 2
+                sequence: 2,
+                address: None
             })
         );
 
@@ -764,6 +783,7 @@ mod tests {
                 *DUMMY_ACCOUNT_ACTOR_CODE_ID,
                 TokenAmount::from_atto(55),
                 1,
+                None,
             ),
         )
         .unwrap();
@@ -775,6 +795,7 @@ mod tests {
                 *DUMMY_ACCOUNT_ACTOR_CODE_ID,
                 TokenAmount::from_atto(55),
                 1,
+                None,
             ),
         )
         .unwrap();
@@ -785,6 +806,7 @@ mod tests {
                 *DUMMY_ACCOUNT_ACTOR_CODE_ID,
                 TokenAmount::from_atto(55),
                 1,
+                None,
             ),
         )
         .unwrap();
@@ -797,7 +819,8 @@ mod tests {
                 *DUMMY_ACCOUNT_ACTOR_CODE_ID,
                 *DUMMY_ACCOUNT_ACTOR_CODE_ID,
                 TokenAmount::from_atto(55),
-                1
+                1,
+                None,
             )
         );
         assert_eq!(
@@ -806,7 +829,8 @@ mod tests {
                 *DUMMY_ACCOUNT_ACTOR_CODE_ID,
                 *DUMMY_ACCOUNT_ACTOR_CODE_ID,
                 TokenAmount::from_atto(55),
-                1
+                1,
+                None,
             )
         );
 
@@ -816,7 +840,8 @@ mod tests {
                 *DUMMY_ACCOUNT_ACTOR_CODE_ID,
                 *DUMMY_ACCOUNT_ACTOR_CODE_ID,
                 TokenAmount::from_atto(55),
-                1
+                1,
+                None
             )
         );
     }
@@ -837,6 +862,7 @@ mod tests {
                 *DUMMY_ACCOUNT_ACTOR_CODE_ID,
                 TokenAmount::from_atto(55),
                 1,
+                None,
             ),
         )
         .unwrap();

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -14,10 +14,11 @@ use fvm_shared::address::{Address, Payload};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::state::{StateInfo0, StateRoot, StateTreeVersion};
 use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
+use num_traits::Zero;
 
 use crate::init_actor::State as InitActorState;
 use crate::kernel::{ClassifyResult, Context as _, ExecutionError, Result};
-use crate::syscall_error;
+use crate::{syscall_error, EMPTY_ARR_CID};
 
 /// State tree implementation using hamt. This structure is not threadsafe and should only be used
 /// in sync contexts.
@@ -531,6 +532,17 @@ impl ActorState {
             balance,
         }
     }
+
+    /// Construct a new empty actor with the specified code.
+    pub fn new_empty(code: Cid) -> Self {
+        ActorState {
+            code,
+            state: *EMPTY_ARR_CID,
+            sequence: 0,
+            balance: TokenAmount::zero(),
+        }
+    }
+
     /// Safely deducts funds from an Actor
     pub fn deduct_funds(&mut self, amt: &TokenAmount) -> Result<()> {
         if &self.balance < amt {

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use fvm_shared::sys;
+use fvm_shared::{sys, ActorID};
 
 use super::Context;
 use crate::kernel::{ClassifyResult, Result};
@@ -13,6 +13,27 @@ pub fn resolve_address(
     let addr = context.memory.read_address(addr_off, addr_len)?;
     let actor_id = context.kernel.resolve_address(&addr)?;
     Ok(actor_id)
+}
+
+pub fn lookup_address(
+    context: Context<'_, impl Kernel>,
+    actor_id: ActorID,
+    obuf_off: u32,
+    obuf_len: u32,
+) -> Result<u32> {
+    let obuf = context.memory.try_slice_mut(obuf_off, obuf_len)?;
+    match context.kernel.lookup_address(actor_id)? {
+        Some(address) => {
+            let address = address.to_bytes();
+            obuf.get_mut(..address.len())
+                .ok_or_else(
+                    || syscall_error!(BufferTooSmall; "address output buffer is too small"),
+                )?
+                .copy_from_slice(&address);
+            Ok(address.len() as u32)
+        }
+        None => Ok(0),
+    }
 }
 
 pub fn get_actor_code_cid(
@@ -72,11 +93,21 @@ pub fn new_actor_address(
 
 pub fn create_actor(
     context: Context<'_, impl Kernel>,
-    actor_id: u64, // Address
+    actor_id: u64, // ID
     typ_off: u32,  // Cid
+    predictable_addr_off: u32,
+    predictable_addr_len: u32,
 ) -> Result<()> {
     let typ = context.memory.read_cid(typ_off)?;
-    context.kernel.create_actor(typ, actor_id)
+    let addr = (predictable_addr_len == 0)
+        .then(|| {
+            context
+                .memory
+                .read_address(predictable_addr_off, predictable_addr_len)
+        })
+        .transpose()?;
+
+    context.kernel.create_actor(typ, actor_id, addr)
 }
 
 pub fn get_builtin_actor_type(

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -122,6 +122,7 @@ pub fn bind_syscalls(
     linker.bind("self", "self_destruct", sself::self_destruct)?;
 
     linker.bind("actor", "resolve_address", actor::resolve_address)?;
+    linker.bind("actor", "lookup_address", actor::lookup_address)?;
     linker.bind("actor", "get_actor_code_cid", actor::get_actor_code_cid)?;
     linker.bind("actor", "new_actor_address", actor::new_actor_address)?;
     linker.bind("actor", "create_actor", actor::create_actor)?;

--- a/sdk/src/actor.rs
+++ b/sdk/src/actor.rs
@@ -1,10 +1,12 @@
-use core::option::Option; // no_std
+use core::option::Option;
+use std::ptr; // no_std
 
 use cid::Cid;
 use fvm_shared::address::{Address, Payload};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::{ActorID, MAX_CID_LEN};
+use log::error;
 
 use crate::{sys, SyscallResult, MAX_ACTOR_ADDR_LEN};
 
@@ -20,6 +22,36 @@ pub fn resolve_address(addr: &Address) -> Option<ActorID> {
     unsafe {
         match sys::actor::resolve_address(bytes.as_ptr(), bytes.len() as u32) {
             Ok(value) => Some(value),
+            Err(ErrorNumber::NotFound) => None,
+            Err(other) => panic!("unexpected address resolution failure: {}", other),
+        }
+    }
+}
+
+/// Looks up the "predictable" address of an actor by ID address. Returns `None` if either the target actor doesn't exist, or if it doesn't have...
+/// cannot be resolved.
+pub fn lookup_address(addr: ActorID) -> Option<Address> {
+    let mut out_buffer = [0u8; MAX_ACTOR_ADDR_LEN];
+    unsafe {
+        match sys::actor::lookup_address(addr, out_buffer.as_mut_ptr(), out_buffer.len() as u32) {
+            Ok(0) => None,
+            Ok(length) => match Address::from_bytes(&out_buffer[..length as usize]) {
+                Ok(addr) => Some(addr),
+                // Ok, so, we _log_ this error (if debugging is enabled) but otherwise move on.
+                // Why? Because the system may add _new_ address classes. In that case, the "least
+                // bad" thing to do here is to claim that the target actor doesn't have an f1/f3/f4
+                // address, which is likely correct.
+                //
+                // https://github.com/filecoin-project/builtin-actors/issues/738
+                Err(e) => {
+                    error!(
+                        "unexpected address from 'lookup_address' with protocol {}: {}",
+                        out_buffer[0], e
+                    );
+                    None
+                }
+            },
+            // We're flattening the "not found" error here, but that's probably reasonable for most users.
             Err(ErrorNumber::NotFound) => None,
             Err(other) => panic!("unexpected address resolution failure: {}", other),
         }
@@ -42,8 +74,7 @@ pub fn get_actor_code_cid(addr: &Address) -> Option<Cid> {
     }
 }
 
-/// Generates a new actor address for an actor deployed
-/// by the calling actor.
+/// Generates a new actor address for an actor deployed by the calling actor.
 pub fn new_actor_address() -> Address {
     let mut buf = [0u8; MAX_ACTOR_ADDR_LEN];
     unsafe {
@@ -53,12 +84,21 @@ pub fn new_actor_address() -> Address {
     }
 }
 
-/// Creates a new actor of the specified type in the state tree, under
-/// the provided address.
-/// TODO(M2): this syscall will change to calculate the address internally.
-pub fn create_actor(actor_id: ActorID, code_cid: &Cid) -> SyscallResult<()> {
-    let cid = code_cid.to_bytes();
-    unsafe { sys::actor::create_actor(actor_id, cid.as_ptr()) }
+/// Creates a new actor of the specified type in the state tree, under the provided address.
+pub fn create_actor(
+    actor_id: ActorID,
+    code_cid: &Cid,
+    predictable_address: Option<Address>,
+) -> SyscallResult<()> {
+    unsafe {
+        let cid = code_cid.to_bytes();
+        let addr_bytes = predictable_address.map(|addr| addr.to_bytes());
+        let (addr_off, addr_len) = addr_bytes
+            .as_deref()
+            .map(|v| (v.as_ptr(), v.len()))
+            .unwrap_or((ptr::null(), 0));
+        sys::actor::create_actor(actor_id, cid.as_ptr(), addr_off, addr_len as u32)
+    }
 }
 
 /// Installs or ensures an actor code CID is valid and loaded.

--- a/sdk/src/actor.rs
+++ b/sdk/src/actor.rs
@@ -28,8 +28,8 @@ pub fn resolve_address(addr: &Address) -> Option<ActorID> {
     }
 }
 
-/// Looks up the "predictable" address of an actor by ID address. Returns `None` if either the target actor doesn't exist, or if it doesn't have...
-/// cannot be resolved.
+/// Looks up the f1, f3, or f4 address of the specified actor. Returns `None` if the actor doesn't
+/// exist or it doesn't have an f1, f3, or f4 address.
 pub fn lookup_address(addr: ActorID) -> Option<Address> {
     let mut out_buffer = [0u8; MAX_ACTOR_ADDR_LEN];
     unsafe {

--- a/sdk/src/sys/actor.rs
+++ b/sdk/src/sys/actor.rs
@@ -24,6 +24,32 @@ super::fvm_syscalls! {
         addr_len: u32,
     ) -> Result<u64>;
 
+    /// Looks up the "predictable" address of the target actor.
+    ///
+    /// # Arguments
+    ///
+    /// `addr_buf_off` and `addr_buf_len` specify the location and length of the output buffer in
+    /// which to store the address.
+    ///
+    /// # Returns
+    ///
+    /// The length of the address written to the output buffer, or 0 if the target actor has no
+    /// predictable address.
+    ///
+    /// # Errors
+    ///
+    /// | Error               | Reason                                                           |
+    /// |---------------------|------------------------------------------------------------------|
+    /// | [`NotFound`]        | if the target actor does not exist                               |
+    /// | [`BufferTooSmall`]  | if the output buffer isn't large enough to fit the address       |
+    /// | [`IllegalArgument`] | if the output buffer isn't valid, in memory, etc.                |
+    pub fn lookup_address(
+        actor_id: u64,
+        addr_buf_off: *mut u8,
+        addr_buf_len: u32,
+    ) -> Result<u32>;
+
+
     /// Gets the CodeCID of an actor by address.
     ///
     /// # Arguments
@@ -89,12 +115,17 @@ super::fvm_syscalls! {
     #[doc(hidden)]
     pub fn new_actor_address(obuf_off: *mut u8, obuf_len: u32) -> Result<u32>;
 
-    /// Creates a new actor of the specified type in the state tree, under
-    /// the provided address.
+    /// Creates a new actor in the state-tree with the specified actor ID, recording the specified
+    /// "predictable" address in the actor root if non-empty, and returning a new stable address.
     ///
     /// **Privileged:** May only be called by the init actor.
     #[doc(hidden)]
-    pub fn create_actor(actor_id: u64, typ_off: *const u8) -> Result<()>;
+    pub fn create_actor(
+        actor_id: u64,
+        typ_off: *const u8,
+        predictable_addr_off: *const u8,
+        predictable_addr_len: u32,
+    ) -> Result<()>;
 
     /// Installs and ensures actor code is valid and loaded.
     /// **Privileged:** May only be called by the init actor.

--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -58,7 +58,10 @@ lazy_static::lazy_static! {
 /// Length of the checksum hash for string encodings.
 pub const CHECKSUM_HASH_LEN: usize = 4;
 
-const MAX_ADDRESS_LEN: usize = 115;
+/// The max encoded length of an address.
+pub const MAX_ADDRESS_LEN: usize = 65;
+
+const MAX_ADDRRESS_TEXT_LEN: usize = 138;
 const MAINNET_PREFIX: &str = "f";
 const TESTNET_PREFIX: &str = "t";
 
@@ -229,7 +232,7 @@ impl fmt::Display for Address {
 }
 
 pub(self) fn parse_address(addr: &str) -> Result<(Address, Network), Error> {
-    if addr.len() > MAX_ADDRESS_LEN || addr.len() < 3 {
+    if addr.len() > MAX_ADDRRESS_TEXT_LEN || addr.len() < 3 {
         return Err(Error::InvalidLength);
     }
     let network = Network::from_prefix(addr.get(0..1).ok_or(Error::UnknownNetwork)?)?;

--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -103,7 +103,7 @@ impl Address {
 
     /// Generates new address using Secp256k1 pubkey.
     pub fn new_secp256k1(pubkey: &[u8]) -> Result<Self, Error> {
-        if pubkey.len() != 65 {
+        if pubkey.len() != SECP_PUB_LEN {
             return Err(Error::InvalidSECPLength(pubkey.len()));
         }
         Ok(Self {

--- a/shared/tests/address_test.rs
+++ b/shared/tests/address_test.rs
@@ -237,9 +237,9 @@ fn delegated_address() {
             expected: "f418446744073709551615-tnkyfaq",
         },
         F4TestVec {
-            namespace: 100,
+            namespace: std::u64::MAX,
             subaddr: &[0; MAX_SUBADDRESS_LEN],
-            expected: "f4100-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacf47tke",
+            expected: "f418446744073709551615-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafbbuagu",
         },
     ];
 

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -361,8 +361,13 @@ where
         self.0.new_actor_address()
     }
 
-    fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<()> {
-        self.0.create_actor(code_id, actor_id)
+    fn create_actor(
+        &mut self,
+        code_id: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) -> Result<()> {
+        self.0.create_actor(code_id, actor_id, predictable_address)
     }
 
     fn get_builtin_actor_type(&self, code_cid: &Cid) -> u32 {
@@ -380,6 +385,10 @@ where
 
     fn balance_of(&self, _actor_id: ActorID) -> Result<TokenAmount> {
         todo!()
+    }
+
+    fn lookup_address(&self, actor_id: ActorID) -> Result<Option<Address>> {
+        self.0.lookup_address(actor_id)
     }
 }
 

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -44,6 +44,7 @@ fil_ipld_actor = { path = 'tests/fil-ipld-actor' }
 fil_malformed_syscall_actor = { path = "tests/fil-malformed-syscall-actor" }
 fil_integer_overflow_actor = { path = "tests/fil-integer-overflow-actor" }
 fil_syscall_actor = { path = "tests/fil-syscall-actor" }
+fil_address_actor = { path = "tests/fil-address-actor" }
 
 actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 

--- a/testing/integration/src/builtin.rs
+++ b/testing/integration/src/builtin.rs
@@ -38,6 +38,7 @@ pub fn set_sys_actor(
         state: sys_state_cid,
         sequence: 0,
         balance: Default::default(),
+        address: None,
     };
     state_tree
         .set_actor(&system_actor::SYSTEM_ACTOR_ADDR, sys_actor_state)
@@ -60,6 +61,7 @@ pub fn set_init_actor(
         state: init_state_cid,
         sequence: 0,
         balance: Default::default(),
+        address: None,
     };
 
     state_tree

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -120,8 +120,8 @@ where
         actor_address: Address,
         balance: TokenAmount,
     ) -> Result<Cid> {
-        // Register actor address (unless ID)
-        if !actor_address.id().is_ok() {
+        // Register actor address (unless it's an ID address)
+        if actor_address.id().is_err() {
             self.state_tree
                 .as_mut()
                 .unwrap()

--- a/testing/integration/tests/address_test.rs
+++ b/testing/integration/tests/address_test.rs
@@ -1,0 +1,64 @@
+mod bundles;
+use bundles::*;
+use fil_address_actor::WASM_BINARY as ADDRESS_BINARY;
+use fvm::executor::{ApplyKind, Executor};
+use fvm_integration_tests::dummy::DummyExterns;
+use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_shared::address::Address;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::message::Message;
+use fvm_shared::state::StateTreeVersion;
+use fvm_shared::version::NetworkVersion;
+use num_traits::Zero;
+
+#[test]
+fn basic_address_tests() {
+    // Instantiate tester
+    let mut tester = new_tester(
+        NetworkVersion::V18,
+        StateTreeVersion::V4,
+        MemoryBlockstore::default(),
+    )
+    .unwrap();
+
+    let [(_sender_id, sender_address)] = tester.create_accounts().unwrap();
+
+    let wasm_bin = ADDRESS_BINARY.unwrap();
+
+    // Set actor state
+    let actor_state = [(); 0];
+    let state_cid = tester.set_state(&actor_state).unwrap();
+
+    // Set actor
+    let actor_address = Address::new_id(10000);
+
+    tester
+        .set_actor_from_bin(wasm_bin, state_cid, actor_address, TokenAmount::zero())
+        .unwrap();
+
+    // Instantiate machine
+    tester.instantiate_machine(DummyExterns).unwrap();
+
+    let executor = tester.executor.as_mut().unwrap();
+
+    // Test all methods.
+    for (seq, method) in (2..=5).enumerate() {
+        let message = Message {
+            from: sender_address,
+            to: actor_address,
+            gas_limit: 1000000000,
+            method_num: method,
+            sequence: seq as u64,
+            ..Message::default()
+        };
+
+        let res = executor
+            .execute_message(message, ApplyKind::Explicit, 100)
+            .unwrap();
+        assert!(
+            res.msg_receipt.exit_code.is_success(),
+            "{:?}",
+            res.failure_info
+        );
+    }
+}

--- a/testing/integration/tests/fil-address-actor/Cargo.toml
+++ b/testing/integration/tests/fil-address-actor/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fil_address_actor"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
+fvm_sdk = { version = "3.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.2", path = "../../../../shared" }
+serde = "1.0.145"
+
+[build-dependencies]
+substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-address-actor/build.rs
+++ b/testing/integration/tests/fil-address-actor/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    use substrate_wasm_builder::WasmBuilder;
+    WasmBuilder::new()
+        .with_current_project()
+        .import_memory()
+        .append_to_rust_flags("-Ctarget-feature=+crt-static")
+        .append_to_rust_flags("-Cpanic=abort")
+        .append_to_rust_flags("-Coverflow-checks=true")
+        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Copt-level=z")
+        .build()
+}

--- a/testing/integration/tests/fil-address-actor/src/actor.rs
+++ b/testing/integration/tests/fil-address-actor/src/actor.rs
@@ -1,0 +1,82 @@
+use fvm_ipld_encoding::RawBytes;
+use fvm_sdk as sdk;
+use fvm_shared::address::{Address, SECP_PUB_LEN};
+use fvm_shared::bigint::Zero;
+use fvm_shared::error::ExitCode;
+use sdk::sys::ErrorNumber;
+
+#[no_mangle]
+pub fn invoke(params: u32) -> u32 {
+    sdk::initialize();
+
+    // Check our address.
+    let (codec, data) = sdk::message::params_raw(params).unwrap();
+    assert_eq!(codec, fvm_ipld_encoding::DAG_CBOR);
+
+    match sdk::message::method_number() {
+        // on construction, make sure the address matches the expected one.`
+        1 => {
+            let expected_address: Option<Address> = fvm_ipld_encoding::from_slice(&data).unwrap();
+            let actual_address = sdk::actor::lookup_address(sdk::message::receiver());
+            assert_eq!(expected_address, actual_address, "addresses did not match");
+        }
+        // send to an f1, then resolve.
+        2 => {
+            // Create an account.
+            let addr = Address::new_secp256k1(&[0; SECP_PUB_LEN]).unwrap();
+            assert!(sdk::send::send(&addr, 0, RawBytes::default(), Zero::zero())
+                .unwrap()
+                .exit_code
+                .is_success());
+
+            // Resolve the ID address of the account.
+            let id = sdk::actor::resolve_address(&addr).expect("failed to find new account");
+
+            // Lookup the f1 of the account.
+            let new_addr =
+                sdk::actor::lookup_address(id).expect("failed to lookup account address");
+            assert_eq!(addr, new_addr, "addresses don't match");
+        }
+        // send to an f4, then resolve.
+        3 => {
+            // Create an embryo.
+            let addr =
+                Address::new_delegated(0, b"foobar").expect("failed to construct f4 address");
+            assert!(sdk::send::send(&addr, 0, RawBytes::default(), Zero::zero())
+                .unwrap()
+                .exit_code
+                .is_success());
+
+            // Resolve the ID address of the embryo.
+            let id = sdk::actor::resolve_address(&addr).expect("failed to find new embryo");
+
+            // Lookup the address of the account.
+            let new_addr =
+                sdk::actor::lookup_address(id).expect("failed to lookup account address");
+            assert_eq!(addr, new_addr, "addresses don't match");
+        }
+        // send to an f4 of an unassigned ID address, then resolve.
+        4 => {
+            // Create an embryo.
+            let addr =
+                Address::new_delegated(999, b"foobar").expect("failed to construct f4 address");
+            assert_eq!(
+                Err(ErrorNumber::NotFound),
+                sdk::send::send(&addr, 0, RawBytes::default(), Zero::zero()),
+                "expected send to unassignable f4 address to fail"
+            );
+        }
+        // check the system actor's predictable address (should not exist).
+        5 => {
+            assert!(
+                sdk::actor::lookup_address(0).is_none(),
+                "system actor shouldn't have a 'predictable' address"
+            );
+        }
+        _ => sdk::vm::abort(
+            ExitCode::USR_UNHANDLED_MESSAGE.value(),
+            Some("unknown method number"),
+        ),
+    }
+    0
+}

--- a/testing/integration/tests/fil-address-actor/src/lib.rs
+++ b/testing/integration/tests/fil-address-actor/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(not(target_arch = "wasm32"))]
+include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+
+#[cfg(target_arch = "wasm32")]
+mod actor;
+
+#[cfg(target_arch = "wasm32")]
+pub use actor::invoke;


### PR DESCRIPTION
- Auto-create embryos on send.
- Allow overwriting embryo actors (used by the init actor).
- Record "predictable" addresses in state.
- Add a syscall for retrieving predictable addresses.