### PR TITLE
MEM-1009: Apply max memory on call stack, not execution

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -123,29 +123,8 @@ where
             });
         }
 
-        // We check _then_ set because we don't count the top call. This effectivly allows a
-        // call-stack depth of `max_call_depth + 1` (or `max_call_depth` sub-calls). While this is
-        // likely a bug, this is how NV15 behaves so we mimic that behavior here.
-        //
-        // By example:
-        //
-        // 1. If the max depth is 0, call_stack_depth will be 1 and the top-level message won't be
-        //    able to make sub-calls (1 > 0).
-        // 2. If the max depth is 1, the call_stack_depth will be 1 in the top-level message, 2 in
-        //    sub-calls, and said sub-calls will not be able to make further subcalls (2 > 1).
-        //
-        // NOTE: Unlike the FVM, Lotus adds _then_ checks. It does this because the
-        // `call_stack_depth` in lotus is 0 for the top-level call, unlike in the FVM where it's 1.
-        if self.call_stack_depth > self.machine.context().max_call_depth {
-            let sys_err = syscall_error!(LimitExceeded, "message execution exceeds call depth");
-            if self.machine.context().tracing {
-                self.trace(ExecutionEvent::CallError(sys_err.clone()));
-            }
-            return Err(sys_err.into());
-        }
-        self.push_call_stack();
-        let result = self.send_unchecked::<K>(from, to, method, params, value);
-        self.pop_call_stack();
+        let result =
+            self.with_stack_frame(|s| s.send_unchecked::<K>(from, to, method, params, value));
 
         if self.machine.context().tracing {
             self.trace(match &result {
@@ -504,6 +483,9 @@ where
         })
     }
 
+    /// Temporarily replace `self` with a version that contains `None` for the inner part,
+    /// to be able to hand over ownership of `self` to a new kernel, while the older kernel
+    /// has a reference to the hollowed out version.
     fn map_mut<F, T>(&mut self, f: F) -> T
     where
         F: FnOnce(Self) -> (T, Self),
@@ -511,14 +493,40 @@ where
         replace_with::replace_with_and_return(self, || DefaultCallManager(None), f)
     }
 
-    fn push_call_stack(&mut self) {
-        self.call_stack_depth += 1;
-        self.limiter_mut().push_call_stack();
-    }
+    /// Check that we're not violating the call stack depth, then envelope a call
+    /// with an increase/decrease of the depth to make sure none of them are missed.
+    fn with_stack_frame<F, V>(&mut self, f: F) -> Result<V>
+    where
+        F: FnOnce(&mut Self) -> Result<V>,
+    {
+        // We check _then_ set because we don't count the top call. This effectivly allows a
+        // call-stack depth of `max_call_depth + 1` (or `max_call_depth` sub-calls). While this is
+        // likely a bug, this is how NV15 behaves so we mimic that behavior here.
+        //
+        // By example:
+        //
+        // 1. If the max depth is 0, call_stack_depth will be 1 and the top-level message won't be
+        //    able to make sub-calls (1 > 0).
+        // 2. If the max depth is 1, the call_stack_depth will be 1 in the top-level message, 2 in
+        //    sub-calls, and said sub-calls will not be able to make further subcalls (2 > 1).
+        //
+        // NOTE: Unlike the FVM, Lotus adds _then_ checks. It does this because the
+        // `call_stack_depth` in lotus is 0 for the top-level call, unlike in the FVM where it's 1.
+        if self.call_stack_depth > self.machine.context().max_call_depth {
+            let sys_err = syscall_error!(LimitExceeded, "message execution exceeds call depth");
+            if self.machine.context().tracing {
+                self.trace(ExecutionEvent::CallError(sys_err.clone()));
+            }
+            return Err(sys_err.into());
+        }
 
-    fn pop_call_stack(&mut self) {
-        assert_ne!(self.call_stack_depth, 0);
-        self.limiter_mut().pop_call_stack();
+        self.call_stack_depth += 1;
+        let res = <<<DefaultCallManager<M> as CallManager>::Machine as Machine>::Limiter>::with_stack_frame(
+            self,
+            |s| s.limiter_mut(),
+            f,
+        );
         self.call_stack_depth -= 1;
+        res
     }
 }

