### PR TITLE
sdk: add invocation context accessors for gas limit and premium

### DIFF
--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -41,6 +41,20 @@ pub fn value_received() -> TokenAmount {
         .expect("invalid bigint")
 }
 
+/// Returns the execution gas limit
+#[inline(always)]
+pub fn gas_limit() -> u64 {
+    INVOCATION_CONTEXT.gas_limit
+}
+
+/// Returns the execution gas premium
+pub fn gas_premium() -> TokenAmount {
+    INVOCATION_CONTEXT
+        .gas_premium
+        .try_into()
+        .expect("invalid bigint")
+}
+
 /// Returns the message codec and parameters.
 pub fn params_raw(id: BlockId) -> SyscallResult<(Codec, Vec<u8>)> {
     if id == NO_DATA_BLOCK_ID {


### PR DESCRIPTION
eaten during refactoring in #905.