### PR TITLE
fix: correct address length check for create_actor

### DIFF
--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -99,7 +99,7 @@ pub fn create_actor(
     predictable_addr_len: u32,
 ) -> Result<()> {
     let typ = context.memory.read_cid(typ_off)?;
-    let addr = (predictable_addr_len == 0)
+    let addr = (predictable_addr_len > 0)
         .then(|| {
             context
                 .memory

--- a/testing/integration/tests/fil-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-syscall-actor/Cargo.toml
@@ -9,6 +9,7 @@ fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0-alpha.5", path = "../../../../sdk" }
 fvm_shared = { version = "3.0.0-alpha.5", path = "../../../../shared" }
 minicov = {version = "0.2", optional = true}
+actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 multihash = "0.16.3"
 
 [build-dependencies]

--- a/testing/integration/tests/fil-syscall-actor/src/actor.rs
+++ b/testing/integration/tests/fil-syscall-actor/src/actor.rs
@@ -1,4 +1,6 @@
+use actors_v10_runtime::runtime::builtins::Type;
 use fvm_sdk as sdk;
+use fvm_shared::address::{Address, SECP_PUB_LEN};
 use fvm_shared::crypto::hash::SupportedHashes as SharedSupportedHashes;
 use fvm_shared::error::ExitCode;
 use multihash::derive::Multihash;
@@ -31,10 +33,35 @@ pub fn invoke(_: u32) -> u32 {
 
     test_expected_hash();
     test_hash_syscall();
+    test_create_actor();
 
     #[cfg(coverage)]
     sdk::debug::store_artifact("syscall_actor.profraw", minicov::capture_coverage());
     0
+}
+
+fn test_create_actor() {
+    let msig_cid = sdk::actor::get_code_cid_for_type(Type::Multisig as i32);
+    let acct_cid = sdk::actor::get_code_cid_for_type(Type::Account as i32);
+    let acct_addr = Address::new_secp256k1(&[0u8; SECP_PUB_LEN]).unwrap();
+
+    // Deploy
+    sdk::actor::create_actor(1000, &msig_cid, None).unwrap();
+    sdk::actor::create_actor(1001, &acct_cid, Some(acct_addr)).unwrap();
+
+    // Check addresses
+    assert_eq!(None, sdk::actor::lookup_address(1000));
+    assert_eq!(Some(acct_addr), sdk::actor::lookup_address(1001));
+
+    // Check code
+    assert_eq!(
+        msig_cid,
+        sdk::actor::get_actor_code_cid(&Address::new_id(1000)).unwrap()
+    );
+    assert_eq!(
+        acct_cid,
+        sdk::actor::get_actor_code_cid(&Address::new_id(1001)).unwrap()
+    );
 }
 
 // use SDK methods to hash and compares against locally (inside the actor) hashed digest


### PR DESCRIPTION
Before, we'd only try to "read" an address if the length were 0, which was obviously incorrect. Previously, we would have caught this with the test vectors, but we had to disable those until we get a chance to extract new ones from a new test network.

This also adds a test so we don't run into this situation again.