--- a/fvm/src/machine/engine.rs
+++ b/fvm/src/machine/engine.rs
@@ -398,7 +398,7 @@ impl Engine {
 
     /// Construct a new wasmtime "store" from the given kernel.
     pub fn new_store<K: Kernel>(&self, mut kernel: K) -> wasmtime::Store<InvocationData<K>> {
-        let memory_bytes = kernel.limiter_mut().total_exec_memory_bytes();
+        let memory_bytes = kernel.limiter_mut().curr_exec_memory_bytes();
 
         let id = InvocationData {
             kernel,

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -98,7 +98,7 @@ pub fn charge_for_exec<K: Kernel>(
         .wasm_rules
         .memory_expansion_per_byte_cost;
 
-    let memory_bytes = data.kernel.limiter_mut().total_exec_memory_bytes();
+    let memory_bytes = data.kernel.limiter_mut().curr_exec_memory_bytes();
     let memory_delta_bytes = memory_bytes - data.last_memory_bytes;
     let mut memory_gas = memory_price * memory_delta_bytes as i64;
     exec_gas = (exec_gas - memory_gas).max(Gas::zero());

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -59,12 +59,13 @@ impl Consensus for DummyExterns {
 
 #[derive(Default)]
 pub struct DummyLimiter {
-    total_exec_memory_bytes: usize,
+    curr_exec_memory_bytes: usize,
+    prev_exec_memory_bytes: Vec<usize>,
 }
 
 impl ResourceLimiter for DummyLimiter {
     fn memory_growing(&mut self, current: usize, desired: usize, _maximum: Option<usize>) -> bool {
-        self.total_exec_memory_bytes += desired - current;
+        self.curr_exec_memory_bytes += desired - current;
         true
     }
 
@@ -74,8 +75,15 @@ impl ResourceLimiter for DummyLimiter {
 }
 
 impl ExecMemory for DummyLimiter {
-    fn total_exec_memory_bytes(&self) -> usize {
-        self.total_exec_memory_bytes
+    fn curr_exec_memory_bytes(&self) -> usize {
+        self.curr_exec_memory_bytes
+    }
+    fn push_call_stack(&mut self) {
+        self.prev_exec_memory_bytes
+            .push(self.curr_exec_memory_bytes);
+    }
+    fn pop_call_stack(&mut self) {
+        self.curr_exec_memory_bytes = self.prev_exec_memory_bytes.pop().unwrap();
     }
 }
 

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -763,7 +763,15 @@ impl<L> ExecMemory for TestLimiter<L>
 where
     L: ExecMemory,
 {
-    fn total_exec_memory_bytes(&self) -> usize {
-        self.inner.total_exec_memory_bytes()
+    fn curr_exec_memory_bytes(&self) -> usize {
+        self.inner.curr_exec_memory_bytes()
+    }
+
+    fn push_call_stack(&mut self) {
+        self.inner.push_call_stack()
+    }
+
+    fn pop_call_stack(&mut self) {
+        self.inner.pop_call_stack()
     }
 }

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -767,11 +767,11 @@ where
         self.inner.curr_exec_memory_bytes()
     }
 
-    fn push_call_stack(&mut self) {
-        self.inner.push_call_stack()
-    }
-
-    fn pop_call_stack(&mut self) {
-        self.inner.pop_call_stack()
+    fn with_stack_frame<T, G, F, R>(t: &mut T, g: G, f: F) -> R
+    where
+        G: Fn(&mut T) -> &mut Self,
+        F: FnOnce(&mut T) -> R,
+    {
+        L::with_stack_frame(t, |t| &mut g(t).inner, f)
     }
 }


### PR DESCRIPTION
Closes https://github.com/filecoin-project/ref-fvm/issues/1009 

Fixes the `ExecResourceLimiter` to apply the `max_exec_memory_bytes` limit on the call stack itself, restoring the available memory limits as the stack depth goes back towards zero, rather than the whole execution; the latter is only limited by the available gas.

## Notes

Initially I tried "deriving" a new limiter so that we can just drop it when the call stack is finished. It doesn't seem that simple though, because the new kernel is created from the `CallManager`, so the limiter inside the `CallManager` must reflect the current total memory in the call stack. Deriving something that points at this instance and gets dropped together with the `Kernel` would require some shared internal memory between the (many) limiters. That seemed to be an overkill compared to just calling an explicit push and pop when the `CallManager` is adjusting the depths.

