### PR TITLE
MEM-1009: Use a ResourceLimiter

### DIFF
--- a/fvm/src/call_manager/limiter.rs
+++ b/fvm/src/call_manager/limiter.rs
@@ -1,0 +1,82 @@
+use wasmtime::ResourceLimiter;
+
+use crate::machine::NetworkConfig;
+
+/// Limit resources throughout the whole message execution,
+/// across all Wasm instances.
+pub struct ExecResourceLimiter {
+    /// Maximum bytes that a single Wasm instance can use.
+    max_inst_memory_bytes: usize,
+    /// Maximum bytes that can be used during an execution, in total.
+    max_exec_memory_bytes: usize,
+    /// Total bytes desired so far in the whole execution.
+    /// This is a constraint for all stores created with the
+    /// same call manager.
+    total_exec_memory_bytes: usize,
+}
+
+impl ExecResourceLimiter {
+    pub fn new(max_inst_memory_bytes: usize, max_exec_memory_bytes: usize) -> Self {
+        Self {
+            max_inst_memory_bytes,
+            max_exec_memory_bytes,
+            total_exec_memory_bytes: 0,
+        }
+    }
+
+    pub fn for_network(config: &NetworkConfig) -> Self {
+        Self::new(
+            config.max_inst_memory_bytes as usize,
+            config.max_exec_memory_bytes as usize,
+        )
+    }
+}
+
+impl ResourceLimiter for ExecResourceLimiter {
+    fn memory_growing(&mut self, current: usize, desired: usize, maximum: Option<usize>) -> bool {
+        if desired > min(self.max_inst_memory_bytes, maximum) {
+            return false;
+        }
+
+        let total_desired = self.total_exec_memory_bytes + (desired - current);
+
+        if total_desired > min(self.max_exec_memory_bytes, maximum) {
+            return false;
+        }
+
+        self.total_exec_memory_bytes = total_desired;
+        true
+    }
+
+    /// No limit on table elements.
+    fn table_growing(&mut self, _current: u32, desired: u32, maximum: Option<u32>) -> bool {
+        maximum.map_or(true, |m| desired <= m)
+    }
+}
+
+fn min(a: usize, b: Option<usize>) -> usize {
+    b.map_or(a, |b| std::cmp::min(a, b))
+}
+
+#[cfg(test)]
+mod tests {
+    use wasmtime::ResourceLimiter;
+
+    use super::ExecResourceLimiter;
+
+    #[test]
+    fn basics() {
+        let mut limits = ExecResourceLimiter::new(4, 10);
+        assert!(limits.memory_growing(0, 3, None));
+        assert!(!limits.memory_growing(3, 4, Some(2)));
+        assert!(limits.memory_growing(3, 4, None));
+        assert!(!limits.memory_growing(4, 5, None));
+        assert!(limits.memory_growing(0, 4, None));
+        assert!(!limits.memory_growing(0, 3, None));
+        assert!(limits.memory_growing(0, 2, None));
+        assert!(!limits.memory_growing(0, 2, None));
+
+        assert!(limits.table_growing(0, 100, None));
+        assert!(!limits.table_growing(0, 100, Some(10)));
+    }
+}

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -2,6 +2,7 @@ use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::{ActorID, MethodNum};
+use wasmtime::ResourceLimiter;
 
 use crate::gas::{GasCharge, GasTracker, PriceList};
 use crate::kernel::{self, Result};
@@ -121,6 +122,9 @@ pub trait CallManager: 'static {
         self.gas_tracker_mut().apply_charge(charge)?;
         Ok(())
     }
+
+    /// Limit memory usage throughout a message execution and charge gas for memory expansion.
+    fn limiter_mut(&mut self) -> &mut dyn ResourceLimiter;
 }
 
 /// The result of a method invocation.

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -11,7 +11,7 @@ use crate::state_tree::StateTree;
 use crate::Kernel;
 
 pub mod backtrace;
