### PR TITLE
EVM-899: Hamt::flush short circuit on no change

### DIFF
--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -96,7 +96,7 @@ where
                 store,
                 bit_width,
                 hash: Default::default(),
-                flushed_cid: Some(cid.clone()),
+                flushed_cid: Some(*cid),
             }),
             None => Err(Error::CidNotFound(cid.to_string())),
         }
@@ -107,7 +107,7 @@ where
         match self.store.get_cbor(cid)? {
             Some(root) => {
                 self.root = root;
-                self.flushed_cid = Some(cid.clone());
+                self.flushed_cid = Some(*cid);
             }
             None => return Err(Error::CidNotFound(cid.to_string())),
         }

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -234,6 +234,10 @@ where
     }
 
     /// Internal method to modify values.
+    ///
+    /// Returns the a tuple with:
+    /// * the old data at this key, if any
+    /// * whether the data has been modified
     #[allow(clippy::too_many_arguments)]
     fn modify_value<S: Blockstore>(
         &mut self,

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -133,7 +133,7 @@ fn set_with_no_effect_does_not_put() {
     );
 
     #[rustfmt::skip]
-    assert_eq!(*store.stats.borrow(), BSStats {r:0, w:19, br:0, bw:1372});
+    assert_eq!(*store.stats.borrow(), BSStats {r:0, w:18, br:0, bw:1282});
 }
 
 #[test]
@@ -313,7 +313,7 @@ fn for_each() {
     );
 
     #[rustfmt::skip]
-    assert_eq!(*store.stats.borrow(), BSStats {r: 30, w: 31, br: 3209, bw: 4529});
+    assert_eq!(*store.stats.borrow(), BSStats {r: 30, w: 30, br: 3209, bw: 3209});
 }
 
 #[cfg(feature = "identity")]


### PR DESCRIPTION
fixes https://github.com/filecoin-project/builtin-actors/pull/709

The PR adds an optional `flushed_cid` field to the `Hamt` which is used to remember the CID it was initialized with until something changes and the `Hamt` if flushed again. If the field is set during `flush`, we have nothing to do and can return the already calculated CID. 

This saves the effort of serializing the root node and passing the data through the Wasm machinery for the CID to be calculated when there was no change made to the contents of the map.

If this PR is acceptable, it would be worth doing the same for the `Amt` in another PR.