### PR TITLE
chore: use rust 2021 edition

### DIFF
--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -4,7 +4,7 @@ description = "Sharded IPLD Array implementation."
 version = "0.4.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]

--- a/ipld/amt/fuzz/Cargo.toml
+++ b/ipld/amt/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "ipld_amt_fuzz"
 version = "0.0.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/ipld/blockstore/Cargo.toml
+++ b/ipld/blockstore/Cargo.toml
@@ -4,7 +4,7 @@ description = "Sharded IPLD Blockstore."
 version = "0.1.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -3,7 +3,7 @@ name = "fvm_ipld_car"
 description = "IPLD CAR handling library"
 version = "0.5.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/filecoin-project/ref-fvm"
 

--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -4,7 +4,7 @@ description = "Sharded IPLD encoding."
 version = "0.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -4,7 +4,7 @@ description = "Sharded IPLD HashMap implementation."
 version = "0.5.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]

--- a/ipld/hamt/fuzz/Cargo.toml
+++ b/ipld/hamt/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "ipld_hamt-fuzz"
 version = "0.0.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -4,7 +4,7 @@ description = "Filecoin Virtual Machine actor development SDK"
 version = "3.0.0-alpha.2"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [lib]


### PR DESCRIPTION
It's nearly the end of 2022, and there are some nice features (e.g., better format strings).