### PR TITLE
feat: auto-load wasm modules from blockstore

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -93,6 +93,10 @@ where
             value_received,
         }
     }
+
+    fn machine(&self) -> &<Self::CallManager as CallManager>::Machine {
+        self.call_manager.machine()
+    }
 }
 
 impl<C> DefaultKernel<C>

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -82,6 +82,9 @@ pub trait Kernel:
     ) -> Self
     where
         Self: Sized;
+
+    /// The kernel's underlying "machine".
+    fn machine(&self) -> &<Self::CallManager as CallManager>::Machine;
 }
 
 /// Network-related operations.

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -331,6 +331,10 @@ where
             data,
         )
     }
+
+    fn machine(&self) -> &<Self::CallManager as CallManager>::Machine {
+        self.0.machine()
+    }
 }
 
 impl<M, C, K> ActorOps for TestKernel<K>


### PR DESCRIPTION
In general, wasm modules should already be cached. However, pre-loading during tests is expensive, so it's nice to allow lazy loading.

This is likely still useful in M2.2. Even though the module _should_ be pre-compiled, the module cache will still be a _cache_.

Also note: A "baseline" compiler is coming to wasmtime (https://github.com/bytecodealliance/wasmtime/pull/4907) that will make lazy-loading a more viable option.

replaces #907 #714