### PR TITLE
FIX: HashBits::next when bit_width does not divide 256 and the full hash is consumed

### DIFF
--- a/ipld/hamt/src/hash_bits.rs
+++ b/ipld/hamt/src/hash_bits.rs
@@ -33,7 +33,7 @@ impl<'a> HashBits<'a> {
     /// Returns next `i` bits of the hash and returns the value as an integer and returns
     /// Error when maximum depth is reached
     pub fn next(&mut self, i: u32) -> Result<u32, Error> {
-        if i > 8 {
+        if i > 8 || i == 0 {
             return Err(Error::InvalidHashBitLen);
         }
         if (self.consumed + i) as usize > self.b.len() * 8 {
@@ -100,5 +100,18 @@ mod tests {
             hb.next(8).unwrap();
         }
         assert!(matches!(hb.next(1), Err(Error::MaxDepth)));
+    }
+
+    #[test]
+    fn test_partial_last_bits() {
+        let mut key: HashedKey = Default::default();
+        key[31] = 0b00000001;
+        let bit_width = 5;
+        let mut hb = HashBits::new(&key);
+        for _ in 0..(256 / bit_width) {
+            hb.next(bit_width).unwrap();
+        }
+        assert!(matches!(hb.next(bit_width), Ok(1)));
+        assert!(matches!(hb.next(bit_width), Err(Error::MaxDepth)));
     }
 }

--- a/ipld/hamt/src/hash_bits.rs
+++ b/ipld/hamt/src/hash_bits.rs
@@ -36,10 +36,13 @@ impl<'a> HashBits<'a> {
         if i > 8 || i == 0 {
             return Err(Error::InvalidHashBitLen);
         }
-        if (self.consumed + i) as usize > self.b.len() * 8 {
+        let maxi = (self.b.len() as u32) * 8 - self.consumed;
+        if maxi == 0 {
             return Err(Error::MaxDepth);
         }
-        Ok(self.next_bits(i))
+        // Only take what's left. If we consume 5 bits at a time from a 256 bit key,
+        // there will be 1 bit left at the bottom.
+        Ok(self.next_bits(std::cmp::min(i, maxi)))
     }
 
     fn next_bits(&mut self, i: u32) -> u32 {


### PR DESCRIPTION
Fixes `HashBits::next` returned an error when we have consumed all but the last bits of a key, and what's left is less than the bit width. The PR changes it so that it consumes whatever is left, and only fails on the next call when the whole key has already been consumed. 

The following table shows width of the last chunk of the 32 byte long hash with various bit widths:

| bit_width | last nibble width |
|-|-|
8 | 8 
7 | 4 
6 | 4
5 | 1
4 | 4
3 | 1
2 | 2
1 | 1

The reason this probably hasn't come up before is that with hashing it's very unlikely that to keys share all but their last bits. However with the hybrid hashing+offset based strategy used by Solidity this is exactly what happens for arrays, and then some bit widths work while others don't.