### PR TITLE
feat: resolve addresses by looking in the state-tree

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -34,8 +34,8 @@ pub struct InnerDefaultCallManager<M> {
     /// The gas tracker.
     gas_tracker: GasTracker,
     /// The ActorID and the address of the original sender of the chain message that initiated
-    /// this call stack. The Address is the address as provided in the chain message.
-    origin: (ActorID, Address),
+    /// this call stack.
+    origin: ActorID,
     /// The nonce of the chain message that initiated this call stack.
     nonce: u64,
     /// Number of actors created in this call stack.
@@ -75,7 +75,7 @@ where
     fn new(
         machine: M,
         gas_limit: i64,
-        origin: (ActorID, Address),
+        origin: ActorID,
         nonce: u64,
         gas_premium: TokenAmount,
     ) -> Self {
@@ -227,8 +227,8 @@ where
 
     // Other accessor methods
 
-    fn origin(&self) -> (ActorID, &Address) {
-        (self.origin.0, &self.origin.1)
+    fn origin(&self) -> ActorID {
+        self.origin
     }
 
     fn nonce(&self) -> u64 {

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -45,7 +45,7 @@ pub trait CallManager: 'static {
     fn new(
         machine: Self::Machine,
         gas_limit: i64,
-        origin: (ActorID, Address),
+        origin: ActorID,
         nonce: u64,
         gas_premium: TokenAmount,
     ) -> Self;
@@ -81,7 +81,7 @@ pub trait CallManager: 'static {
     fn gas_tracker_mut(&mut self) -> &mut GasTracker;
 
     /// Getter for origin actor.
-    fn origin(&self) -> (ActorID, &Address);
+    fn origin(&self) -> ActorID;
 
     /// Getter for message nonce.
     fn nonce(&self) -> u64;

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -69,7 +69,7 @@ where
             let mut cm = K::CallManager::new(
                 machine,
                 msg.gas_limit,
-                (sender_id, msg.from),
+                sender_id,
                 msg.sequence,
                 msg.gas_premium.clone(),
             );

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -8,8 +8,8 @@ use byteorder::{BigEndian, WriteBytesExt};
 use cid::Cid;
 use filecoin_proofs_api::{self as proofs, ProverId, PublicReplicaInfo, SectorId};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::{bytes_32, from_slice, to_vec};
-use fvm_shared::address::Protocol;
+use fvm_ipld_encoding::{bytes_32, to_vec};
+use fvm_shared::address::{Payload, Protocol};
 use fvm_shared::bigint::Zero;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::signature;
@@ -103,61 +103,6 @@ impl<C> DefaultKernel<C>
 where
     C: CallManager,
 {
-    fn resolve_to_key_addr(&mut self, addr: &Address, charge_gas: bool) -> Result<Address> {
-        if addr.protocol() == Protocol::BLS || addr.protocol() == Protocol::Secp256k1 {
-            return Ok(*addr);
-        }
-
-        let act = self
-            .call_manager
-            .machine()
-            .state_tree()
-            .get_actor(addr)?
-            .context("state tree doesn't contain actor")
-            .or_error(ErrorNumber::NotFound)?;
-
-        let is_account = self
-            .call_manager
-            .machine()
-            .builtin_actors()
-            .is_account_actor(&act.code);
-
-        if !is_account {
-            // TODO: this is wrong. Maybe some InvalidActor type?
-            // The argument is syntactically correct, but semantically wrong.
-            return Err(syscall_error!(IllegalArgument; "target actor is not an account").into());
-        }
-
-        if charge_gas {
-            self.call_manager
-                .charge_gas(self.call_manager.price_list().on_block_open_base())?;
-        }
-
-        let state_block = self
-            .call_manager
-            .state_tree()
-            .store()
-            .get(&act.state)
-            .context("failed to look up state")
-            .or_fatal()?
-            .context("account actor state not found")
-            .or_fatal()?;
-
-        if charge_gas {
-            self.call_manager.charge_gas(
-                self.call_manager
-                    .price_list()
-                    .on_block_open_per_byte(state_block.len()),
-            )?;
-        }
-
-        let state: crate::account_actor::State = from_slice(&state_block)
-            .context("failed to decode actor state as an account")
-            .or_fatal()?; // because we've checked and this should be an account.
-
-        Ok(state.address)
-    }
-
     /// Returns `Some(actor_state)` or `None` if this actor has been deleted.
     fn get_self(&self) -> Result<Option<ActorState>> {
         self.call_manager
@@ -364,7 +309,7 @@ where
         self.caller
     }
 
-    fn msg_origin(&self) -> (ActorID, &Address) {
+    fn msg_origin(&self) -> ActorID {
         self.call_manager.origin()
     }
 
@@ -465,7 +410,25 @@ where
             .charge_gas(self.call_manager.price_list().on_verify_signature(sig_type))?;
 
         // Resolve to key address before verifying signature.
-        let signing_addr = self.resolve_to_key_addr(signer, true)?;
+        let signing_addr = match signer.payload() {
+            // Already a key address.
+            Payload::BLS(_) | Payload::Secp256k1(_) => *signer,
+            // Resolve and re-check.
+            Payload::ID(id) => {
+                let addr = self
+                    .lookup_address(*id)?
+                    .context("address not found")
+                    .or_error(ErrorNumber::NotFound)?;
+                if !matches!(addr.protocol(), Protocol::Secp256k1 | Protocol::BLS) {
+                    return Err(syscall_error!(NotFound; "address protocol not supported").into());
+                }
+                addr
+            }
+            // Not a key address.
+            _ => {
+                return Err(syscall_error!(NotFound; "address protocol not supported").into());
+            }
+        };
 
         // Verify signature, catching errors. Signature verification can include some complicated
         // math.
@@ -762,11 +725,11 @@ where
 
     // TODO(M2) merge new_actor_address and create_actor into a single syscall.
     fn new_actor_address(&mut self) -> Result<Address> {
-        let origin_addr = *self.call_manager.origin().1;
         let oa = self
-            .resolve_to_key_addr(&origin_addr, false)
-            // This is already an execution error, but we're _making_ it fatal.
-            .or_fatal()?;
+            .lookup_address(self.call_manager.origin())
+            .or_fatal()? // actor not found
+            .context("origin does not have a predictable address")
+            .or_fatal()?; // actor doesn't have a predictable address.
 
         let mut b = to_vec(&oa)
             .or_fatal()
@@ -931,7 +894,7 @@ where
             let dir: PathBuf = [
                 dir,
                 self.call_manager.machine().machine_id(),
-                &self.call_manager.origin().0.to_string(),
+                &self.call_manager.origin().to_string(),
                 &self.call_manager.nonce().to_string(),
                 &self.actor_id.to_string(),
                 &self.call_manager.invocation_count().to_string(),

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -112,7 +112,7 @@ pub trait MessageOps {
     fn msg_caller(&self) -> ActorID;
 
     /// The origin actor
-    fn msg_origin(&self) -> (ActorID, &Address);
+    fn msg_origin(&self) -> ActorID;
 
     /// The receiving actor (this actor) (constant).
     fn msg_receiver(&self) -> ActorID;

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -53,7 +53,7 @@ pub fn context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<Invoc
 
     Ok(InvocationContext {
         caller: context.kernel.msg_caller(),
-        origin: context.kernel.msg_origin().0,
+        origin: context.kernel.msg_origin(),
         receiver: context.kernel.msg_receiver(),
         method_number: context.kernel.msg_method_number(),
         value_received: context

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -168,7 +168,7 @@ impl Machine for DummyMachine {
 pub struct DummyCallManager {
     pub machine: DummyMachine,
     pub gas_tracker: GasTracker,
-    pub origin: (ActorID, Address),
+    pub origin: ActorID,
     pub nonce: u64,
     pub test_data: Rc<RefCell<TestData>>,
 }
@@ -188,7 +188,7 @@ impl DummyCallManager {
             Self {
                 machine: DummyMachine::new_stub().unwrap(),
                 gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0), TokenAmount::zero()),
-                origin: (0, Address::new_actor(&[])),
+                origin: 0,
                 nonce: 0,
                 test_data: rc,
             },
@@ -205,7 +205,7 @@ impl DummyCallManager {
             Self {
                 machine: DummyMachine::new_stub().unwrap(),
                 gas_tracker,
-                origin: (0, Address::new_actor(&[])),
+                origin: 0,
                 nonce: 0,
                 test_data: rc,
             },
@@ -220,7 +220,7 @@ impl CallManager for DummyCallManager {
     fn new(
         machine: Self::Machine,
         _gas_limit: i64,
-        origin: (ActorID, Address),
+        origin: ActorID,
         nonce: u64,
         gas_premium: TokenAmount,
     ) -> Self {
@@ -291,8 +291,8 @@ impl CallManager for DummyCallManager {
         self.gas_tracker_mut().apply_charge(charge)
     }
 
-    fn origin(&self) -> (ActorID, &Address) {
-        (self.origin.0, &self.origin.1)
+    fn origin(&self) -> ActorID {
+        self.origin
     }
 
     fn nonce(&self) -> u64 {

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -190,7 +190,7 @@ where
     fn new(
         machine: Self::Machine,
         gas_limit: i64,
-        origin: (ActorID, Address),
+        origin: ActorID,
         nonce: u64,
         gas_premium: TokenAmount,
     ) -> Self {
@@ -247,7 +247,7 @@ where
         self.0.gas_tracker_mut()
     }
 
-    fn origin(&self) -> (ActorID, &Address) {
+    fn origin(&self) -> ActorID {
         self.0.origin()
     }
 
@@ -570,7 +570,7 @@ where
         self.0.msg_caller()
     }
 
-    fn msg_origin(&self) -> (ActorID, &Address) {
+    fn msg_origin(&self) -> ActorID {
         self.0.msg_origin()
     }
 


### PR DESCRIPTION
Before, we'd look in the actor state itself. But that's no longer necessary.

This patch:

1. Saves us a bit of gas/complexity.
2. Paves the way for allowing sends from f4 addresses.