### PR TITLE
fix compile issues with f4-as-account feature.

### DIFF
--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -5,6 +5,8 @@ use anyhow::{anyhow, Result};
 use cid::Cid;
 use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
 use fvm_shared::address::Address;
+#[cfg(feature = "f4-as-account")]
+use fvm_shared::address::Payload;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::message::Message;
@@ -312,9 +314,9 @@ where
         let sender_is_account = sender_is_account
             || sender
                 .address
-                .map(|a| matches!(a.payload(), Payload::Delgated(da) if da.namespace() == 10 /* eam */))
+                .map(|a| matches!(a.payload(), Payload::Delegated(da) if da.namespace() == 10 /* eam */))
                 .unwrap_or_default()
-                && self.builtin_actors().is_embryo_actor(cid);
+                && self.builtin_actors().is_embryo_actor(&sender.code);
 
         if !sender_is_account {
             return Ok(Err(ApplyRet::prevalidation_fail(

--- a/shared/src/crypto/signature.rs
+++ b/shared/src/crypto/signature.rs
@@ -287,7 +287,7 @@ pub mod ops {
         signature: &[u8; SECP_SIG_LEN],
     ) -> Result<Address, Error> {
         use sha3::Digest;
-        let pubkey = recover_secp_public_key(hash, &signature)?.serialize();
+        let pubkey = recover_secp_public_key(hash, signature)?.serialize();
         let mut hasher = sha3::Keccak256::default();
         hasher.update(&pubkey[1..]);
         let digest = hasher.finalize();

--- a/shared/src/crypto/signature.rs
+++ b/shared/src/crypto/signature.rs
@@ -288,7 +288,7 @@ pub mod ops {
     ) -> Result<Address, Error> {
         use sha3::Digest;
         let pubkey = recover_secp_public_key(hash, &signature)?.serialize();
-        let hasher = sha3::Keccak256::default();
+        let mut hasher = sha3::Keccak256::default();
         hasher.update(&pubkey[1..]);
         let digest = hasher.finalize();
 

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -51,3 +51,4 @@ actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/
 [features]
 default = ["fvm/testing", "fvm_shared/testing"]
 m2-native = []
+f4-as-account = ["fvm/f4-as-account"]

--- a/testing/integration/src/builtin.rs
+++ b/testing/integration/src/builtin.rs
@@ -14,12 +14,13 @@ pub fn fetch_builtin_code_cid(
     blockstore: &impl Blockstore,
     builtin_actors: &Cid,
     ver: u32,
-) -> Result<(Cid, Cid, Cid)> {
+) -> Result<(Cid, Cid, Cid, Cid)> {
     let manifest = Manifest::load(blockstore, builtin_actors, ver).context(FailedToLoadManifest)?;
     Ok((
         *manifest.get_system_code(),
         *manifest.get_init_code(),
         *manifest.get_account_code(),
+        *manifest.get_embryo_code(),
     ))
 }
 

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -35,6 +35,8 @@ pub struct Tester<B: Blockstore + 'static, E: Externs + 'static> {
     builtin_actors: Cid,
     // Accounts actor cid
     accounts_code_cid: Cid,
+    // Embryo code cid.
+    embryo_code_cid: Cid,
     // Custom code cid deployed by developer
     code_cids: Vec<Cid>,
     // Executor used to interact with deployed actors.
@@ -61,7 +63,7 @@ where
             };
 
         // Get sys and init actors code cid
-        let (sys_code_cid, init_code_cid, accounts_code_cid) =
+        let (sys_code_cid, init_code_cid, accounts_code_cid, embryo_code_cid) =
             fetch_builtin_code_cid(&blockstore, &manifest_data_cid, manifest_version)?;
 
         // Initialize state tree
@@ -80,6 +82,7 @@ where
             code_cids: vec![],
             state_tree: Some(state_tree),
             accounts_code_cid,
+            embryo_code_cid,
         })
     }
 
@@ -96,6 +99,32 @@ where
             *account = self.make_secp256k1_account(priv_key, TokenAmount::from_atto(10000))?;
         }
         Ok(ret)
+    }
+
+    pub fn create_embryo(&mut self, address: &Address, init_balance: TokenAmount) -> Result<()> {
+        assert_eq!(address.protocol(), Protocol::Delegated);
+
+        let state_tree = self
+            .state_tree
+            .as_mut()
+            .ok_or_else(|| anyhow!("unable get state tree"))?;
+
+        let id = state_tree.register_new_address(address).unwrap();
+        let state: [u8; 32] = [0; 32];
+
+        let cid = state_tree.store().put_cbor(&state, Code::Blake2b256)?;
+
+        let actor_state = ActorState {
+            code: self.embryo_code_cid,
+            state: cid,
+            sequence: 0,
+            balance: init_balance,
+            address: Some(*address),
+        };
+
+        state_tree
+            .set_actor(&Address::new_id(id), actor_state)
+            .map_err(anyhow::Error::from)
     }
 
     /// Set a new state in the state tree

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -13,6 +13,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, IPLD_RAW};
+use lazy_static::lazy_static;
 use libsecp256k1::{PublicKey, SecretKey};
 use multihash::Code;
 
