### PR TITLE
EVM-892: Add min_data_depth option.

### DIFF
--- a/ipld/hamt/fuzz/fuzz_targets/extensions.rs
+++ b/ipld/hamt/fuzz/fuzz_targets/extensions.rs
@@ -12,6 +12,7 @@ fuzz_target!(|data: (u8, Vec<common::Operation>)| {
     let conf = Config {
         bit_width: 2,
         use_extensions: true,
+        min_data_depth: 1,
     };
     common::run(flush_rate, operations, conf);
 });

--- a/ipld/hamt/src/lib.rs
+++ b/ipld/hamt/src/lib.rs
@@ -51,6 +51,20 @@ pub struct Config {
     ///
     /// It's also safe to disable it, the code will still handle extensions that already exist.
     pub use_extensions: bool,
+    /// The minimum depth at which the HAMT can store key-value pairs in a `Node`.
+    ///
+    /// Storing values in the nodes means we have to read and write larger chunks of data
+    /// whenever we're accessing something (be it a link or values) in any other bucket.
+    /// This is particularly costly in the root node, which is always retrieved as soon
+    /// as the HAMT is instantiated.
+    ///
+    /// This setting allows us to keep the root, and possibly a few more levels, free of
+    /// data, reserved for links. A sufficiently saturated tree will tend to contain only
+    /// links in the first levels anyway, once all the buckets have been filled and pushed
+    /// further down.
+    ///
+    /// A value of 0 means data can be put in the root node, which is the default behaviour.
+    pub min_data_depth: u32,
 }
 
 impl Default for Config {
@@ -58,6 +72,7 @@ impl Default for Config {
         Self {
             bit_width: DEFAULT_BIT_WIDTH,
             use_extensions: false,
+            min_data_depth: 0,
         }
     }
 }

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -187,14 +187,13 @@ where
         Q: Eq + Hash,
     {
         let hash = H::hash(q);
-        self.get_value(&mut HashBits::new(&hash), conf, 0, q, store)
+        self.get_value(&mut HashBits::new(&hash), conf, q, store)
     }
 
     fn get_value<Q: ?Sized, S: Blockstore>(
         &self,
         hashed_key: &mut HashBits,
         conf: &Config,
-        depth: u32,
         key: &Q,
         store: &S,
     ) -> Result<Option<&KeyValuePair<K, V>>, Error>
@@ -239,9 +238,7 @@ where
         };
 
         match match_extension(conf, hashed_key, ext)? {
-            ExtensionMatch::Full { skipped } => {
-                node.get_value(hashed_key, conf, depth + 1 + skipped, key, store)
-            }
+            ExtensionMatch::Full { .. } => node.get_value(hashed_key, conf, key, store),
             ExtensionMatch::Partial { .. } => Ok(None),
         }
     }

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -161,7 +161,13 @@ where
 
     /// Internal method to cleanup children, to ensure consistent tree representation
     /// after deletes.
-    pub(crate) fn clean(&mut self, conf: &Config) -> Result<(), Error> {
+    pub(crate) fn clean(&mut self, conf: &Config, depth: u32) -> Result<(), Error> {
+        // All cleaning is about bringing `Pointer::Values` up a level if that's the only
+        // content in the node. If we're in the shallows where we don't want to keep data
+        // we can skip cleaning completely.
+        if depth < conf.min_data_depth {
+            return Ok(());
+        }
         match self {
             Pointer::Dirty { node: n, ext: ext1 } => match n.pointers.len() {
                 0 => Err(Error::ZeroPointers),

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -880,6 +880,28 @@ test_hamt_mod!(
         conf: Config {
             use_extensions: true,
             bit_width: 1, // Use smaller bit width to induce more overlap in key prefixes
+            min_data_depth: 0,
+        },
+    }
+);
+
+test_hamt_mod!(
+    test_min_data_depth,
+    HamtFactory {
+        conf: Config {
+            use_extensions: false,
+            bit_width: 4,
+            min_data_depth: 1,
+        },
+    }
+);
+
+test_hamt_mod!(
+    test_min_data_depth_with_extensions,
+    HamtFactory {
+        conf: Config {
+            use_extensions: true,
+            bit_width: 2,
             min_data_depth: 1,
         },
     }

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -880,6 +880,7 @@ test_hamt_mod!(
         conf: Config {
             use_extensions: true,
             bit_width: 1, // Use smaller bit width to induce more overlap in key prefixes
+            min_data_depth: 1,
         },
     }
 );


### PR DESCRIPTION
part of https://github.com/filecoin-project/ref-fvm/issues/892 

Adds an option to the HAMT `Config` to keep the first N levels of the tree free of key-value pairs, reserved for routing links. The motivation is to reduce the write amplification we observed in https://github.com/filecoin-project/ref-fvm/issues/888

This should help with the `mapping` type that Solidity puts in random keys in the HAMT which weight down on everything by saturating the root node and then its children with data. 

Unfortunately we also want the top level variables to be easily accessible, they would be okayish to be in the root node (unless perhaps if they are fixed size arrays stored inline). This would be an awkward setting for the HAMT to have, though. Also if there are enough top level variables their keys will all look like `000...01`, `000...10` etc, so they will most likely fill the first bucket in the root node (takes 3*256 bits) and rely on the extension mechanism to keep them from going all the way down to level 32.