-
+pub mod limiter;
 pub use backtrace::Backtrace;
 
 mod default;

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -93,10 +93,6 @@ where
             value_received,
         }
     }
-
-    fn limiter_mut(&mut self) -> &mut dyn ResourceLimiter {
-        self.call_manager.limiter_mut()
-    }
 }
 
 impl<C> DefaultKernel<C>
@@ -858,6 +854,15 @@ where
             )
         }
         Ok(())
+    }
+}
+
+impl<C> LimiterOps for DefaultKernel<C>
+where
+    C: CallManager,
+{
+    fn limiter_mut(&mut self) -> &mut dyn ResourceLimiter {
+        self.call_manager.limiter_mut()
     }
 }
 

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -93,6 +93,10 @@ where
             value_received,
         }
     }
+
+    fn limiter_mut(&mut self) -> &mut dyn ResourceLimiter {
+        self.call_manager.limiter_mut()
+    }
 }
 
 impl<C> DefaultKernel<C>

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -26,6 +26,7 @@ mod error;
 
 pub use error::{ClassifyResult, Context, ExecutionError, Result, SyscallError};
 use multihash::MultihashGeneric;
+use wasmtime::ResourceLimiter;
 
 use crate::call_manager::CallManager;
 use crate::gas::{Gas, PriceList};
@@ -82,6 +83,9 @@ pub trait Kernel:
     ) -> Self
     where
         Self: Sized;
+
+    /// Give access to the limiter of the underlying call manager.
+    fn limiter_mut(&mut self) -> &mut dyn ResourceLimiter;
 }
 
 /// Network-related operations.

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -56,6 +56,7 @@ pub trait Kernel:
     + RandomnessOps
     + SelfOps
     + SendOps
+    + LimiterOps
     + 'static
 {
     /// The [`Kernel`]'s [`CallManager`] is
@@ -83,9 +84,6 @@ pub trait Kernel:
     ) -> Self
     where
         Self: Sized;
-
-    /// Give access to the limiter of the underlying call manager.
-    fn limiter_mut(&mut self) -> &mut dyn ResourceLimiter;
 }
 
 /// Network-related operations.
@@ -341,4 +339,14 @@ pub trait DebugOps {
     /// Store an artifact.
     /// Returns error on malformed name, returns Ok and logs the error on system/os errors.
     fn store_artifact(&self, name: &str, data: &[u8]) -> Result<()>;
+}
+
+/// Track and charge for memory expansion.
+///
+/// This interface is not one of the operations the kernel provides to actors.
+/// It's only part of the kernel out of necessity to pass it through to the
+/// call manager which tracks the limits across the whole execution stack.
+pub trait LimiterOps {
+    /// Give access to the limiter of the underlying call manager.
+    fn limiter_mut(&mut self) -> &mut dyn ResourceLimiter;
 }

--- a/fvm/src/machine/engine.rs
+++ b/fvm/src/machine/engine.rs
@@ -405,13 +405,13 @@ impl Engine {
             memory: self.0.dummy_memory,
         };
 
-        //        todo!("Configure resource limiter");
-
         let mut store = wasmtime::Store::new(&self.0.engine, id);
         let ggtype = GlobalType::new(ValType::I64, Mutability::Var);
         let gg = Global::new(&mut store, ggtype, Val::I64(0))
             .expect("failed to create available_gas global");
         store.data_mut().avail_gas_global = gg;
