### PR TITLE
fix: make the f4 address format conform to FIP0048

### DIFF
--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -215,7 +215,7 @@ impl fmt::Display for Address {
             }
             Payload::BLS(data) => write_payload(f, protocol, None, data),
             Payload::Delegated(addr) => {
-                write!(f, "{}-", addr.namespace())?;
+                write!(f, "{}f", addr.namespace())?;
                 write_payload(
                     f,
                     protocol,
@@ -285,7 +285,7 @@ pub(self) fn parse_address(addr: &str) -> Result<(Address, Network), Error> {
             }
         }
         Protocol::Delegated => {
-            let (id, subaddr) = raw.split_once('-').ok_or(Error::InvalidPayload)?;
+            let (id, subaddr) = raw.split_once('f').ok_or(Error::InvalidPayload)?;
             if id.len() > 20 {
                 // 20 is max u64 as string
                 return Err(Error::InvalidLength);

--- a/shared/tests/address_test.rs
+++ b/shared/tests/address_test.rs
@@ -229,17 +229,17 @@ fn delegated_address() {
         F4TestVec {
             namespace: 32,
             subaddr: &[0xff; 5],
-            expected: "f432-77777777x32lpna",
+            expected: "f432f77777777x32lpna",
         },
         F4TestVec {
             namespace: std::u64::MAX,
             subaddr: &[],
-            expected: "f418446744073709551615-tnkyfaq",
+            expected: "f418446744073709551615ftnkyfaq",
         },
         F4TestVec {
             namespace: std::u64::MAX,
             subaddr: &[0; MAX_SUBADDRESS_LEN],
-            expected: "f418446744073709551615-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafbbuagu",
+            expected: "f418446744073709551615faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafbbuagu",
         },
     ];
 


### PR DESCRIPTION
Specifically, use `f` as the separator.