### PR TITLE
state tree v5

### DIFF
--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -104,7 +104,7 @@ mod test {
     #[test]
     fn test_constructor() {
         let mut bs = MemoryBlockstore::default();
-        let mut st = StateTree::new(bs, StateTreeVersion::V4).unwrap();
+        let mut st = StateTree::new(bs, StateTreeVersion::V5).unwrap();
         let root = st.flush().unwrap();
         bs = st.into_store();
 

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -72,7 +72,7 @@ impl DummyMachine {
         let bs = MemoryBlockstore::new();
 
         // generate new state root
-        let mut state_tree = StateTree::new(bs, StateTreeVersion::V4)?;
+        let mut state_tree = StateTree::new(bs, StateTreeVersion::V5)?;
         let root = state_tree.flush()?;
         let bs = state_tree.into_store();
 

--- a/shared/src/state/mod.rs
+++ b/shared/src/state/mod.rs
@@ -21,6 +21,8 @@ pub enum StateTreeVersion {
     V3,
     /// Corresponds to actors >= v5
     V4,
+    /// Corresponding to actors >= v10
+    V5,
 }
 
 /// State root information. Contains information about the version of the state tree,

--- a/testing/integration/examples/integration.rs
+++ b/testing/integration/examples/integration.rs
@@ -31,7 +31,7 @@ pub fn main() {
     let bs = MemoryBlockstore::default();
     let bundle_root = bundle::import_bundle(&bs, actors_v10::BUNDLE_CAR).unwrap();
     let mut tester =
-        Tester::new(NetworkVersion::V18, StateTreeVersion::V4, bundle_root, bs).unwrap();
+        Tester::new(NetworkVersion::V18, StateTreeVersion::V5, bundle_root, bs).unwrap();
 
     let sender: [Account; 1] = tester.create_accounts().unwrap();
 

--- a/testing/integration/tests/address_test.rs
+++ b/testing/integration/tests/address_test.rs
@@ -16,7 +16,7 @@ fn basic_address_tests() {
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,
-        StateTreeVersion::V4,
+        StateTreeVersion::V5,
         MemoryBlockstore::default(),
     )
     .unwrap();

--- a/testing/integration/tests/embryo_sender_test.rs
+++ b/testing/integration/tests/embryo_sender_test.rs
@@ -19,7 +19,7 @@ fn embryo_as_sender() {
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,
-        StateTreeVersion::V4,
+        StateTreeVersion::V5,
         MemoryBlockstore::default(),
     )
     .unwrap();

--- a/testing/integration/tests/fil_integer_overflow.rs
+++ b/testing/integration/tests/fil_integer_overflow.rs
@@ -26,7 +26,7 @@ fn instantiate_tester() -> (Account, Tester<MemoryBlockstore, DummyExterns>, Add
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,
-        StateTreeVersion::V4,
+        StateTreeVersion::V5,
         MemoryBlockstore::default(),
     )
     .unwrap();

--- a/testing/integration/tests/fil_syscall.rs
+++ b/testing/integration/tests/fil_syscall.rs
@@ -44,7 +44,7 @@ fn instantiate_tester(
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,
-        StateTreeVersion::V4,
+        StateTreeVersion::V5,
         MemoryBlockstore::default(),
     )
     .unwrap();

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -36,7 +36,7 @@ fn hello_world() {
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,
-        StateTreeVersion::V4,
+        StateTreeVersion::V5,
         MemoryBlockstore::default(),
     )
     .unwrap();
@@ -82,7 +82,7 @@ fn ipld() {
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,
-        StateTreeVersion::V4,
+        StateTreeVersion::V5,
         MemoryBlockstore::default(),
     )
     .unwrap();
@@ -134,7 +134,7 @@ fn syscalls() {
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,
-        StateTreeVersion::V4,
+        StateTreeVersion::V5,
         MemoryBlockstore::default(),
     )
     .unwrap();
@@ -186,7 +186,7 @@ fn native_stack_overflow() {
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,
-        StateTreeVersion::V4,
+        StateTreeVersion::V5,
         MemoryBlockstore::default(),
     )
     .unwrap();
@@ -251,7 +251,7 @@ fn test_exitcode(wat: &str, code: ExitCode) {
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,
-        StateTreeVersion::V4,
+        StateTreeVersion::V5,
         MemoryBlockstore::default(),
     )
     .unwrap();
@@ -407,7 +407,7 @@ fn backtraces() {
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,
-        StateTreeVersion::V4,
+        StateTreeVersion::V5,
         blockstore.clone(),
     )
     .unwrap();


### PR DESCRIPTION
Really, we have changed the data structure for ActorState, so we must bump the state tree version as well and we can't parse anything else.