### PR TITLE
Add support for legacy amt v0

### DIFF
--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -12,7 +12,8 @@ use itertools::sorted;
 
 use super::ValueMut;
 use crate::node::{CollapsedNode, Link};
-use crate::root::{RootImpl, Version as AmtVersion, V0, V3};
+use crate::root::version::{Version as AmtVersion, V0, V3};
+use crate::root::RootImpl;
 use crate::{
     init_sized_vec, nodes_for_height, Error, Node, DEFAULT_BIT_WIDTH, MAX_HEIGHT, MAX_INDEX,
 };
@@ -65,10 +66,10 @@ where
         Self::new_with_bit_width(block_store, DEFAULT_BIT_WIDTH)
     }
 
-    /// Construct new Amt with given bit width (v3)
+    /// Construct new Amt with given bit width
     pub fn new_with_bit_width(block_store: BS, bit_width: u32) -> Self {
         Self {
-            root: RootImpl::<V, Ver>::new_with_bit_width(bit_width),
+            root: RootImpl::new_with_bit_width(bit_width),
             block_store,
         }
     }

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 
 #[derive(Debug)]
+#[doc(hidden)]
 pub struct AmtImpl<V, BS, Ver> {
     root: RootImpl<V, Ver>,
     block_store: BS,
@@ -61,7 +62,7 @@ where
     BS: Blockstore,
     Ver: AmtVersion,
 {
-    /// Constructor for Root AMT node (v0)
+    /// Constructor for Root AMT node
     pub fn new(block_store: BS) -> Self {
         Self::new_with_bit_width(block_store, DEFAULT_BIT_WIDTH)
     }

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -12,9 +12,16 @@ use itertools::sorted;
 
 use super::ValueMut;
 use crate::node::{CollapsedNode, Link};
+use crate::root::RootImpl;
 use crate::{
     init_sized_vec, nodes_for_height, Error, Node, Root, DEFAULT_BIT_WIDTH, MAX_HEIGHT, MAX_INDEX,
 };
+
+#[derive(Debug)]
+pub struct AmtImpl<V, BS, const VER: u8> {
+    root: RootImpl<V, VER>,
+    block_store: BS,
+}
 
 /// Array Mapped Trie allows for the insertion and persistence of data, serializable to a CID.
 ///
@@ -37,11 +44,9 @@ use crate::{
 /// // Generate cid by calling flush to remove cache
 /// let cid = amt.flush().unwrap();
 /// ```
-#[derive(Debug)]
-pub struct Amt<V, BS> {
-    root: Root<V>,
-    block_store: BS,
-}
+pub type Amt<V, BS> = AmtImpl<V, BS, 3>;
+/// Legacy amt V0
+pub type Amtv0<V, BS> = AmtImpl<V, BS, 0>;
 
 impl<V: PartialEq, BS: Blockstore> PartialEq for Amt<V, BS> {
     fn eq(&self, other: &Self) -> bool {

--- a/ipld/amt/src/lib.rs
+++ b/ipld/amt/src/lib.rs
@@ -12,10 +12,10 @@ mod node;
 mod root;
 mod value_mut;
 
-pub use self::amt::Amt;
+pub use self::amt::{Amt, Amtv0};
 pub use self::error::Error;
 pub(crate) use self::node::Node;
-pub(crate) use self::root::Root;
+pub use self::root::Version as AmtVersion;
 pub use self::value_mut::ValueMut;
 
 const DEFAULT_BIT_WIDTH: u32 = 3;

--- a/ipld/amt/src/lib.rs
+++ b/ipld/amt/src/lib.rs
@@ -15,7 +15,6 @@ mod value_mut;
 pub use self::amt::{Amt, Amtv0};
 pub use self::error::Error;
 pub(crate) use self::node::Node;
-pub use self::root::Version as AmtVersion;
 pub use self::value_mut::ValueMut;
 
 const DEFAULT_BIT_WIDTH: u32 = 3;

--- a/ipld/amt/src/root.rs
+++ b/ipld/amt/src/root.rs
@@ -5,18 +5,25 @@ use serde::de::{self, Deserialize};
 use serde::ser::{self, Serialize};
 
 use crate::node::CollapsedNode;
-use crate::{init_sized_vec, Node};
+use crate::{init_sized_vec, Node, DEFAULT_BIT_WIDTH};
+
+const V0: u8 = 0;
+const V3: u8 = 3;
 
 /// Root of an AMT vector, can be serialized and keeps track of height and count
+pub(super) type Root<V> = RootImpl<V, 3>;
+
+pub(super) type Rootv0<V> = RootImpl<V, 0>;
+
 #[derive(PartialEq, Debug)]
-pub(super) struct Root<V> {
+pub(crate) struct RootImpl<V, const VER: u8 = V3> {
     pub bit_width: u32,
     pub height: u32,
     pub count: u64,
     pub node: Node<V>,
 }
 
-impl<V> Root<V> {
+impl<V> RootImpl<V, V3> {
     pub(super) fn new(bit_width: u32) -> Self {
         Self {
             bit_width,
@@ -29,7 +36,20 @@ impl<V> Root<V> {
     }
 }
 
-impl<V> Serialize for Root<V>
+impl<V> RootImpl<V, V0> {
+    pub(super) fn new() -> Rootv0<V> {
+        Self {
+            bit_width: crate::DEFAULT_BIT_WIDTH,
+            count: 0,
+            height: 0,
+            node: Node::Leaf {
+                vals: init_sized_vec(crate::DEFAULT_BIT_WIDTH),
+            },
+        }
+    }
+}
+
+impl<V, const VER: u8> Serialize for RootImpl<V, VER>
 where
     V: Serialize,
 {
@@ -37,11 +57,16 @@ where
     where
         S: ser::Serializer,
     {
-        (&self.bit_width, &self.height, &self.count, &self.node).serialize(s)
+        match VER {
+            // legacy amt v0 doesn't serialize bit_width as DEFAULT_BIT_WIDTH is used.
+            V0 => (&self.height, &self.count, &self.node).serialize(s),
+            V3 => (&self.bit_width, &self.height, &self.count, &self.node).serialize(s),
+            _ => unreachable!(),
+        }
     }
 }
 
-impl<'de, V> Deserialize<'de> for Root<V>
+impl<'de, V> Deserialize<'de> for RootImpl<V, V3>
 where
     V: Deserialize<'de>,
 {
@@ -60,6 +85,29 @@ where
     }
 }
 
+// Deserialize impl for legacy amt v0
+impl<'de, V> Deserialize<'de> for RootImpl<V, V0>
+where
+    V: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        // legacy amt v0 doesn't include bit_width as DEFAULT_BIT_WIDTH is used.
+        let (height, count, node): (_, _, CollapsedNode<V>) =
+            Deserialize::deserialize(deserializer)?;
+        Ok(Self {
+            bit_width: crate::DEFAULT_BIT_WIDTH,
+            height,
+            count,
+            node: node
+                .expand(crate::DEFAULT_BIT_WIDTH)
+                .map_err(de::Error::custom)?,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use fvm_ipld_encoding::{from_slice, to_vec};
@@ -74,5 +122,15 @@ mod tests {
         root.node = Node::Leaf { vals: vec![None] };
         let rbz = to_vec(&root).unwrap();
         assert_eq!(from_slice::<Root<String>>(&rbz).unwrap(), root);
+    }
+
+    #[test]
+    fn serialize_deserialize_legacy_amt() {
+        let mut root: Rootv0<_> = Rootv0::new();
+        root.height = 2;
+        root.count = 1;
+        root.node = Node::Leaf {vals: vec![None]};
+        let rbz = to_vec(&root).unwrap();
+        assert_eq!(from_slice::<Rootv0<String>>(&rbz).unwrap(), root); // FIXME: fails currently
     }
 }

--- a/ipld/amt/src/root.rs
+++ b/ipld/amt/src/root.rs
@@ -28,11 +28,6 @@ pub(crate) mod version {
     }
 }
 
-/// Root of an AMT vector, can be serialized and keeps track of height and count
-type Root<V> = RootImpl<V, self::version::V3>;
-/// Legacy AMT v0, used to read block headers.
-type Rootv0<V> = RootImpl<V, self::version::V0>;
-
 #[derive(PartialEq, Debug)]
 pub(crate) struct RootImpl<V, Ver> {
     pub bit_width: u32,
@@ -50,20 +45,6 @@ impl<V, Ver> RootImpl<V, Ver> {
             height: 0,
             node: Node::Leaf {
                 vals: init_sized_vec(bit_width),
-            },
-            ver: PhantomData,
-        }
-    }
-}
-
-impl<V> RootImpl<V, self::version::V0> {
-    pub(crate) fn new() -> Rootv0<V> {
-        Self {
-            bit_width: DEFAULT_BIT_WIDTH,
-            count: 0,
-            height: 0,
-            node: Node::Leaf {
-                vals: init_sized_vec(DEFAULT_BIT_WIDTH),
             },
             ver: PhantomData,
         }
@@ -131,6 +112,25 @@ mod tests {
     use fvm_ipld_encoding::{from_slice, to_vec};
 
     use super::*;
+
+    /// Root of an AMT vector, can be serialized and keeps track of height and count
+    type Root<V> = RootImpl<V, self::version::V3>;
+    /// Legacy AMT v0, used to read block headers.
+    type Rootv0<V> = RootImpl<V, self::version::V0>;
+
+    impl<V> RootImpl<V, self::version::V0> {
+        pub(crate) fn new() -> Rootv0<V> {
+            Self {
+                bit_width: DEFAULT_BIT_WIDTH,
+                count: 0,
+                height: 0,
+                node: Node::Leaf {
+                    vals: init_sized_vec(DEFAULT_BIT_WIDTH),
+                },
+                ver: PhantomData,
+            }
+        }
+    }
 
     #[test]
     fn serialize_symmetric() {

--- a/ipld/amt/src/root.rs
+++ b/ipld/amt/src/root.rs
@@ -29,9 +29,9 @@ pub(crate) mod version {
 }
 
 /// Root of an AMT vector, can be serialized and keeps track of height and count
-pub(super) type Root<V> = RootImpl<V, self::version::V3>;
+type Root<V> = RootImpl<V, self::version::V3>;
 /// Legacy AMT v0, used to read block headers.
-pub(super) type Rootv0<V> = RootImpl<V, self::version::V0>;
+type Rootv0<V> = RootImpl<V, self::version::V0>;
 
 #[derive(PartialEq, Debug)]
 pub(crate) struct RootImpl<V, Ver> {
@@ -43,7 +43,7 @@ pub(crate) struct RootImpl<V, Ver> {
 }
 
 impl<V, Ver> RootImpl<V, Ver> {
-    pub(super) fn new_with_bit_width(bit_width: u32) -> Self {
+    pub(crate) fn new_with_bit_width(bit_width: u32) -> Self {
         Self {
             bit_width,
             count: 0,

--- a/ipld/amt/src/root.rs
+++ b/ipld/amt/src/root.rs
@@ -9,27 +9,29 @@ use serde::ser::{self, Serialize};
 use crate::node::CollapsedNode;
 use crate::{init_sized_vec, Node, DEFAULT_BIT_WIDTH};
 
-#[derive(PartialEq, Debug)]
-pub struct V0;
-#[derive(PartialEq, Debug)]
-pub struct V3;
+pub(crate) mod version {
+    #[derive(PartialEq, Debug)]
+    pub struct V0;
+    #[derive(PartialEq, Debug)]
+    pub struct V3;
 
-pub trait Version {
-    const NUMBER: usize;
-}
+    pub trait Version {
+        const NUMBER: usize;
+    }
 
-impl Version for V0 {
-    const NUMBER: usize = 0;
-}
+    impl Version for V0 {
+        const NUMBER: usize = 0;
+    }
 
-impl Version for V3 {
-    const NUMBER: usize = 3;
+    impl Version for V3 {
+        const NUMBER: usize = 3;
+    }
 }
 
 /// Root of an AMT vector, can be serialized and keeps track of height and count
-pub(super) type Root<V> = RootImpl<V, V3>;
+pub(super) type Root<V> = RootImpl<V, self::version::V3>;
 /// Legacy AMT v0, used to read block headers.
-pub(super) type Rootv0<V> = RootImpl<V, V0>;
+pub(super) type Rootv0<V> = RootImpl<V, self::version::V0>;
 
 #[derive(PartialEq, Debug)]
 pub(crate) struct RootImpl<V, Ver> {
@@ -54,7 +56,7 @@ impl<V, Ver> RootImpl<V, Ver> {
     }
 }
 
-impl<V> RootImpl<V, V0> {
+impl<V> RootImpl<V, self::version::V0> {
     pub(crate) fn new() -> Rootv0<V> {
         Self {
             bit_width: DEFAULT_BIT_WIDTH,
@@ -71,7 +73,7 @@ impl<V> RootImpl<V, V0> {
 impl<V, Ver> Serialize for RootImpl<V, Ver>
 where
     V: Serialize,
-    Ver: Version,
+    Ver: self::version::Version,
 {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
@@ -89,7 +91,7 @@ where
 impl<'de, V, Ver> Deserialize<'de> for RootImpl<V, Ver>
 where
     V: Deserialize<'de>,
-    Ver: Version,
+    Ver: self::version::Version,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/ipld/amt/src/root.rs
+++ b/ipld/amt/src/root.rs
@@ -39,11 +39,11 @@ impl<V> RootImpl<V, V3> {
 impl<V> RootImpl<V, V0> {
     pub(crate) fn new() -> Rootv0<V> {
         Self {
-            bit_width: crate::DEFAULT_BIT_WIDTH,
+            bit_width: DEFAULT_BIT_WIDTH,
             count: 0,
             height: 0,
             node: Node::Leaf {
-                vals: init_sized_vec(crate::DEFAULT_BIT_WIDTH),
+                vals: init_sized_vec(DEFAULT_BIT_WIDTH),
             },
         }
     }
@@ -90,12 +90,10 @@ where
                 let (height, count, node): (_, _, CollapsedNode<V>) =
                     Deserialize::deserialize(deserializer)?;
                 Ok(Self {
-                    bit_width: crate::DEFAULT_BIT_WIDTH,
+                    bit_width: DEFAULT_BIT_WIDTH,
                     height,
                     count,
-                    node: node
-                        .expand(crate::DEFAULT_BIT_WIDTH)
-                        .map_err(de::Error::custom)?,
+                    node: node.expand(DEFAULT_BIT_WIDTH).map_err(de::Error::custom)?,
                 })
             }
             _ => unreachable!(),
@@ -114,9 +112,7 @@ mod tests {
         let mut root = Root::new(0);
         root.height = 2;
         root.count = 1;
-        root.node = Node::Leaf {
-            vals: vec![None, None],
-        };
+        root.node = Node::Leaf { vals: vec![None] };
         let rbz = to_vec(&root).unwrap();
         assert_eq!(from_slice::<Root<String>>(&rbz).unwrap(), root);
     }
@@ -130,6 +126,18 @@ mod tests {
             vals: vec![None; 8],
         };
         let rbz = to_vec(&root).unwrap();
-        assert_eq!(from_slice::<Rootv0<String>>(&rbz).unwrap(), root); // FIXME: fails currently
+        assert_eq!(from_slice::<Rootv0<String>>(&rbz).unwrap(), root);
+    }
+
+    #[test]
+    fn serialize_deserialize_v3_v0() {
+        let mut root: Root<_> = Root::new(3);
+        root.height = 2;
+        root.count = 1;
+        root.node = Node::Leaf {
+            vals: vec![None; 8],
+        };
+        let rbz = to_vec(&root).unwrap();
+        assert_eq!(from_slice::<Root<String>>(&rbz).unwrap(), root);
     }
 }

--- a/ipld/amt/src/root.rs
+++ b/ipld/amt/src/root.rs
@@ -10,9 +10,9 @@ use crate::node::CollapsedNode;
 use crate::{init_sized_vec, Node, DEFAULT_BIT_WIDTH};
 
 pub(crate) mod version {
-    #[derive(PartialEq, Debug)]
+    #[derive(PartialEq, Eq, Debug)]
     pub struct V0;
-    #[derive(PartialEq, Debug)]
+    #[derive(PartialEq, Eq, Debug)]
     pub struct V3;
 
     pub trait Version {
@@ -152,25 +152,5 @@ mod tests {
         };
         let rbz = to_vec(&root).unwrap();
         assert_eq!(from_slice::<Rootv0<String>>(&rbz).unwrap(), root);
-    }
-
-    #[test]
-    fn serialize_deserialize_from_v3_to_v0() {
-        let mut root: Root<String> = Root::new_with_bit_width(3);
-        root.height = 2;
-        root.count = 1;
-        root.node = Node::Leaf {
-            vals: vec![None; 8],
-        };
-        let rbz = to_vec(&root).unwrap();
-
-        let mut root_v0: Rootv0<_> = Rootv0::new();
-        root_v0.height = 2;
-        root_v0.count = 1;
-        root_v0.node = Node::Leaf {
-            vals: vec![None; 8],
-        };
-
-        assert_eq!(from_slice::<Rootv0<String>>(&rbz).unwrap(), root_v0);
     }
 }

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -51,6 +51,9 @@ fn basic_get_set() {
 }
 
 #[test]
+fn foo() {}
+
+#[test]
 fn legacy_amtv0_basic_get_set() {
     let mem = MemoryBlockstore::default();
     let db = TrackingBlockstore::new(&mem);

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -51,9 +51,6 @@ fn basic_get_set() {
 }
 
 #[test]
-fn foo() {}
-
-#[test]
 fn legacy_amtv0_basic_get_set() {
     let mem = MemoryBlockstore::default();
     let db = TrackingBlockstore::new(&mem);


### PR DESCRIPTION
This PR adds support for serializing and deserializing amt v0 data structures, which are still used in filecoin for reading headers etc.

Fixes: #924 