### PR TITLE
feat: remove RawBytes from APIs

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context};
 use derive_more::{Deref, DerefMut};
-use fvm_ipld_encoding::{to_vec, RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::{to_vec, DAG_CBOR};
 use fvm_shared::address::{Address, Payload};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
@@ -148,7 +148,7 @@ where
             self.trace(match &result {
                 Ok(InvocationResult::Return(v)) => ExecutionEvent::CallReturn(
                     v.as_ref()
-                        .map(|blk| RawBytes::from(blk.data().to_vec()))
+                        .map(|blk| blk.data().to_vec())
                         .unwrap_or_default(),
                 ),
                 Ok(InvocationResult::Failure(code)) => ExecutionEvent::CallAbort(*code),

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -3,7 +3,7 @@ use std::result::Result as StdResult;
 
 use anyhow::{anyhow, Result};
 use cid::Cid;
-use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::DAG_CBOR;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
@@ -82,7 +82,7 @@ where
             let params = if msg.params.is_empty() {
                 None
             } else {
-                Some(Block::new(DAG_CBOR, msg.params.bytes()))
+                Some(Block::new(DAG_CBOR, &*msg.params))
             };
 
             let result = cm.with_transaction(|cm| {
@@ -111,7 +111,7 @@ where
                 // Convert back into a top-level return "value". We throw away the codec here,
                 // unfortunately.
                 let return_data = return_value
-                    .map(|blk| RawBytes::from(blk.data().to_vec()))
+                    .map(|blk| blk.data().to_vec())
                     .unwrap_or_default();
 
                 backtrace.clear();

--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -5,7 +5,6 @@ use std::fmt::Display;
 
 use cid::Cid;
 pub use default::DefaultExecutor;
-use fvm_ipld_encoding::RawBytes;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::message::Message;
@@ -100,7 +99,7 @@ impl ApplyRet {
         ApplyRet {
             msg_receipt: Receipt {
                 exit_code: code,
-                return_data: RawBytes::default(),
+                return_data: Vec::new(),
                 gas_used: 0,
             },
             penalty: miner_penalty,

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -1,4 +1,3 @@
-use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -21,10 +20,10 @@ pub enum ExecutionEvent {
         from: ActorID,
         to: Address,
         method: MethodNum,
-        params: RawBytes,
+        params: Vec<u8>,
         value: TokenAmount,
     },
-    CallReturn(RawBytes),
+    CallReturn(Vec<u8>),
     CallAbort(ExitCode),
     CallError(SyscallError),
 }

--- a/sdk/src/send.rs
+++ b/sdk/src/send.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 
-use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::DAG_CBOR;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
@@ -15,7 +15,7 @@ use crate::{sys, SyscallResult, NO_DATA_BLOCK_ID};
 pub fn send(
     to: &Address,
     method: MethodNum,
-    params: RawBytes,
+    params: &[u8],
     value: TokenAmount,
 ) -> SyscallResult<Receipt> {
     let recipient = to.to_bytes();
@@ -56,7 +56,7 @@ pub fn send(
                 // Now read the return data.
                 let unread = sys::ipld::block_read(return_id, 0, bytes.as_mut_ptr(), return_size)?;
                 assert_eq!(0, unread);
-                RawBytes::from(bytes)
+                bytes
             }
             _ => Default::default(),
         };

--- a/shared/src/receipt.rs
+++ b/shared/src/receipt.rs
@@ -1,8 +1,8 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
-use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_encoding::tuple::*;
+use fvm_ipld_encoding::{strict_bytes, Cbor};
 
 use crate::error::ExitCode;
 
@@ -10,7 +10,8 @@ use crate::error::ExitCode;
 #[derive(Debug, PartialEq, Eq, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct Receipt {
     pub exit_code: ExitCode,
-    pub return_data: RawBytes,
+    #[serde(with = "strict_bytes")]
+    pub return_data: Vec<u8>,
     pub gas_used: i64,
 }
 

--- a/testing/conformance/benches/bench_conformance_overhead.rs
+++ b/testing/conformance/benches/bench_conformance_overhead.rs
@@ -7,7 +7,7 @@ use criterion::*;
 use fvm::machine::{MultiEngine, BURNT_FUNDS_ACTOR_ADDR};
 use fvm_conformance_tests::driver::*;
 use fvm_conformance_tests::vector::{ApplyMessage, MessageVector};
-use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_encoding::Cbor;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::message::Message;
 use num_traits::Zero;
@@ -55,7 +55,7 @@ fn bench_500_simple_state_access(
                 sequence: i,
                 value: TokenAmount::zero(),
                 method_num: 2,
-                params: RawBytes::default(),
+                params: Vec::new(),
                 gas_limit: 5000000000,
                 gas_fee_cap: TokenAmount::zero(),
                 gas_premium: TokenAmount::zero(),

--- a/testing/conformance/src/vector.rs
+++ b/testing/conformance/src/vector.rs
@@ -228,7 +228,6 @@ mod base64_bytes {
 }
 
 mod message_receipt_vec {
-    use fvm_ipld_encoding::RawBytes;
     use fvm_shared::error::ExitCode;
 
     use super::*;
@@ -249,7 +248,7 @@ mod message_receipt_vec {
         Ok(s.into_iter()
             .map(|v| Receipt {
                 exit_code: v.exit_code,
-                return_data: RawBytes::new(v.return_value),
+                return_data: v.return_value,
                 gas_used: v.gas_used,
             })
             .collect())

--- a/testing/integration/tests/fil-address-actor/src/actor.rs
+++ b/testing/integration/tests/fil-address-actor/src/actor.rs
@@ -1,4 +1,3 @@
-use fvm_ipld_encoding::RawBytes;
 use fvm_sdk as sdk;
 use fvm_shared::address::{Address, SECP_PUB_LEN};
 use fvm_shared::bigint::Zero;
@@ -24,7 +23,7 @@ pub fn invoke(params: u32) -> u32 {
         2 => {
             // Create an account.
             let addr = Address::new_secp256k1(&[0; SECP_PUB_LEN]).unwrap();
-            assert!(sdk::send::send(&addr, 0, RawBytes::default(), Zero::zero())
+            assert!(sdk::send::send(&addr, 0, &[], Zero::zero())
                 .unwrap()
                 .exit_code
                 .is_success());
@@ -42,7 +41,7 @@ pub fn invoke(params: u32) -> u32 {
             // Create an embryo.
             let addr =
                 Address::new_delegated(0, b"foobar").expect("failed to construct f4 address");
-            assert!(sdk::send::send(&addr, 0, RawBytes::default(), Zero::zero())
+            assert!(sdk::send::send(&addr, 0, &[], Zero::zero())
                 .unwrap()
                 .exit_code
                 .is_success());
@@ -62,7 +61,7 @@ pub fn invoke(params: u32) -> u32 {
                 Address::new_delegated(999, b"foobar").expect("failed to construct f4 address");
             assert_eq!(
                 Err(ErrorNumber::NotFound),
-                sdk::send::send(&addr, 0, RawBytes::default(), Zero::zero()),
+                sdk::send::send(&addr, 0, &[], Zero::zero()),
                 "expected send to unassignable f4 address to fail"
             );
         }

--- a/testing/integration/tests/fil-stack-overflow-actor/src/actor.rs
+++ b/testing/integration/tests/fil-stack-overflow-actor/src/actor.rs
@@ -55,12 +55,7 @@ pub fn call_extern() {
 
 #[inline(never)]
 pub fn do_send(m: u64) -> u32 {
-    let r = sdk::send::send(
-        &Address::new_id(10000),
-        m + 1,
-        Vec::new().into(),
-        TokenAmount::zero(),
-    );
+    let r = sdk::send::send(&Address::new_id(10000), m + 1, &[], TokenAmount::zero());
     match r {
         Ok(rec) => match rec.exit_code {
             ExitCode::OK => 0,

--- a/testing/integration/tests/fil_integer_overflow.rs
+++ b/testing/integration/tests/fil_integer_overflow.rs
@@ -4,7 +4,7 @@ use fvm_integration_tests::dummy::DummyExterns;
 use fvm_integration_tests::tester::{Account, Tester};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::RawBytes;
+use fvm_ipld_encoding::{from_slice, to_vec};
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -60,7 +60,7 @@ fn integer_overflow() {
 
     // Params setup
     let x: i64 = 10000000000;
-    let params = RawBytes::serialize(x).unwrap();
+    let params = to_vec(&x).unwrap();
 
     // Send message to set
     let message = Message {
@@ -104,7 +104,7 @@ fn integer_overflow() {
         .execute_message(message, ApplyKind::Explicit, 100)
         .unwrap();
 
-    let current_state_value: i64 = res.msg_receipt.return_data.deserialize().unwrap();
+    let current_state_value: i64 = from_slice(&res.msg_receipt.return_data).unwrap();
 
     assert_eq!(current_state_value, x);
 
@@ -142,7 +142,7 @@ fn integer_overflow() {
         .execute_message(message, ApplyKind::Explicit, 100)
         .unwrap();
 
-    let current_state_value: i64 = res.msg_receipt.return_data.deserialize().unwrap();
+    let current_state_value: i64 = from_slice(&res.msg_receipt.return_data).unwrap();
 
     // Check overflow
     let overflow_value: i64 = -5340232216128654848;

--- a/testing/integration/tests/fil_syscall.rs
+++ b/testing/integration/tests/fil_syscall.rs
@@ -5,7 +5,6 @@ use fvm_integration_tests::dummy::DummyExterns;
 use fvm_integration_tests::tester::{Account, Tester};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
@@ -77,7 +76,7 @@ fn non_existing_syscall() {
     tester.instantiate_machine(DummyExterns).unwrap();
 
     // Params setup
-    let params = RawBytes::new(Vec::<u8>::new());
+    let params = Vec::new();
 
     // Send message to set
     let message = Message {
@@ -133,7 +132,7 @@ fn malformed_syscall_parameter() {
     tester.instantiate_machine(DummyExterns).unwrap();
 
     // Params setup
-    let params = RawBytes::new(Vec::<u8>::new());
+    let params = Vec::new();
 
     // Send message to set
     let message = Message {


### PR DESCRIPTION
Use raw byte slices/vecs everywhere. Otherwise, this type kind of leaks into all APIs.