@@ -20,6 +21,10 @@ use crate::builtin::{fetch_builtin_code_cid, set_init_actor, set_sys_actor};
 use crate::error::Error::{FailedToFlushTree, NoManifestInformation};
 
 const DEFAULT_BASE_FEE: u64 = 100;
+
+lazy_static! {
+    pub static ref INITIAL_ACCOUNT_BALANCE: TokenAmount = TokenAmount::from_atto(10000);
+}
 
 pub trait Store: Blockstore + Sized + 'static {}
 
@@ -96,7 +101,7 @@ where
         let mut ret: [Account; N] = [(0, Address::default()); N];
         for account in ret.iter_mut().take(N) {
             let priv_key = SecretKey::random(rng);
-            *account = self.make_secp256k1_account(priv_key, TokenAmount::from_atto(10000))?;
+            *account = self.make_secp256k1_account(priv_key, INITIAL_ACCOUNT_BALANCE.clone())?;
         }
         Ok(ret)
     }

--- a/testing/integration/tests/bundles/mod.rs
+++ b/testing/integration/tests/bundles/mod.rs
@@ -16,6 +16,7 @@ lazy_static! {
             .collect();
 }
 
+#[allow(dead_code)]
 pub fn new_tester<B: Blockstore, E: Externs>(
     nv: NetworkVersion,
     stv: StateTreeVersion,

--- a/testing/integration/tests/embryo_sender_test.rs
+++ b/testing/integration/tests/embryo_sender_test.rs
@@ -1,0 +1,67 @@
+mod bundles;
+
+use bundles::*;
+use fvm::executor::{ApplyKind, Executor};
+use fvm::machine::Machine;
+use fvm_integration_tests::dummy::DummyExterns;
+use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_shared::address::Address;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::message::Message;
+use fvm_shared::state::StateTreeVersion;
+use fvm_shared::version::NetworkVersion;
+use fvm_shared::METHOD_SEND;
+
+#[cfg(feature = "f4-as-account")]
+#[test]
+fn embryo_as_sender() {
+    // Instantiate tester
+    let mut tester = new_tester(
+        NetworkVersion::V18,
+        StateTreeVersion::V4,
+        MemoryBlockstore::default(),
+    )
+    .unwrap();
+
+    let sender = Address::new_delegated(10, b"foobar").expect("failed to construct address");
+    tester
+        .create_embryo(&sender, TokenAmount::from_whole(100))
+        .expect("failed to instantiate embryo");
+
+    let [(_, receiver)] = tester.create_accounts().unwrap();
+
+    // Instantiate machine
+    tester.instantiate_machine(DummyExterns).unwrap();
+
+    let executor = tester.executor.as_mut().unwrap();
+
+    let message = Message {
+        from: sender.clone(),
+        to: receiver.clone(),
+        gas_limit: 1000000000,
+        method_num: METHOD_SEND,
+        sequence: 0,
+        ..Message::default()
+    };
+
+    let res = executor
+        .execute_message(message, ApplyKind::Explicit, 100)
+        .unwrap();
+
+    assert!(
+        res.msg_receipt.exit_code.is_success(),
+        "{:?}",
+        res.failure_info
+    );
+
+    let balance = tester
+        .executor
+        .unwrap()
+        .state_tree()
+        .get_actor(&receiver)
+        .expect("couldn't find receiver actor")
+        .expect("actor state didn't exist")
+        .balance;
+
+    println!("{}", balance)
+}

--- a/testing/integration/tests/embryo_sender_test.rs
+++ b/testing/integration/tests/embryo_sender_test.rs
@@ -1,20 +1,20 @@
 mod bundles;
 
-use bundles::*;
-use fvm::executor::{ApplyKind, Executor};
-use fvm::machine::Machine;
-use fvm_integration_tests::dummy::DummyExterns;
-use fvm_ipld_blockstore::MemoryBlockstore;
-use fvm_shared::address::Address;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::message::Message;
-use fvm_shared::state::StateTreeVersion;
-use fvm_shared::version::NetworkVersion;
-use fvm_shared::METHOD_SEND;
-
 #[cfg(feature = "f4-as-account")]
 #[test]
 fn embryo_as_sender() {
+    use bundles::*;
+    use fvm::executor::{ApplyKind, Executor};
+    use fvm::machine::Machine;
+    use fvm_integration_tests::dummy::DummyExterns;
+    use fvm_ipld_blockstore::MemoryBlockstore;
+    use fvm_shared::address::Address;
+    use fvm_shared::econ::TokenAmount;
+    use fvm_shared::message::Message;
+    use fvm_shared::state::StateTreeVersion;
+    use fvm_shared::version::NetworkVersion;
+    use fvm_shared::METHOD_SEND;
+
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,


### PR DESCRIPTION
These were not caught in CI because we don't build with `--all-features` due to that triggering CUDA dependencies. Need to figure out a solution.

Also adds a test, even though it can only be triggered manually now by calling `cargo test` with `--feature f4-as-account`.