+
+        store.limiter(|id| id.kernel.limiter_mut());
 
         store
     }

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -112,6 +112,11 @@ pub struct NetworkConfig {
     /// DEFAULT: 4GB
     pub max_inst_memory_bytes: u64,
 
+    /// Maximum size of memory used during the entire (recursive) message execution.
+    ///
+    /// DEFAULT: 4GB
+    pub max_exec_memory_bytes: u64,
+
     /// An override for builtin-actors. If specified, this should be the CID of a builtin-actors
     /// "manifest".
     ///
@@ -140,6 +145,7 @@ impl NetworkConfig {
             max_call_depth: 1024,
             max_wasm_stack: 2048,
             max_inst_memory_bytes: 4 * (1 << 30),
+            max_exec_memory_bytes: 4 * (1 << 30),
             actor_debugging: false,
             builtin_actors_override: None,
             price_list: price_list_by_network_version(network_version),

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -109,12 +109,12 @@ pub struct NetworkConfig {
 
     /// Maximum size of memory of any Wasm instance, ie. each level of the recursion, in bytes.
     ///
-    /// DEFAULT: 4GB
+    /// DEFAULT: 512MiB
     pub max_inst_memory_bytes: u64,
 
     /// Maximum size of memory used during the entire (recursive) message execution.
     ///
-    /// DEFAULT: 4GB
+    /// DEFAULT: 512MiB
     pub max_exec_memory_bytes: u64,
 
     /// An override for builtin-actors. If specified, this should be the CID of a builtin-actors
@@ -144,8 +144,8 @@ impl NetworkConfig {
             network_version,
             max_call_depth: 1024,
             max_wasm_stack: 2048,
-            max_inst_memory_bytes: 4 * (1 << 30),
-            max_exec_memory_bytes: 4 * (1 << 30),
+            max_inst_memory_bytes: 512 * (1 << 20),
+            max_exec_memory_bytes: 512 * (1 << 20),
             actor_debugging: false,
             builtin_actors_override: None,
             price_list: price_list_by_network_version(network_version),

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -15,6 +15,7 @@ use fvm_shared::address::Address;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use multihash::Code;
+use wasmtime::StoreLimits;
 
 pub const STUB_NETWORK_VER: NetworkVersion = NetworkVersion::V15;
 
@@ -168,6 +169,7 @@ pub struct DummyCallManager {
     pub origin: Address,
     pub nonce: u64,
     pub test_data: Rc<RefCell<TestData>>,
+    limits: StoreLimits,
 }
 
 /// Information to be read by external tests
@@ -188,6 +190,7 @@ impl DummyCallManager {
                 origin: Address::new_actor(&[]),
                 nonce: 0,
                 test_data: rc,
+                limits: StoreLimits::default(),
             },
             cell_ref,
         )
@@ -205,6 +208,7 @@ impl DummyCallManager {
                 origin: Address::new_actor(&[]),
                 nonce: 0,
                 test_data: rc,
+                limits: StoreLimits::default(),
             },
             cell_ref,
         )
@@ -224,6 +228,7 @@ impl CallManager for DummyCallManager {
             origin,
             nonce,
             test_data: rc,
+            limits: StoreLimits::default(),
         }
     }
 
@@ -296,5 +301,9 @@ impl CallManager for DummyCallManager {
 
     fn invocation_count(&self) -> u64 {
         todo!()
+    }
+
+    fn limiter_mut(&mut self) -> &mut dyn wasmtime::ResourceLimiter {
+        &mut self.limits
     }
 }

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -339,10 +339,6 @@ where
             data,
         )
     }
-
-    fn limiter_mut(&mut self) -> &mut dyn wasmtime::ResourceLimiter {
-        self.0.limiter_mut()
-    }
 }
 
 impl<M, C, K> ActorOps for TestKernel<K>
@@ -650,5 +646,14 @@ where
         value: &TokenAmount,
     ) -> Result<SendResult> {
         self.0.send(recipient, method, params, value)
+    }
+}
+
+impl<K> LimiterOps for TestKernel<K>
+where
+    K: LimiterOps,
+{
+    fn limiter_mut(&mut self) -> &mut dyn wasmtime::ResourceLimiter {
+        self.0.limiter_mut()
     }
 }

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -288,6 +288,10 @@ where
     fn invocation_count(&self) -> u64 {
         self.0.invocation_count()
     }
