### PR TITLE
Hack: allow f4-embryos to be used as accounts

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -52,7 +52,7 @@ default-features = false
 features = ["cranelift", "pooling-allocator", "parallel-compilation"]
 
 [features]
-f4-as-account = []
+f4-as-account = ["fvm_shared/f4-as-account"]
 default = ["opencl"]
 opencl = ["filecoin-proofs-api/opencl"]
 cuda = ["filecoin-proofs-api/cuda"]

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -52,6 +52,7 @@ default-features = false
 features = ["cranelift", "pooling-allocator", "parallel-compilation"]
 
 [features]
+f4-as-account = []
 default = ["opencl"]
 opencl = ["filecoin-proofs-api/opencl"]
 cuda = ["filecoin-proofs-api/cuda"]

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -413,6 +413,8 @@ where
         let signing_addr = match signer.payload() {
             // Already a key address.
             Payload::BLS(_) | Payload::Secp256k1(_) => *signer,
+            #[cfg(feature = "f4-as-account")]
+            Payload::Delegated(addr) if addr.namespace() == 10 /* eam id */ => *signer,
             // Resolve and re-check.
             Payload::ID(id) => {
                 let addr = self

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -36,6 +36,7 @@ filecoin-proofs-api = { version = "12", default-features = false, optional = tru
 libsecp256k1 = { version = "0.7", optional = true }
 bls-signatures = { version = "0.12", default-features = false, optional = true }
 byteorder = "1.4.3"
+sha3 = { version = "0.10.0", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = "0.8"
@@ -45,6 +46,7 @@ multihash = { version = "0.16.3", default-features = false, features = ["multiha
 
 [features]
 default = []
+f4-as-account = ["sha3"]
 crypto = ["libsecp256k1", "blst", "proofs"]
 proofs = ["filecoin-proofs-api"]
 secp256k1 = ["libsecp256k1"]

--- a/shared/src/crypto/signature.rs
+++ b/shared/src/crypto/signature.rs
@@ -137,8 +137,11 @@ pub mod ops {
     };
 
     use super::{Error, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE};
-    use crate::address::{Address, Protocol};
+    use crate::address::{Address, Payload, Protocol};
     use crate::crypto::signature::Signature;
+
+    #[cfg(feature = "f4-as-account")]
+    const EAM_ACTOR_ID: u64 = 10;
 
     /// Returns `String` error if a bls signature is invalid.
     pub fn verify_bls_sig(signature: &[u8], data: &[u8], addr: &Address) -> Result<(), String> {
@@ -174,11 +177,16 @@ pub mod ops {
         data: &[u8],
         addr: &Address,
     ) -> Result<(), String> {
-        if addr.protocol() != Protocol::Secp256k1 {
-            return Err(format!(
-                "cannot validate a secp256k1 signature against a {} address",
-                addr.protocol()
-            ));
+        match addr.payload() {
+            Payload::Secp256k1(_) => {}
+            #[cfg(feature = "f4-as-account")]
+            Payload::Delegated(addr) if addr.namespace() == EAM_ACTOR_ID => {}
+            _ => {
+                return Err(format!(
+                    "cannot validate a secp256k1 signature against a {} address",
+                    addr.protocol()
+                ))
+            }
         }
 
         if signature.len() != SECP_SIG_LEN {
@@ -194,12 +202,18 @@ pub mod ops {
             .to_state()
             .update(data)
             .finalize();
+        let hash = hash.as_bytes().try_into().expect("fixed array size");
 
         // Ecrecover with hash and signature
         let mut sig = [0u8; SECP_SIG_LEN];
         sig[..].copy_from_slice(signature);
-        let rec_addr = ecrecover(hash.as_bytes().try_into().expect("fixed array size"), &sig)
-            .map_err(|e| e.to_string())?;
+        let rec_addr = match addr.protocol() {
+            Protocol::Secp256k1 => ecrecover(hash, &sig),
+            #[cfg(feature = "f4-as-account")]
+            Protocol::Delegated => ecrecover_fevm(hash, &sig),
+            _ => unreachable!(),
+        }
+        .map_err(|e| e.to_string())?;
 
         // check address against recovered address
         if &rec_addr == addr {
@@ -208,6 +222,7 @@ pub mod ops {
             Err("Secp signature verification failed".to_owned())
         }
     }
+
     /// Aggregates and verifies bls signatures collectively.
     pub fn verify_bls_aggregate(
         data: &[&[u8]],
@@ -263,6 +278,21 @@ pub mod ops {
         let key = recover_secp_public_key(hash, signature)?;
         let ret = key.serialize();
         let addr = Address::new_secp256k1(&ret)?;
+        Ok(addr)
+    }
+
+    #[cfg(feature = "f4-as-account")]
+    pub fn ecrecover_fevm(
+        hash: &[u8; 32],
+        signature: &[u8; SECP_SIG_LEN],
+    ) -> Result<Address, Error> {
+        use sha3::Digest;
+        let pubkey = recover_secp_public_key(hash, &signature)?.serialize();
+        let hasher = sha3::Keccak256::default();
+        hasher.update(&pubkey[1..]);
+        let digest = hasher.finalize();
+
+        let addr = Address::new_delegated(EAM_ACTOR_ID, &digest[12..])?;
         Ok(addr)
     }
 


### PR DESCRIPTION
There are two commits, we can decide to drop the second:

1. Commit 1 allows sending from an f4 embryo.
2. Commit 2 allows validating messages from an f4 embryo. However, this likely requires https://github.com/filecoin-project/FIPs/discussions/497 to actually be useful. We can pull this off as a last minute hack, but it's not great.