### PR TITLE
Import serde_bytes in-tree and make it work with arrays

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -19,11 +19,11 @@ derive_builder = "0.11.2"
 num-derive = "0.3.3"
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.3", default-features = false }
-fvm_shared = { version = "3.0.0-alpha.4", path = "../shared", features = ["crypto"] }
-fvm_ipld_hamt = { version = "0.5.1", path = "../ipld/hamt"}
-fvm_ipld_amt = { version = "0.4.2", path = "../ipld/amt"}
+fvm_shared = { version = "3.0.0-alpha.5", path = "../shared", features = ["crypto"] }
+fvm_ipld_hamt = { version = "0.6.0", path = "../ipld/hamt"}
+fvm_ipld_amt = { version = "0.5.0", path = "../ipld/amt"}
 fvm_ipld_blockstore = { version = "0.1.1", path = "../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.2.2", path = "../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.0", path = "../ipld/encoding" }
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = "0.5"
 serde_repr = "0.1"

--- a/ipld/amt/CHANGELOG.md
+++ b/ipld/amt/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 0.5.0
+
+- Bumps `fvm_ipld_encoding` and switches from `cs_serde_bytes` to `fvm_ipld_encoding::strict_bytes`.
+
 ## 0.4.2
 
 - Return the correct value from `batch_delete`.

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_amt"
 description = "Sharded IPLD Array implementation."
-version = "0.4.2"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -16,7 +16,7 @@ ahash = { version = "0.8", optional = true }
 itertools = "0.10"
 anyhow = "1.0.51"
 fvm_ipld_blockstore = { version = "0.1", path = "../blockstore" }
-fvm_ipld_encoding = { version = "0.2", path = "../encoding" }
+fvm_ipld_encoding = { version = "0.3", path = "../encoding" }
 
 [features]
 go-interop = ["ahash"]

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::{serde_bytes, BytesSer, CborStore};
+use fvm_ipld_encoding::{strict_bytes, BytesSer, CborStore};
 use once_cell::unsync::OnceCell;
 use serde::de::{self, DeserializeOwned};
 use serde::{ser, Deserialize, Serialize};
@@ -117,7 +117,7 @@ where
 }
 
 #[derive(Serialize, Deserialize)]
-pub(crate) struct CollapsedNode<V>(#[serde(with = "serde_bytes")] Vec<u8>, Vec<Cid>, Vec<V>);
+pub(crate) struct CollapsedNode<V>(#[serde(with = "strict_bytes")] Vec<u8>, Vec<Cid>, Vec<V>);
 
 impl<V> CollapsedNode<V> {
     pub(crate) fn expand(self, bit_width: u32) -> Result<Node<V>, Error> {

--- a/ipld/bitfield/CHANGELOG.md
+++ b/ipld/bitfield/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to Filecoin's Bitfield library.
 
 ## [Unreleased]
 
+## 0.5.4 [2022-10-11]
+
+- Bumps `fvm_ipld_encoding` and switches from `cs_serde_bytes` to `fvm_ipld_encoding::strict_bytes`.
+
 ## 0.5.3 [2022-09-12]
 
 - Optimize no-op operations.

--- a/ipld/bitfield/Cargo.toml
+++ b/ipld/bitfield/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_bitfield"
 description = "Bitfield logic for use in Filecoin actors"
-version = "0.5.3"
+version = "0.5.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -12,7 +12,7 @@ unsigned-varint = "0.7.1"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.30"
 arbitrary = { version = "1.1.0", optional = true}
-fvm_ipld_encoding = { version = "0.2", path = "../encoding" }
+fvm_ipld_encoding = { version = "0.3", path = "../encoding" }
 
 [dev-dependencies]
 rand_xorshift = "0.3.0"

--- a/ipld/bitfield/Cargo.toml
+++ b/ipld/bitfield/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 [dependencies]
 unsigned-varint = "0.7.1"
 serde = { version = "1.0", features = ["derive"] }
-serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
 thiserror = "1.0.30"
 arbitrary = { version = "1.1.0", optional = true}
 fvm_ipld_encoding = { version = "0.2", path = "../encoding" }

--- a/ipld/bitfield/src/rleplus/mod.rs
+++ b/ipld/bitfield/src/rleplus/mod.rs
@@ -70,6 +70,7 @@ use std::borrow::Cow;
 #[cfg(feature = "enable-arbitrary")]
 use arbitrary::{size_hint, Arbitrary, Unstructured};
 pub use error::Error;
+use fvm_ipld_encoding::serde_bytes;
 pub use reader::BitReader;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub use writer::BitWriter;

--- a/ipld/bitfield/src/rleplus/mod.rs
+++ b/ipld/bitfield/src/rleplus/mod.rs
@@ -70,7 +70,7 @@ use std::borrow::Cow;
 #[cfg(feature = "enable-arbitrary")]
 use arbitrary::{size_hint, Arbitrary, Unstructured};
 pub use error::Error;
-use fvm_ipld_encoding::serde_bytes;
+use fvm_ipld_encoding::strict_bytes;
 pub use reader::BitReader;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub use writer::BitWriter;
@@ -90,7 +90,7 @@ impl Serialize for BitField {
                 bytes.len()
             )));
         }
-        serde_bytes::serialize(&bytes, serializer)
+        strict_bytes::serialize(&bytes, serializer)
     }
 }
 
