### PR TITLE
MEM-1051: syscall (re-)pricing stats

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -41,6 +41,7 @@ fvm-wasm-instrument = { version = "0.2.0", features = ["bulk"] }
 yastl = "0.1.2"
 arbitrary = { version = "1.1.0", optional = true, features = ["derive"] }
 rand = "0.8.5"
+once_cell = "1.5"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -269,7 +269,7 @@ where
     where
         K: Kernel<CallManager = Self>,
     {
-        self.charge_gas(self.price_list().on_create_actor())?;
+        let t = self.charge_gas(self.price_list().on_create_actor())?;
 
         if addr.is_bls_zero_address() {
             return Err(
@@ -295,6 +295,9 @@ where
             );
             syscall_error!(IllegalArgument; "failed to serialize params: {}", e)
         })?;
+
+        // The cost of sending the message is measured independently.
+        t.stop();
 
         self.send_resolved::<K>(
             account_actor::SYSTEM_ACTOR_ID,
@@ -355,7 +358,7 @@ where
             .ok_or_else(|| syscall_error!(NotFound; "actor does not exist: {}", to))?;
 
         // Charge the method gas. Not sure why this comes second, but it does.
-        self.charge_gas(self.price_list().on_method_invocation(value, method))?;
+        let _ = self.charge_gas(self.price_list().on_method_invocation(value, method))?;
 
         // Transfer, if necessary.
         if !value.is_zero() {

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -3,7 +3,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::{ActorID, MethodNum};
 
-use crate::gas::{GasCharge, GasTracker, PriceList};
+use crate::gas::{GasCharge, GasTimer, GasTracker, PriceList};
 use crate::kernel::{self, Result};
 use crate::machine::{Machine, MachineContext};
 use crate::state_tree::StateTree;
@@ -116,9 +116,8 @@ pub trait CallManager: 'static {
     }
 
     /// Charge gas.
-    fn charge_gas(&mut self, charge: GasCharge) -> Result<()> {
-        self.gas_tracker_mut().apply_charge(charge)?;
-        Ok(())
+    fn charge_gas(&mut self, charge: GasCharge) -> Result<GasTimer> {
+        self.gas_tracker_mut().apply_charge(charge)
     }
 
     /// Limit memory usage throughout a message execution and charge gas for memory expansion.

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -84,7 +84,7 @@ where
 
                 // Charge for including the result (before we end the transaction).
                 if let InvocationResult::Return(value) = &ret {
-                    cm.charge_gas(cm.context().price_list.on_chain_return_value(
+                    let _ = cm.charge_gas(cm.context().price_list.on_chain_return_value(
                         value.as_ref().map(|v| v.size() as usize).unwrap_or(0),
                     ))?;
                 }

--- a/fvm/src/gas/charge.rs
+++ b/fvm/src/gas/charge.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::borrow::Cow;
+use std::time::Duration;
 
 use super::Gas;
 
@@ -14,6 +15,8 @@ pub struct GasCharge {
     pub compute_gas: Gas,
     /// Storage costs
     pub storage_gas: Gas,
+    /// Execution time related to this charge, if measured.
+    pub elapsed: Option<Duration>,
 }
 
 impl GasCharge {
@@ -23,6 +26,7 @@ impl GasCharge {
             name,
             compute_gas,
             storage_gas,
+            elapsed: None,
         }
     }
 

--- a/fvm/src/gas/charge.rs
+++ b/fvm/src/gas/charge.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::borrow::Cow;
+use std::sync::Arc;
 use std::time::Duration;
+
+use once_cell::sync::OnceCell;
 
 use super::Gas;
 
@@ -15,8 +18,8 @@ pub struct GasCharge {
     pub compute_gas: Gas,
     /// Storage costs
     pub storage_gas: Gas,
-    /// Execution time related to this charge, if measured.
-    pub elapsed: Option<Duration>,
+    /// Execution time related to this charge, if successfully measured.
+    pub elapsed: Arc<OnceCell<Duration>>,
 }
 
 impl GasCharge {
@@ -26,7 +29,7 @@ impl GasCharge {
             name,
             compute_gas,
             storage_gas,
-            elapsed: None,
+            elapsed: Default::default(),
         }
     }
 

--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -9,11 +9,13 @@ use num_traits::Zero;
 pub use self::charge::GasCharge;
 pub(crate) use self::outputs::GasOutputs;
 pub use self::price_list::{price_list_by_network_version, PriceList, WasmGasPrices};
+pub use self::timer::{GasInstant, GasTimer};
 use crate::kernel::{ExecutionError, Result};
 
 mod charge;
 mod outputs;
 mod price_list;
+mod timer;
 
 pub const MILLIGAS_PRECISION: i64 = 1000;
 
@@ -186,21 +188,28 @@ impl GasTracker {
 
     /// Safely consumes gas and returns an out of gas error if there is not sufficient
     /// enough gas remaining for charge.
-    pub fn charge_gas(&mut self, name: &str, to_use: Gas) -> Result<()> {
+    pub fn charge_gas(&mut self, name: &str, to_use: Gas) -> Result<GasTimer> {
         let res = self.charge_gas_inner(name, to_use);
         if let Some(trace) = &mut self.trace {
-            trace.push(GasCharge::new(name.to_owned(), to_use, Gas::zero()))
+            let charge = GasCharge::new(name.to_owned(), to_use, Gas::zero());
+            let timer = GasTimer::new(&charge);
+            trace.push(charge);
+            res.map(|_| timer)
+        } else {
+            res.map(|_| GasTimer::empty())
         }
-        res
     }
 
     /// Applies the specified gas charge, where quantities are supplied in milligas.
-    pub fn apply_charge(&mut self, charge: GasCharge) -> Result<()> {
+    pub fn apply_charge(&mut self, charge: GasCharge) -> Result<GasTimer> {
         let res = self.charge_gas_inner(&charge.name, charge.total());
         if let Some(trace) = &mut self.trace {
+            let timer = GasTimer::new(&charge);
             trace.push(charge);
+            res.map(|_| timer)
+        } else {
+            res.map(|_| GasTimer::empty())
         }
-        res
     }
 
     /// Getter for the maximum gas usable by this message.
@@ -249,9 +258,9 @@ mod tests {
     #[allow(clippy::identity_op)]
     fn basic_gas_tracker() -> Result<()> {
         let mut t = GasTracker::new(Gas::new(20), Gas::new(10));
-        t.apply_charge(GasCharge::new("", Gas::new(5), Gas::zero()))?;
+        let _ = t.apply_charge(GasCharge::new("", Gas::new(5), Gas::zero()))?;
         assert_eq!(t.gas_used(), Gas::new(15));
-        t.apply_charge(GasCharge::new("", Gas::new(5), Gas::zero()))?;
+        let _ = t.apply_charge(GasCharge::new("", Gas::new(5), Gas::zero()))?;
         assert_eq!(t.gas_used(), Gas::new(20));
         assert!(t
             .apply_charge(GasCharge::new("", Gas::new(1), Gas::zero()))

--- a/fvm/src/gas/timer.rs
+++ b/fvm/src/gas/timer.rs
@@ -1,4 +1,7 @@
-use std::time::Instant;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use once_cell::sync::OnceCell;
 
 use super::GasCharge;
 
@@ -14,14 +17,10 @@ pub struct GasTimer(Option<GasTimerInner>);
 #[derive(Debug)]
 struct GasTimerInner {
     start: GasInstant,
+    elapsed: Arc<OnceCell<Duration>>,
 }
 
 impl GasTimer {
-    /// Create a timer that doesn't measure anything.
-    pub fn empty() -> Self {
-        GasTimer(None)
-    }
-
     /// Convenience method to start measuring time before the charge is made.
     ///
     /// Use the return value with [GasTimer::finish_with] to override the internal
@@ -30,22 +29,49 @@ impl GasTimer {
         GasInstant::now()
     }
 
+    /// Create a timer that doesn't measure anything.
+    pub fn empty() -> Self {
+        GasTimer(None)
+    }
+
     /// Create a new timer that will update the elapsed time of a charge when it's finished.
     pub fn new(charge: &GasCharge) -> Self {
-        todo!()
+        assert!(
+            charge.elapsed.get().is_none(),
+            "GasCharge::elapsed already set!"
+        );
+
+        Self(Some(GasTimerInner {
+            start: Self::start(),
+            elapsed: charge.elapsed.clone(),
+        }))
     }
 
     /// Record the elapsed time since the charge was made.
     pub fn stop(self) {
-        todo!()
+        if let Some(timer) = self.0 {
+            Self::set_elapsed(timer.elapsed, timer.start)
+        }
     }
 
     /// Record the elapsed time based on an instant taken before the charge was made.
     pub fn stop_with(self, start: GasInstant) {
-        todo!()
+        if let Some(timer) = self.0 {
+            Self::set_elapsed(timer.elapsed, start)
+        }
+    }
+
+    fn set_elapsed(elapsed: Arc<OnceCell<Duration>>, start: GasInstant) {
+        elapsed
+            .set(start.elapsed())
+            .expect("GasCharge::elapsed already set!")
     }
 
     /// Convenience method to record the elapsed time only if some execution was successful.
+    ///
+    /// There's no need to record the time of unsuccessful executions because we don't know
+    /// how they would compare to successful ones; maybe the error arised before the bulk
+    /// of the computation could have taken place.
     pub fn record<R, E>(self, result: Result<R, E>) -> Result<R, E> {
         if result.is_ok() {
             self.stop()

--- a/fvm/src/gas/timer.rs
+++ b/fvm/src/gas/timer.rs
@@ -1,0 +1,55 @@
+use std::time::Instant;
+
+use super::GasCharge;
+
+/// Type alias so that we can disable this with a compiler flag.
+pub type GasInstant = Instant;
+
+/// A handle returned by `charge_gas` which must be used to mark the end of
+/// the execution associated with that gas.
+#[must_use]
+#[derive(Debug)]
+pub struct GasTimer(Option<GasTimerInner>);
+
+#[derive(Debug)]
+struct GasTimerInner {
+    start: GasInstant,
+}
+
+impl GasTimer {
+    /// Create a timer that doesn't measure anything.
+    pub fn empty() -> Self {
+        GasTimer(None)
+    }
+
+    /// Convenience method to start measuring time before the charge is made.
+    ///
+    /// Use the return value with [GasTimer::finish_with] to override the internal
+    /// instant that the timer was started with.
+    pub fn start() -> GasInstant {
+        GasInstant::now()
+    }
+
+    /// Create a new timer that will update the elapsed time of a charge when it's finished.
+    pub fn new(charge: &GasCharge) -> Self {
+        todo!()
+    }
+
+    /// Record the elapsed time since the charge was made.
+    pub fn stop(self) {
+        todo!()
+    }
+
+    /// Record the elapsed time based on an instant taken before the charge was made.
+    pub fn stop_with(self, start: GasInstant) {
+        todo!()
+    }
+
+    /// Convenience method to record the elapsed time only if some execution was successful.
+    pub fn record<R, E>(self, result: Result<R, E>) -> Result<R, E> {
+        if result.is_ok() {
+            self.stop()
+        }
+        result
+    }
+}

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -29,7 +29,7 @@ use multihash::MultihashGeneric;
 use wasmtime::ResourceLimiter;
 
 use crate::call_manager::CallManager;
-use crate::gas::{Gas, PriceList};
+use crate::gas::{Gas, GasTimer, PriceList};
 use crate::machine::limiter::ExecMemory;
 use crate::machine::Machine;
 
@@ -228,7 +228,7 @@ pub trait GasOps {
 
     /// ChargeGas charges specified amount of `gas` for execution.
     /// `name` provides information about gas charging point.
-    fn charge_gas(&mut self, name: &str, compute: Gas) -> Result<()>;
+    fn charge_gas(&mut self, name: &str, compute: Gas) -> Result<GasTimer>;
 
     /// Returns the currently active gas price list.
     fn price_list(&self) -> &PriceList;

--- a/fvm/src/machine/engine.rs
+++ b/fvm/src/machine/engine.rs
@@ -16,7 +16,7 @@ use wasmtime::{
 };
 
 use super::limiter::ExecMemory;
-use crate::gas::WasmGasPrices;
+use crate::gas::{GasTimer, WasmGasPrices};
 use crate::machine::NetworkConfig;
 use crate::syscalls::{bind_syscalls, InvocationData};
 use crate::Kernel;
@@ -407,6 +407,7 @@ impl Engine {
             last_milligas_available: 0,
             start_memory_bytes: memory_bytes,
             last_memory_bytes: memory_bytes,
+            last_charge_time: GasTimer::start(),
             memory: self.0.dummy_memory,
         };
 

--- a/fvm/src/syscalls/bind.rs
+++ b/fvm/src/syscalls/bind.rs
@@ -95,7 +95,7 @@ fn memory_and_data<'a, K: Kernel>(
 macro_rules! charge_syscall_gas {
     ($kernel:expr) => {
         let charge = $kernel.price_list().on_syscall();
-        $kernel
+        let _ = $kernel
             .charge_gas(&charge.name, charge.compute_gas)
             .map_err(Abort::from_error_as_fatal)?;
     };

--- a/fvm/src/syscalls/gas.rs
+++ b/fvm/src/syscalls/gas.rs
@@ -14,5 +14,8 @@ pub fn charge_gas(
     let name =
         str::from_utf8(context.memory.try_slice(name_off, name_len)?).or_illegal_argument()?;
     // Gas charges from actors are always in full gas units. We use milligas internally, so convert here.
-    context.kernel.charge_gas(name, Gas::new(compute))
+    context
+        .kernel
+        .charge_gas(name, Gas::new(compute))
+        .map(|_| ())
 }

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -447,12 +447,12 @@ mod gas {
         assert_eq!(kern.gas_available(), avaliable);
         assert_eq!(kern.gas_used(), Gas::new(0));
 
-        kern.charge_gas("charge 6 gas", Gas::new(6))?;
+        let _ = kern.charge_gas("charge 6 gas", Gas::new(6))?;
 
         assert_eq!(kern.gas_available(), Gas::new(4));
         assert_eq!(kern.gas_used(), Gas::new(6));
 
-        kern.charge_gas("refund 6 gas", Gas::new(-6))?;
+        let _ = kern.charge_gas("refund 6 gas", Gas::new(-6))?;
 
         assert_eq!(kern.gas_available(), avaliable);
         assert_eq!(kern.gas_used(), Gas::new(0));
@@ -492,7 +492,7 @@ mod gas {
         let (mut kern, _) = build_inspecting_gas_test(gas_tracker)?;
 
         // charge exactly as much as avaliable
-        kern.charge_gas("test test 123", test_gas)?;
+        let _ = kern.charge_gas("test test 123", test_gas)?;
         assert_eq!(kern.gas_used(), test_gas);
 
         // charge over by 1
@@ -505,9 +505,9 @@ mod gas {
         );
 
         // charge negative (refund) gas
-        kern.charge_gas("refund~", neg_test_gas)?;
+        let _ = kern.charge_gas("refund~", neg_test_gas)?;
         assert_eq!(kern.gas_used(), Gas::new(0));
-        kern.charge_gas("free gas!", neg_test_gas)?;
+        let _ = kern.charge_gas("free gas!", neg_test_gas)?;
 
         assert_eq!(
             kern.gas_used(),

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use anyhow::Context;
 use fvm::call_manager::{Backtrace, CallManager, FinishRet, InvocationResult};
 use fvm::externs::{Consensus, Externs, Rand};
-use fvm::gas::{Gas, GasCharge, GasTracker};
+use fvm::gas::{Gas, GasCharge, GasTimer, GasTracker};
 use fvm::machine::limiter::ExecMemory;
 use fvm::machine::{Engine, Machine, MachineContext, Manifest, NetworkConfig};
 use fvm::state_tree::{ActorState, StateTree};
@@ -310,7 +310,7 @@ impl CallManager for DummyCallManager {
         &mut self.gas_tracker
     }
 
-    fn charge_gas(&mut self, charge: GasCharge) -> kernel::Result<()> {
+    fn charge_gas(&mut self, charge: GasCharge) -> kernel::Result<GasTimer> {
         self.test_data.borrow_mut().charge_gas_calls += 1;
         self.gas_tracker_mut().apply_charge(charge)
     }


### PR DESCRIPTION
Resolves https://github.com/filecoin-project/ref-fvm/issues/1051

The PR aims to put in place some machinery to collect time statistics for things we charge gas for. The goal is to be able to do an analysis as described in https://arxiv.org/pdf/1905.00553v1.pdf , notably to establish a _Time-to-Gas ratio_ for syscalls, where possible.

The PR does so by returning a new `GasTimer` from the `charge_gas` method available on the `CallManager` and the `Kernel` which the caller must use either by ignoring it (where measuring time doesn't seem to make sense) or by stopping it at a point where the scope of the elapsed time is germane to the gas charged. The `GasTimer` writes the measured duration into a new field on `GasCharge`, from where it can be collected later for analysis as part of the execution trace.