### PR TITLE
Fix integration module

### DIFF
--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -73,11 +73,13 @@ where
         set_sys_actor(&mut state_tree, sys_state, sys_code_cid)?;
         set_init_actor(&mut state_tree, init_code_cid, init_state)?;
 
+        let code_cids = vec![sys_code_cid, init_code_cid, accounts_code_cid];
+
         Ok(Tester {
             nv,
             builtin_actors,
             executor: None,
-            code_cids: vec![],
+            code_cids,
             state_tree: Some(state_tree),
             accounts_code_cid,
         })


### PR DESCRIPTION
In order to be able to call the INIT_ACTOR using the local fvm it is required to have registered its code cid.