### PR TITLE
feat: simplify syscall returns

### DIFF
--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -188,10 +188,10 @@ pub trait ActorOps {
     /// Resolves an address of any protocol to an ID address (via the Init actor's table).
     /// This allows resolution of externally-provided SECP, BLS, or actor addresses to the canonical form.
     /// If the argument is an ID address it is returned directly.
-    fn resolve_address(&self, address: &Address) -> Result<Option<ActorID>>;
+    fn resolve_address(&self, address: &Address) -> Result<ActorID>;
 
     /// Look up the code CID of an actor.
-    fn get_actor_code_cid(&self, id: ActorID) -> Result<Option<Cid>>;
+    fn get_actor_code_cid(&self, id: ActorID) -> Result<Cid>;
 
     /// Computes an address for a new actor. The returned address is intended to uniquely refer to
     /// the actor even in the event of a chain re-org (whereas an ID-address might refer to a

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -11,10 +11,7 @@ pub fn resolve_address(
     addr_len: u32,
 ) -> Result<u64> {
     let addr = context.memory.read_address(addr_off, addr_len)?;
-    let actor_id = context
-        .kernel
-        .resolve_address(&addr)?
-        .ok_or_else(|| syscall_error!(NotFound; "actor not found"))?;
+    let actor_id = context.kernel.resolve_address(&addr)?;
     Ok(actor_id)
 }
 
@@ -27,10 +24,7 @@ pub fn get_actor_code_cid(
     // We always check arguments _first_, before we do anything else.
     context.memory.check_bounds(obuf_off, obuf_len)?;
 
-    let typ = context
-        .kernel
-        .get_actor_code_cid(actor_id)?
-        .ok_or_else(|| syscall_error!(NotFound; "target actor not found"))?;
+    let typ = context.kernel.get_actor_code_cid(actor_id)?;
 
     context.memory.write_cid(&typ, obuf_off, obuf_len)
 }

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -349,11 +349,11 @@ where
     C: CallManager<Machine = TestMachine<M>>,
     K: Kernel<CallManager = TestCallManager<C>>,
 {
-    fn resolve_address(&self, address: &Address) -> Result<Option<ActorID>> {
+    fn resolve_address(&self, address: &Address) -> Result<ActorID> {
         self.0.resolve_address(address)
     }
 
-    fn get_actor_code_cid(&self, id: ActorID) -> Result<Option<Cid>> {
+    fn get_actor_code_cid(&self, id: ActorID) -> Result<Cid> {
         self.0.get_actor_code_cid(id)
     }
 


### PR DESCRIPTION
Some history:

- At first, we returned an Option because these syscalls would return a special sentinel value for "not found".
- Then we changed the syscalls to return the NotFound error code, but we never updated the kernel methods.

Now, I'm adding another kernel method. But in my case, to keep this pattern, I'd need to return `Option<Option<Address>>`... so I'm proposing that we change these other kernel functions instead.