### PR TITLE
chore: update wasmtime to 1.0

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -47,7 +47,7 @@ pretty_assertions = "1.2.1"
 fvm = { path = ".", features = ["testing"], default-features = false }
 
 [dependencies.wasmtime]
-version = "0.40.1"
+version = "1.0.1"
 default-features = false
 features = ["cranelift", "pooling-allocator", "parallel-compilation"]
 

--- a/fvm/src/machine/engine.rs
+++ b/fvm/src/machine/engine.rs
@@ -123,6 +123,8 @@ pub fn default_wasmtime_config() -> wasmtime::Config {
     c.debug_info(false);
     c.generate_address_map(false);
     c.cranelift_debug_verifier(false);
+    c.native_unwind_info(false);
+    #[allow(deprecated)] // TODO https://github.com/bytecodealliance/wasmtime/issues/5037
     c.wasm_backtrace(false);
     c.wasm_reference_types(false);
 

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4.14"
 byteorder = "1.4.3"
 futures = "0.3.19"
 async-std = { version = "1.9", features = ["attributes"] }
-wasmtime = { version = "0.40.1", default-features = false }
+wasmtime = { version = "1.0.1", default-features = false }
 base64 = "0.13.0"
 flate2 = { version = "1.0" }
 colored = "2"

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -31,7 +31,7 @@ serde_repr = "0.1"
 thiserror = "1.0.30"
 
 [dependencies.wasmtime]
-version = "0.40.1"
+version = "1.0.1"
 default-features = false
 features = ["cranelift", "parallel-compilation"]
 


### PR DESCRIPTION
Backports #943 without the other dependency updates.

Fixes #962.