@@ -99,7 +99,7 @@ impl<'de> Deserialize<'de> for BitField {
     where
         D: Deserializer<'de>,
     {
-        let bytes: Cow<'de, [u8]> = serde_bytes::deserialize(deserializer)?;
+        let bytes: Cow<'de, [u8]> = strict_bytes::deserialize(deserializer)?;
         if bytes.len() > MAX_ENCODED_SIZE {
             return Err(serde::de::Error::custom(format!(
                 "encoded bitfield was too large {}",

--- a/ipld/bitfield/src/unvalidated.rs
+++ b/ipld/bitfield/src/unvalidated.rs
@@ -3,7 +3,7 @@
 
 use std::convert::TryFrom;
 
-use fvm_ipld_encoding::serde_bytes;
+use fvm_ipld_encoding::strict_bytes;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::BitField;
@@ -36,7 +36,7 @@ impl<'a> Validate<'a> for &'a BitField {
 #[serde(untagged)]
 pub enum UnvalidatedBitField {
     Validated(BitField),
-    Unvalidated(#[serde(with = "serde_bytes")] Vec<u8>),
+    Unvalidated(#[serde(with = "strict_bytes")] Vec<u8>),
 }
 
 impl UnvalidatedBitField {
@@ -94,7 +94,7 @@ impl<'de> Deserialize<'de> for UnvalidatedBitField {
     where
         D: Deserializer<'de>,
     {
-        let bytes: Vec<u8> = serde_bytes::deserialize(deserializer)?;
+        let bytes: Vec<u8> = strict_bytes::deserialize(deserializer)?;
         if bytes.len() > MAX_ENCODED_SIZE {
             return Err(serde::de::Error::custom(format!(
                 "encoded bitfield was too large {}",

--- a/ipld/car/CHANGELOG.md
+++ b/ipld/car/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the FVM's CAR implementation.
 
 ## [Unreleased]
 
+## 0.6.0 [2022-10-11]
+
+- Bumps `fvm_ipld_encoding` and switches from `cs_serde_bytes` to `fvm_ipld_encoding::strict_bytes`.
+
 ## 0.5.0 [2022-08-03]
 
 This release includes several CAR sanity checks and validations.

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_car"
 description = "IPLD CAR handling library"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ thiserror = "1.0"
 futures = "0.3.5"
 integer-encoding = { version = "3.0", features = ["futures_async"] }
 fvm_ipld_blockstore = { version = "0.1", path = "../blockstore" }
-fvm_ipld_encoding = { version = "0.2", path = "../encoding" }
+fvm_ipld_encoding = { version = "0.3", path = "../encoding" }
 
 [dev-dependencies]
 async-std = { version = "1.9", features = ["attributes"] }

--- a/ipld/encoding/CHANGELOG.md
+++ b/ipld/encoding/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 Changes to the FVM's shared encoding utilities.
 
-## [Unreleased]
+## 0.3.0 [2022-10-11]
 
-Publicly use `serde` to expose it when developing actors.
+- Publicly use `serde` to expose it when developing actors.
+- Expose a new `strict_bytes` module based on `serde_bytes`. This new module:
+    - Refuses to decode anything that's not "bytes" (like `cs_serde_bytes`).
+    - Can also decode into a fixed-sized array.
+    - Has ~1% of the code of upstream.
 
 ## 0.2.2 [2022-06-13]
 

--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
 serde_ipld_dagcbor = "0.2.2"
 serde_tuple = "0.5"
 serde_repr = "0.1"

--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_encoding"
 description = "Sharded IPLD encoding."
-version = "0.2.2"
+version = "0.3.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/ipld/encoding/src/bytes.rs
+++ b/ipld/encoding/src/bytes.rs
@@ -3,9 +3,10 @@
 
 /// A much simplified version of serde_bytes that:
 ///
-/// 1. Refuses to decode strings/arrays into "bytes".
+/// 1. Refuses to decode strings/arrays into "bytes", only accepting "bytes" (hence the "strict"
+///    part).
 /// 2. Can decode to/from byte arrays.
-pub mod serde_bytes {
+pub mod strict_bytes {
     use std::borrow::Cow;
     use std::fmt;
 
@@ -166,15 +167,18 @@ pub mod serde_bytes {
     }
 }
 
-pub use serde_bytes::ByteBuf as BytesDe;
+pub use strict_bytes::ByteBuf as BytesDe;
 
 /// Wrapper for serializing slice of bytes.
 #[derive(serde::Serialize)]
 #[serde(transparent)]
-pub struct BytesSer<'a>(#[serde(with = "serde_bytes")] pub &'a [u8]);
+pub struct BytesSer<'a>(#[serde(with = "strict_bytes")] pub &'a [u8]);
 
 pub fn bytes_32(buf: &[u8]) -> [u8; 32] {
     let mut array = [0; 32];
     array.copy_from_slice(buf.as_ref());
     array
 }
+
+#[deprecated = "Use strict_bytes. serde_bytes is a deprecated alias."]
+pub use strict_bytes as serde_bytes;

--- a/ipld/encoding/src/bytes.rs
+++ b/ipld/encoding/src/bytes.rs
@@ -1,65 +1,180 @@
-// Copyright 2019-2022 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems, David Tolnay (serde)
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-use serde_bytes::ByteBuf;
+/// A much simplified version of serde_bytes that:
+///
+/// 1. Refuses to decode strings/arrays into "bytes".
+/// 2. Can decode to/from byte arrays.
+pub mod serde_bytes {
+    use std::borrow::Cow;
+    use std::fmt;
 
-/// Wrapper for serializing slice of bytes.
-#[derive(Serialize)]
-#[serde(transparent)]
-pub struct BytesSer<'a>(#[serde(with = "serde_bytes")] pub &'a [u8]);
+    use serde::de::{Error, Visitor};
+    pub use serde::{Deserializer, Serializer};
 
-/// Wrapper for deserializing dynamic sized Bytes.
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
-#[serde(transparent)]
-pub struct BytesDe(#[serde(with = "serde_bytes")] pub Vec<u8>);
+    pub trait Deserialize<'de>: Sized {
+        #[allow(missing_docs)]
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>;
+    }
 
-/// Wrapper for deserializing array of 32 Bytes.
-pub struct Byte32De(pub [u8; 32]);
+    pub trait Serialize {
+        #[allow(missing_docs)]
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer;
+    }
 
-impl Serialize for Byte32De {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    impl<T: ?Sized> Serialize for T
     where
+        T: AsRef<[u8]>,
+    {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_bytes(self.as_ref())
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Vec<u8> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct VecVisitor;
+
+            impl<'de> Visitor<'de> for VecVisitor {
+                type Value = Vec<u8>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("byte array")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Vec<u8>, E>
+                where
+                    E: Error,
+                {
+                    Ok(v.into())
+                }
+
+                fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Vec<u8>, E>
+                where
+                    E: Error,
+                {
+                    Ok(v)
+                }
+            }
+            deserializer.deserialize_byte_buf(VecVisitor)
+        }
+    }
+
+    impl<'de: 'a, 'a> Deserialize<'de> for Cow<'a, [u8]> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct CowVisitor;
+
+            impl<'de> Visitor<'de> for CowVisitor {
+                type Value = Cow<'de, [u8]>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("a byte array")
+                }
+
+                fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+                where
+                    E: Error,
+                {
+                    Ok(Cow::Borrowed(v))
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: Error,
+                {
+                    Ok(Cow::Owned(v.to_vec()))
+                }
+
+                fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+                where
+                    E: Error,
+                {
+                    Ok(Cow::Owned(v))
+                }
+            }
+            deserializer.deserialize_bytes(CowVisitor)
+        }
+    }
+
+    impl<'de, const L: usize> Deserialize<'de> for [u8; L] {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct ArrVisitor<const S: usize>;
+            impl<'de, const S: usize> Visitor<'de> for ArrVisitor<S> {
+                type Value = [u8; S];
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    write!(formatter, "a {}byte array", S)
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: Error,
+                {
+                    if v.len() != S {
+                        return Err(serde::de::Error::invalid_length(v.len(), &self));
+                    }
+                    let mut array = [0; S];
+                    array.copy_from_slice(v);
+                    Ok(array)
+                }
+            }
+            deserializer.deserialize_bytes(ArrVisitor)
+        }
+    }
+
+    /// Wrapper for serializing and deserializing dynamic sized Bytes.
+    #[derive(serde::Deserialize, serde::Serialize, Debug, Eq, PartialEq, Clone)]
+    #[serde(transparent)]
+    pub struct ByteBuf(#[serde(with = "self")] pub Vec<u8>);
+
+    impl ByteBuf {
+        pub fn into_vec(self) -> Vec<u8> {
+            self.0
+        }
+    }
+
+    pub fn serialize<T, S>(bytes: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: ?Sized + AsRef<[u8]>,
         S: Serializer,
     {
-        <[u8] as serde_bytes::Serialize>::serialize(&self.0, serializer)
+        Serialize::serialize(bytes.as_ref(), serializer)
+    }
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        Deserialize::deserialize(deserializer)
     }
 }
 
-impl<'de> Deserialize<'de> for Byte32De {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let bz_buf: ByteBuf = Deserialize::deserialize(deserializer)?;
-        if bz_buf.len() != 32 {
-            return Err(de::Error::custom("Array of bytes not length 32"));
-        }
-        let mut array = [0; 32];
-        array.copy_from_slice(bz_buf.as_ref());
-        Ok(Byte32De(array))
-    }
-}
+pub use serde_bytes::ByteBuf as BytesDe;
+
+/// Wrapper for serializing slice of bytes.
+#[derive(serde::Serialize)]
+#[serde(transparent)]
+pub struct BytesSer<'a>(#[serde(with = "serde_bytes")] pub &'a [u8]);
 
 pub fn bytes_32(buf: &[u8]) -> [u8; 32] {
     let mut array = [0; 32];
     array.copy_from_slice(buf.as_ref());
     array
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{from_slice, to_vec};
-
-    #[test]
-    fn array_symmetric_serialization() {
-        let vec: Vec<u8> = (0..32).collect::<Vec<u8>>();
-        let slice_bz = to_vec(&BytesSer(&vec)).unwrap();
-        let Byte32De(arr) = from_slice(&slice_bz).unwrap();
-        // Check decoded array against slice
-        assert_eq!(arr.as_ref(), vec.as_slice());
-        // Check re-encoded array is equal to the slice encoded
-        assert_eq!(to_vec(&BytesSer(&arr)).unwrap(), slice_bz);
-    }
 }

--- a/ipld/encoding/src/cbor.rs
+++ b/ipld/encoding/src/cbor.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use serde::{Deserialize, Serialize};
 
 use super::errors::Error;
-use crate::{de, from_slice, ser, to_vec};
+use crate::{de, from_slice, ser, serde_bytes, to_vec};
 
 pub const DAG_CBOR: u64 = 0x71;
 

--- a/ipld/encoding/src/cbor.rs
+++ b/ipld/encoding/src/cbor.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use serde::{Deserialize, Serialize};
 
 use super::errors::Error;
-use crate::{de, from_slice, ser, serde_bytes, to_vec};
+use crate::{de, from_slice, ser, strict_bytes, to_vec};
 
 pub const DAG_CBOR: u64 = 0x71;
 
@@ -33,7 +33,7 @@ impl<T> Cbor for Option<T> where T: Cbor {}
 #[derive(Clone, PartialEq, Serialize, Deserialize, Hash, Eq, Default)]
 #[serde(transparent)]
 pub struct RawBytes {
-    #[serde(with = "serde_bytes")]
+    #[serde(with = "strict_bytes")]
     bytes: Vec<u8>,
 }
 

--- a/ipld/encoding/src/lib.rs
+++ b/ipld/encoding/src/lib.rs
@@ -9,7 +9,6 @@ mod vec;
 use std::io;
 
 pub use serde::{self, de, ser};
-pub use serde_bytes;
 
 pub use self::bytes::*;
 pub use self::cbor::*;

--- a/ipld/hamt/CHANGELOG.md
+++ b/ipld/hamt/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 0.6.0
+
+- Bumps `fvm_ipld_encoding` and switches from `cs_serde_bytes` to `fvm_ipld_encoding::strict_bytes`.
+
 ## 0.5.1
 
 - Update `fvm_ipld_encoding` to 0.2.0.

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -12,7 +12,6 @@ serde = { version = "1.0", features = ["derive"] }
 byteorder = "1.3.2"
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.1", default-features = false }
-serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
 thiserror = "1.0"
 sha2 = "0.10"
 once_cell = "1.5"

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_hamt"
 description = "Sharded IPLD HashMap implementation."
-version = "0.5.1"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -18,7 +18,7 @@ once_cell = "1.5"
 forest_hash_utils = "0.1"
 anyhow = "1.0.51"
 libipld-core = { version = "0.14.0", features = ["serde-codec"] }
-fvm_ipld_encoding = { version = "0.2", path = "../encoding" }
+fvm_ipld_encoding = { version = "0.3", path = "../encoding" }
 fvm_ipld_blockstore = { version = "0.1", path = "../blockstore" }
 
 [features]

--- a/ipld/hamt/src/bitfield.rs
+++ b/ipld/hamt/src/bitfield.rs
@@ -6,7 +6,7 @@ use std::u64;
 use byteorder::{BigEndian, ByteOrder};
 use fvm_ipld_encoding::de::{Deserialize, Deserializer};
 use fvm_ipld_encoding::ser::{Serialize, Serializer};
-use fvm_ipld_encoding::serde_bytes;
+use fvm_ipld_encoding::strict_bytes;
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Bitfield([u64; 4]);
@@ -25,11 +25,11 @@ impl Serialize for Bitfield {
 
         for i in 0..v.len() {
             if v[i] != 0 {
-                return serde_bytes::Serialize::serialize(&v[i..], serializer);
+                return strict_bytes::Serialize::serialize(&v[i..], serializer);
             }
         }
 
-        <[u8] as serde_bytes::Serialize>::serialize(&[], serializer)
+        <[u8] as strict_bytes::Serialize>::serialize(&[], serializer)
     }
 }
 
@@ -39,7 +39,7 @@ impl<'de> Deserialize<'de> for Bitfield {
         D: Deserializer<'de>,
     {
         let mut res = Bitfield::zero();
-        let bytes = serde_bytes::ByteBuf::deserialize(deserializer)?.into_vec();
+        let bytes = strict_bytes::ByteBuf::deserialize(deserializer)?.into_vec();
 
         let mut arr = [0u8; 4 * 8];
         let len = bytes.len();

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 
 use fvm_ipld_blockstore::tracking::{BSStats, TrackingBlockstore};
 use fvm_ipld_blockstore::MemoryBlockstore;
-use fvm_ipld_encoding::serde_bytes::ByteBuf;
+use fvm_ipld_encoding::strict_bytes::ByteBuf;
 use fvm_ipld_encoding::CborStore;
 #[cfg(feature = "identity")]
 use fvm_ipld_hamt::Identity;

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -5,12 +5,12 @@ use std::fmt::Display;
 
 use fvm_ipld_blockstore::tracking::{BSStats, TrackingBlockstore};
 use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_encoding::serde_bytes::ByteBuf;
 use fvm_ipld_encoding::CborStore;
 #[cfg(feature = "identity")]
 use fvm_ipld_hamt::Identity;
 use fvm_ipld_hamt::{BytesKey, Hamt};
 use multihash::Code;
-use serde_bytes::ByteBuf;
 
 // Redeclaring max array size of Hamt to avoid exposing value
 const BUCKET_SIZE: usize = 3;
@@ -172,7 +172,7 @@ fn delete_case() {
 
     let mut hamt: Hamt<_, _> = Hamt::new(&store);
 
-    hamt.set([0].to_vec().into(), ByteBuf::from(b"Test data".as_ref()))
+    hamt.set([0].to_vec().into(), ByteBuf(b"Test data".as_ref().into()))
         .unwrap();
 
     let c = hamt.flush().unwrap();

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 3.0.0-alpha.5 [2022-10-10]
+
+- Bumps `fvm_ipld_encoding` and switches from `cs_serde_bytes` to `fvm_ipld_encoding::strict_bytes`.
+
 ## 3.0.0-alpha.4 [2022-10-10]
 
 - Add support for recording & looking up f4 addresses.

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "3.0.0-alpha.4"
+version = "3.0.0-alpha.5"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -12,13 +12,13 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { version = "0.8.5", default-features = false }
-fvm_shared = { version = "3.0.0-alpha.4", path = "../shared" }
+fvm_shared = { version = "3.0.0-alpha.5", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
 log = "0.4.14"
 thiserror = "1.0.30"
-fvm_ipld_encoding = { version = "0.2", path = "../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3", path = "../ipld/encoding" }
 
 [features]
 default = ["debug"]

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
 
-## 3.0.0-alpha.5 [UNRELEASED]
+## 3.0.0-alpha.6 [UNRELEASED]
+
+## 3.0.0-alpha.5 [2022-10-10]
+
+- Bumps `fvm_ipld_encoding` and switches from `cs_serde_bytes` to `fvm_ipld_encoding::strict_bytes`.
 
 ## 3.0.0-alpha.4 [2022-10-10]
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "3.0.0-alpha.4"
+version = "3.0.0-alpha.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
@@ -23,7 +23,7 @@ multihash = { version = "0.16.3", default-features = false, features = ["multiha
 unsigned-varint = "0.7.1"
 anyhow = "1.0.51"
 fvm_ipld_blockstore = { version = "0.1", path = "../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.2", path = "../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3", path = "../ipld/encoding" }
 serde = { version = "1", default-features = false }
 serde_tuple = "0.5"
 serde_repr = "0.1"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -27,7 +27,6 @@ fvm_ipld_encoding = { version = "0.2", path = "../ipld/encoding" }
 serde = { version = "1", default-features = false }
 serde_tuple = "0.5"
 serde_repr = "0.1"
-serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
 arbitrary = { version = "1.1", optional = true, features = ["derive"]}
 
 ## non-wasm dependencies; these dependencies and the respective code is

--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 
 use data_encoding::Encoding;
 use data_encoding_macro::new_encoding;
-use fvm_ipld_encoding::{serde_bytes, Cbor};
+use fvm_ipld_encoding::{strict_bytes, Cbor};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 pub use self::errors::Error;
@@ -343,7 +343,7 @@ impl Serialize for Address {
         S: Serializer,
     {
         let address_bytes = self.to_bytes();
-        serde_bytes::Serialize::serialize(&address_bytes, s)
+        strict_bytes::Serialize::serialize(&address_bytes, s)
     }
 }
 
@@ -352,7 +352,7 @@ impl<'de> Deserialize<'de> for Address {
     where
         D: Deserializer<'de>,
     {
-        let bz: Cow<'de, [u8]> = serde_bytes::Deserialize::deserialize(deserializer)?;
+        let bz: Cow<'de, [u8]> = strict_bytes::Deserialize::deserialize(deserializer)?;
 
         // Create and return created address of unmarshalled bytes
         Address::from_bytes(&bz).map_err(de::Error::custom)

--- a/shared/src/bigint/bigint_ser.rs
+++ b/shared/src/bigint/bigint_ser.rs
@@ -3,7 +3,7 @@
 
 use std::borrow::Cow;
 
-use fvm_ipld_encoding::serde_bytes;
+use fvm_ipld_encoding::strict_bytes;
 use num_bigint::{BigInt, Sign};
 use serde::{Deserialize, Serialize};
 
@@ -38,7 +38,7 @@ where
     }
 
     // Serialize as bytes
-    serde_bytes::Serialize::serialize(&bz, serializer)
+    strict_bytes::Serialize::serialize(&bz, serializer)
 }
 
 /// Deserializes bytes into big int.
@@ -46,7 +46,7 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<BigInt, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let bz: Cow<'de, [u8]> = serde_bytes::Deserialize::deserialize(deserializer)?;
+    let bz: Cow<'de, [u8]> = strict_bytes::Deserialize::deserialize(deserializer)?;
     if bz.is_empty() {
         return Ok(BigInt::default());
     }
@@ -105,7 +105,7 @@ mod tests {
                 Sign::Minus => source.insert(0, 0),
                 _ => source.insert(0, 1),
             }
-            to_vec(&serde_bytes::ByteBuf(source)).unwrap()
+            to_vec(&strict_bytes::ByteBuf(source)).unwrap()
         };
 
         let res: Result<BigIntDe, _> = from_slice(&bad_bytes);

--- a/shared/src/bigint/bigint_ser.rs
+++ b/shared/src/bigint/bigint_ser.rs
@@ -3,6 +3,7 @@
 
 use std::borrow::Cow;
 
+use fvm_ipld_encoding::serde_bytes;
 use num_bigint::{BigInt, Sign};
 use serde::{Deserialize, Serialize};
 
@@ -104,7 +105,7 @@ mod tests {
                 Sign::Minus => source.insert(0, 0),
                 _ => source.insert(0, 1),
             }
-            to_vec(&serde_bytes::Bytes::new(&source)).unwrap()
+            to_vec(&serde_bytes::ByteBuf(source)).unwrap()
         };
 
         let res: Result<BigIntDe, _> = from_slice(&bad_bytes);

--- a/shared/src/bigint/biguint_ser.rs
+++ b/shared/src/bigint/biguint_ser.rs
@@ -3,6 +3,7 @@
 
 use std::borrow::Cow;
 
+use fvm_ipld_encoding::serde_bytes;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
@@ -86,7 +87,7 @@ mod tests {
         let bad_bytes = {
             let mut source = bad1.to_bytes_be();
             source.insert(0, 0);
-            to_vec(&serde_bytes::Bytes::new(&source)).unwrap()
+            to_vec(&serde_bytes::ByteBuf(source)).unwrap()
         };
 
         let res: Result<BigUintDe, _> = from_slice(&bad_bytes);

--- a/shared/src/bigint/biguint_ser.rs
+++ b/shared/src/bigint/biguint_ser.rs
@@ -3,7 +3,7 @@
 
 use std::borrow::Cow;
 
-use fvm_ipld_encoding::serde_bytes;
+use fvm_ipld_encoding::strict_bytes;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
@@ -37,14 +37,14 @@ where
     }
 
     // Serialize as bytes
-    serde_bytes::Serialize::serialize(&bz, serializer)
+    strict_bytes::Serialize::serialize(&bz, serializer)
 }
 
 pub fn deserialize<'de, D>(deserializer: D) -> Result<BigUint, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let bz: Cow<'de, [u8]> = serde_bytes::Deserialize::deserialize(deserializer)?;
+    let bz: Cow<'de, [u8]> = strict_bytes::Deserialize::deserialize(deserializer)?;
     if bz.is_empty() {
         return Ok(BigUint::default());
     }
@@ -87,7 +87,7 @@ mod tests {
         let bad_bytes = {
             let mut source = bad1.to_bytes_be();
             source.insert(0, 0);
-            to_vec(&serde_bytes::ByteBuf(source)).unwrap()
+            to_vec(&strict_bytes::ByteBuf(source)).unwrap()
         };
 
         let res: Result<BigUintDe, _> = from_slice(&bad_bytes);

--- a/shared/src/crypto/signature.rs
+++ b/shared/src/crypto/signature.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use std::error;
 
 use fvm_ipld_encoding::repr::*;
-use fvm_ipld_encoding::{de, ser, serde_bytes, Cbor, Error as EncodingError};
+use fvm_ipld_encoding::{de, ser, strict_bytes, Cbor, Error as EncodingError};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use thiserror::Error;
@@ -53,7 +53,7 @@ impl ser::Serialize for Signature {
         bytes.push(self.sig_type as u8);
         bytes.extend_from_slice(&self.bytes);
 
-        serde_bytes::Serialize::serialize(&bytes, serializer)
+        strict_bytes::Serialize::serialize(&bytes, serializer)
     }
 }
 
@@ -62,7 +62,7 @@ impl<'de> de::Deserialize<'de> for Signature {
     where
         D: de::Deserializer<'de>,
     {
-        let bytes: Cow<'de, [u8]> = serde_bytes::Deserialize::deserialize(deserializer)?;
+        let bytes: Cow<'de, [u8]> = strict_bytes::Deserialize::deserialize(deserializer)?;
         if bytes.is_empty() {
             return Err(de::Error::custom("Cannot deserialize empty bytes"));
         }

--- a/shared/src/sector/post.rs
+++ b/shared/src/sector/post.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-use fvm_ipld_encoding::{serde_bytes, Cbor};
+use fvm_ipld_encoding::{strict_bytes, Cbor};
 use serde_tuple::*;
 
 use super::*;
@@ -25,7 +25,7 @@ pub struct SectorInfo {
 #[derive(Debug, PartialEq, Clone, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct PoStProof {
     pub post_proof: RegisteredPoStProof,
-    #[serde(with = "serde_bytes")]
+    #[serde(with = "strict_bytes")]
     pub proof_bytes: Vec<u8>,
 }
 

--- a/shared/src/sector/post.rs
+++ b/shared/src/sector/post.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-use fvm_ipld_encoding::Cbor;
+use fvm_ipld_encoding::{serde_bytes, Cbor};
 use serde_tuple::*;
 
 use super::*;

--- a/shared/src/sector/seal.rs
+++ b/shared/src/sector/seal.rs
@@ -4,7 +4,7 @@
 use cid::Cid;
 use clock::ChainEpoch;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::{serde_bytes, Cbor};
+use fvm_ipld_encoding::{strict_bytes, Cbor};
 
 use crate::randomness::Randomness;
 use crate::sector::{
@@ -26,7 +26,7 @@ pub struct SealVerifyInfo {
     pub deal_ids: Vec<deal::DealID>,
     pub randomness: SealRandomness,
     pub interactive_randomness: InteractiveSealRandomness,
-    #[serde(with = "serde_bytes")]
+    #[serde(with = "strict_bytes")]
     pub proof: Vec<u8>,
     pub sealed_cid: Cid,   // Commr
     pub unsealed_cid: Cid, // Commd
@@ -44,7 +44,7 @@ pub struct SealVerifyParams {
     pub sealed_cid: Cid,
     pub interactive_epoch: ChainEpoch,
     pub registered_seal_proof: RegisteredSealProof,
-    #[serde(with = "serde_bytes")]
+    #[serde(with = "strict_bytes")]
     pub proof: Vec<u8>,
     pub deal_ids: Vec<deal::DealID>,
     pub sector_num: SectorNumber,
@@ -67,7 +67,7 @@ pub struct AggregateSealVerifyProofAndInfos {
     pub miner: ActorID,
     pub seal_proof: RegisteredSealProof,
     pub aggregate_proof: RegisteredAggregateProof,
-    #[serde(with = "serde_bytes")]
+    #[serde(with = "strict_bytes")]
     pub proof: Vec<u8>,
     pub infos: Vec<AggregateSealVerifyInfo>,
 }

--- a/testing/common_fuzz/fuzz/Cargo.toml
+++ b/testing/common_fuzz/fuzz/Cargo.toml
@@ -22,7 +22,6 @@ fvm_ipld_bitfield = { path = "../../../ipld/bitfield", features = ["enable-arbit
 fvm_ipld_encoding = { path = "../../../ipld/encoding" }
 fvm_shared = { path = "../../../shared", features = ["arb"] }
 serde = { version = "1", features = ["derive"] }
-serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
 hex = "0.4"
 
 # Prevent this from interfering with workspaces

--- a/testing/common_fuzz/fuzz/src/cbor.rs
+++ b/testing/common_fuzz/fuzz/src/cbor.rs
@@ -1,7 +1,7 @@
 use arbitrary::Arbitrary;
 use cid::Cid;
 use fvm_ipld_bitfield::{BitField, UnvalidatedBitField};
-use fvm_ipld_encoding::serde_bytes;
+use fvm_ipld_encoding::strict_bytes;
 #[allow(unused_imports)]
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
@@ -9,7 +9,7 @@ use fvm_shared::address::Address;
 
 #[derive(Deserialize_tuple, Serialize_tuple, Arbitrary, Debug)]
 pub struct Payload {
-    #[serde(with = "serde_bytes")]
+    #[serde(with = "strict_bytes")]
     pub serde_bytes_bytes: Vec<u8>,
     pub integer: u64,
     pub address: Address,

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,12 +9,12 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "3.0.0-alpha.4", path = "../../shared" }
-fvm_ipld_hamt = { version = "0.5.1", path = "../../ipld/hamt"}
-fvm_ipld_amt = { version = "0.4.2", path = "../../ipld/amt"}
-fvm_ipld_car = { version = "0.5.0", path = "../../ipld/car" }
+fvm_shared = { version = "3.0.0-alpha.5", path = "../../shared" }
+fvm_ipld_hamt = { version = "0.6.0", path = "../../ipld/hamt"}
+fvm_ipld_amt = { version = "0.5.0", path = "../../ipld/amt"}
+fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.2.2", path = "../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.0", path = "../../ipld/encoding" }
 
 anyhow = "1.0.47"
 thiserror = "1.0.30"

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
 fvm = { version = "3.0.0-alpha.1", path = "../../fvm", default-features = false }
-fvm_shared = { version = "3.0.0-alpha.4", path = "../../shared" }
-fvm_ipld_hamt = { version = "0.5.1", path = "../../ipld/hamt" }
-fvm_ipld_amt = { version = "0.4.2", path = "../../ipld/amt" }
-fvm_ipld_car = { version = "0.5.0", path = "../../ipld/car" }
+fvm_shared = { version = "3.0.0-alpha.5", path = "../../shared" }
+fvm_ipld_hamt = { version = "0.6.0", path = "../../ipld/hamt" }
+fvm_ipld_amt = { version = "0.5.0", path = "../../ipld/amt" }
+fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.2.2", path = "../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.0", path = "../../ipld/encoding" }
 
 anyhow = "1.0.47"
 cid = { version = "0.8.5", default-features = false }

--- a/testing/integration/tests/fil-address-actor/Cargo.toml
+++ b/testing/integration/tests/fil-address-actor/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.4", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.4", path = "../../../../shared" }
+fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
+fvm_sdk = { version = "3.0.0-alpha.5", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.5", path = "../../../../shared" }
 serde = "1.0.145"
 
 [build-dependencies]

--- a/testing/integration/tests/fil-hello-world-actor/Cargo.toml
+++ b/testing/integration/tests/fil-hello-world-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.4", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.4", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.5", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.5", path = "../../../../shared" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.4", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.4", path = "../../../../shared" }
-fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
+fvm_sdk = { version = "3.0.0-alpha.5", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.5", path = "../../../../shared" }
+fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../../../ipld/blockstore" }
 
 anyhow = "1.0.57"

--- a/testing/integration/tests/fil-ipld-actor/Cargo.toml
+++ b/testing/integration/tests/fil-ipld-actor/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.4", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.4", path = "../../../../shared" }
+fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
+fvm_sdk = { version = "3.0.0-alpha.5", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.5", path = "../../../../shared" }
 
 [target.'cfg(coverage)'.dependencies]
 minicov = "0.2"

--- a/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_shared = { version = "3.0.0-alpha.4", path = "../../../../shared" }
-fvm_sdk = { version = "3.0.0-alpha.4", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.5", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.5", path = "../../../../sdk" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.4", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.4", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.5", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.5", path = "../../../../shared" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-syscall-actor/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.4", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.4", path = "../../../../shared" }
+fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
+fvm_sdk = { version = "3.0.0-alpha.5", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.5", path = "../../../../shared" }
 minicov = {version = "0.2", optional = true}
 multihash = "0.16.3"
 


### PR DESCRIPTION
1. Import `serde_bytes` (really, `cs_serde_bytes`) in-tree. We only need a small fraction of it anyways.
2. Rename to `ipld_bytes` to make it clear that we're not the same as upstream (leaving an alias for backwards compatibility).
3. Extend it to support fixed-sized arrays.