### PR TITLE
release fvm crates; versions below (+).

### DIFF
--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Changes to the reference FVM implementation.
 
-##  [Unreleased]
+## [Unreleased]
+
+## 3.0.0-alpha.7 [2022-11-14]
+
+- MEM-851: Memory expansion gas (#1067)
+- Split `InvokeContext` into two (#1070)
+- Support EAM singleton in manifest (#1005)
 
 ## 3.0.0-alpha.6
 

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "3.0.0-alpha.6"
+version = "3.0.0-alpha.7"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -19,8 +19,8 @@ derive_builder = "0.11.2"
 num-derive = "0.3.3"
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.3", default-features = false }
-fvm_shared = { version = "3.0.0-alpha.9", path = "../shared", features = ["crypto"] }
-fvm_ipld_hamt = { version = "0.6.0", path = "../ipld/hamt" }
+fvm_shared = { version = "3.0.0-alpha.10", path = "../shared", features = ["crypto"] }
+fvm_ipld_hamt = { version = "0.6.1", path = "../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.0", path = "../ipld/amt" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.3.0", path = "../ipld/encoding" }

--- a/ipld/hamt/CHANGELOG.md
+++ b/ipld/hamt/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+- ...
+
+## 0.6.1 [2022-11-14]
+
+- FIX: HashBits::next when bit_width does not divide 256 and the full hash is consumed
+
 ## 0.6.0
 
 - Bumps `fvm_ipld_encoding` and switches from `cs_serde_bytes` to `fvm_ipld_encoding::strict_bytes`.

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_hamt"
 description = "Sharded IPLD HashMap implementation."
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 3.0.0-alpha.10 [2022-11-14]
+
+- Split `InvokeContext` into two (#1070)
+
 ## 3.0.0-alpha.9 [2022-10-21]
 
 - When debugging is enabled, set the default actor log level to trace. This won't affect actors unless debugging is enabled.

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "3.0.0-alpha.9"
+version = "3.0.0-alpha.10"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { version = "0.8.5", default-features = false }
-fvm_shared = { version = "3.0.0-alpha.9", path = "../shared" }
+fvm_shared = { version = "3.0.0-alpha.10", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = { version = "1.4.0", optional = true }

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 3.0.0-alpha.9 [UNRELEASED]
+## [Unreleased]
+
+- ...
+
+## 3.0.0-alpha.10 [2022-11-14]
+
+- Split `InvokeContext` into two (#1070)
+- fix: correctly format negative token amounts (#1065)
 
 ## 3.0.0-alpha.9 [2022-11-08]
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "3.0.0-alpha.9"
+version = "3.0.0-alpha.10"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "3.0.0-alpha.9", path = "../../shared" }
-fvm_ipld_hamt = { version = "0.6.0", path = "../../ipld/hamt" }
+fvm_shared = { version = "3.0.0-alpha.10", path = "../../shared" }
+fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.0", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
@@ -50,7 +50,7 @@ actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/
 libipld-core = { version = "0.14.0", features = ["serde-codec"] }
 
 [dependencies.fvm]
-version = "3.0.0-alpha.6"
+version = "3.0.0-alpha.7"
 path = "../../fvm"
 default-features = false
 features = ["testing"]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -8,9 +8,9 @@ authors = ["Protocol Labs", "Filecoin Core Devs", "Polyphene"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "3.0.0-alpha.6", path = "../../fvm", default-features = false }
-fvm_shared = { version = "3.0.0-alpha.9", path = "../../shared" }
-fvm_ipld_hamt = { version = "0.6.0", path = "../../ipld/hamt" }
+fvm = { version = "3.0.0-alpha.7", path = "../../fvm", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.10", path = "../../shared" }
+fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.0", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }

--- a/testing/integration/tests/fil-address-actor/Cargo.toml
+++ b/testing/integration/tests/fil-address-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.9", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.9", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.10", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.10", path = "../../../../shared" }
 serde = "1.0.145"
 
 [build-dependencies]

--- a/testing/integration/tests/fil-hello-world-actor/Cargo.toml
+++ b/testing/integration/tests/fil-hello-world-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.9", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.9", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.10", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.10", path = "../../../../shared" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.9", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.9", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.10", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.10", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../../../ipld/blockstore" }
 

--- a/testing/integration/tests/fil-ipld-actor/Cargo.toml
+++ b/testing/integration/tests/fil-ipld-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.9", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.9", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.10", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.10", path = "../../../../shared" }
 
 [target.'cfg(coverage)'.dependencies]
 minicov = "0.2"

--- a/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_shared = { version = "3.0.0-alpha.9", path = "../../../../shared" }
-fvm_sdk = { version = "3.0.0-alpha.9", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.10", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.10", path = "../../../../sdk" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.9", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.9", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.10", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.10", path = "../../../../shared" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-syscall-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.9", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.9", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.10", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.10", path = "../../../../shared" }
 minicov = {version = "0.2", optional = true}
 actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 multihash = "0.16.3"


### PR DESCRIPTION
- fvm => 3.0.0-alpha.7
- fvm_shared => 3.0.0-alpha.10
- fvm_sdk => 3.0.0-alpha.10
- fvm_ipld_hamt => 0.6.1