### PR TITLE
init actor's state in nv18 and later unconditionally includes the extra field

### DIFF
--- a/fvm/src/init_actor.rs
+++ b/fvm/src/init_actor.rs
@@ -33,7 +33,6 @@ pub struct State {
     pub address_map: Cid,
     pub next_id: ActorID,
     pub network_name: String,
-    #[cfg(feature = "m2-native")]
     pub installed_actors: Cid,
 }
 
@@ -44,7 +43,6 @@ impl State {
     // integration/tester.
     #[allow(unused)]
     pub fn new_test<B: Blockstore>(store: &B) -> Self {
-        #[cfg(feature = "m2-native")]
         use cid::multihash::Code::Blake2b256;
 
         // Empty hamt Cid used for testing
@@ -53,14 +51,12 @@ impl State {
             .unwrap();
 
         // Empty list Cid used for testing
-        #[cfg(feature = "m2-native")]
         let el_cid = store.put_cbor(&Vec::<Cid>::new(), Blake2b256).unwrap();
 
         State {
             address_map: e_cid,
             next_id: 100,
             network_name: "test".to_owned(),
-            #[cfg(feature = "m2-native")]
             installed_actors: el_cid,
         }
     }


### PR DESCRIPTION
aka `installed_actors` which will only be populated in m2.2 or when the m2-native feature is enabled.

Companion to https://github.com/filecoin-project/builtin-actors/pull/813