### PR TITLE
fix: remove ahash from the amt

### DIFF
--- a/ipld/amt/CHANGELOG.md
+++ b/ipld/amt/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 0.5.0
 
 - Bumps `fvm_ipld_encoding` and switches from `cs_serde_bytes` to `fvm_ipld_encoding::strict_bytes`.
+- Remove `ahash` and just use a vec.
 
 ## 0.4.2
 

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -12,14 +12,13 @@ cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] 
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 once_cell = "1.5"
-ahash = { version = "0.8", optional = true }
 itertools = "0.10"
 anyhow = "1.0.51"
 fvm_ipld_blockstore = { version = "0.1", path = "../blockstore" }
 fvm_ipld_encoding = { version = "0.3", path = "../encoding" }
 
 [features]
-go-interop = ["ahash"]
+go-interop = []
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -359,7 +359,7 @@ where
         // change, and since it should not be feasibly triggered, it's left as this for now.
         #[cfg(feature = "go-interop")]
         {
-            let mut mutated = ahash::AHashMap::new();
+            let mut mutated = Vec::new();
 
             self.root.node.for_each_while_mut(
                 &self.block_store,
@@ -375,14 +375,14 @@ where
                         // which we cannot do because it is memory unsafe (and I'm not certain we
                         // don't have side effects from doing this unsafely)
                         value.mark_unchanged();
-                        mutated.insert(idx, value.clone());
+                        mutated.push((idx, value.clone()));
                     }
 
                     Ok(keep_going)
                 },
             )?;
 
-            for (i, v) in mutated.into_iter() {
+            for (i, v) in mutated {
                 self.set(i, v)?;
             }
 


### PR DESCRIPTION
- A vec is simpler for what we're doing here.
- Ahash needs randmness...