+
+    fn limiter_mut(&mut self) -> &mut dyn wasmtime::ResourceLimiter {
+        self.0.limiter_mut()
+    }
 }
 
 /// A kernel for intercepting syscalls.
@@ -334,6 +338,10 @@ where
             ),
             data,
         )
+    }
+
+    fn limiter_mut(&mut self) -> &mut dyn wasmtime::ResourceLimiter {
+        self.0.limiter_mut()
     }
 }
 

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -159,6 +159,17 @@ where
 
     /// Sets the Machine and the Executor in our Tester structure.
     pub fn instantiate_machine(&mut self, externs: E) -> Result<()> {
+        self.instantiate_machine_with_config(externs, |_| ())
+    }
+
+    /// Sets the Machine and the Executor in our Tester structure.
+    ///
+    /// The `configure` function allows the caller to adjust the `NetworkConfiguration` before
+    /// it's used to instantiate the rest of the components.
+    pub fn instantiate_machine_with_config<F>(&mut self, externs: E, configure: F) -> Result<()>
+    where
+        F: FnOnce(&mut NetworkConfig),
+    {
         // Take the state tree and leave None behind.
         let mut state_tree = self.state_tree.take().unwrap();
 
@@ -175,6 +186,9 @@ where
         nc.actor_debugging = true;
         nc.override_actors(self.builtin_actors);
         nc.enable_actor_debugging();
+
+        // Custom configuration.
+        configure(&mut nc);
 
         let mut mc = nc.for_epoch(0, state_root);
         mc.set_base_fee(TokenAmount::from_atto(DEFAULT_BASE_FEE));

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -207,7 +207,11 @@ fn native_stack_overflow() {
         .unwrap();
 
     // Instantiate machine
-    tester.instantiate_machine(DummyExterns).unwrap();
+    tester
+        .instantiate_machine_with_config(DummyExterns, |nc| {
+            nc.max_exec_memory_bytes = 4 * (1 << 30) // Use 4GB memory.
+        })
+        .unwrap();
 
     let exec_test =
         |exec: &mut ThreadedExecutor<IntegrationExecutor<MemoryBlockstore, DummyExterns>>,

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -209,7 +209,9 @@ fn native_stack_overflow() {
     // Instantiate machine
     tester
         .instantiate_machine_with_config(DummyExterns, |nc| {
-            nc.max_exec_memory_bytes = 4 * (1 << 30) // Use 4GB memory.
+            // The stack overflow test consumed the default 512MiB before it hit the recursion limit.
+            nc.max_exec_memory_bytes = 4 * (1 << 30);
+            nc.max_inst_memory_bytes = 4 * (1 << 30);
         })
         .unwrap();
 


### PR DESCRIPTION
Part of https://github.com/filecoin-project/ref-fvm/issues/1009 

The PR adds an `ExecResourceLimiter` that puts limits on the memory consumption allowed during execution in two ways:
1. `max_inst_memory_bytes` limits the amount of memory any single message _send_ can use
2. `max_exec_memory_bytes` limits the amount of memory that can be used throughout the whole execution. _This is wrong, see notes._

The limiter is created at the beginning of the message execution and used for everything as long as the `CallManager` is alive. Both `CallManager` and `Kernel` got a new `limiter_mut` method to return the limiter where they have to be handed over to wasmtime.

## Notes 

### Applying the wrong limit

On the 2nd point it turned out that the maximum limit should have been applied on the call stack _at any given time_, not overall, ie. once a recursive call is finished the limit should have been released back and made available for the next recursive call. I will address this in a separate PR.

### Extending the Kernel
I'm not too happy about the fact that I had to add it to the `Kernel` but it seemed like the lesser evil, as opposed to having a shared mutable reference to some limiter. That seems like it would have gone against the grain of what the `DefaultCallManager` is doing with the `map_mut` dance. The other options would be to add a method to expose the `CallManager` from the `Kernel` but that would give away too much power.

