### PR TITLE
feat: allow constructing an AMT from an iterator or borrowed values.

### DIFF
--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -7,6 +7,7 @@ use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::de::DeserializeOwned;
 use fvm_ipld_encoding::ser::Serialize;
+use fvm_ipld_encoding::serde::Deserialize;
 use fvm_ipld_encoding::CborStore;
 use itertools::sorted;
 
@@ -58,8 +59,6 @@ impl<V: PartialEq, BS: Blockstore, Ver: PartialEq> PartialEq for AmtImpl<V, BS, 
 
 impl<V, BS, Ver> AmtImpl<V, BS, Ver>
 where
-    V: DeserializeOwned + Serialize,
-    BS: Blockstore,
     Ver: AmtVersion,
 {
     /// Constructor for Root AMT node
@@ -79,6 +78,55 @@ where
         self.root.bit_width
     }
 
+    /// Gets the height of the `Amt`.
+    pub fn height(&self) -> u32 {
+        self.root.height
+    }
+
+    /// Gets count of elements added in the `Amt`.
+    pub fn count(&self) -> u64 {
+        self.root.count
+    }
+}
+
+impl<V, BS, Ver> AmtImpl<V, BS, Ver>
+where
+    Ver: AmtVersion,
+    BS: Blockstore,
+    V: Serialize,
+{
+    /// Generates an AMT with block store and array of cbor marshallable objects and returns Cid
+    ///
+    /// This can be called with an iterator of _references_ to values to avoid copying.
+    pub fn new_from_iter(block_store: BS, vals: impl IntoIterator<Item = V>) -> Result<Cid, Error> {
+        #[derive(serde::Serialize)]
+        #[serde(transparent)]
+        struct FakeDeserialize<V>(V);
+
+        impl<'de, V> Deserialize<'de> for FakeDeserialize<V> {
+            fn deserialize<D>(_: D) -> Result<Self, D::Error>
+            where
+                D: fvm_ipld_encoding::serde_bytes::Deserializer<'de>,
+            {
+                use serde::de::Error;
+                Err(D::Error::custom("can't deserialize"))
+            }
+        }
+
+        let mut t = AmtImpl::<_, BS, Ver>::new(block_store);
+
+        t.batch_set(vals.into_iter().map(FakeDeserialize))?;
+
+        t.flush()
+    }
+}
+
+impl<V, BS, Ver> AmtImpl<V, BS, Ver>
+where
+    V: DeserializeOwned + Serialize,
+    BS: Blockstore,
+    Ver: AmtVersion,
+{
     /// Constructs an AMT with a blockstore and a Cid of the root of the AMT
     pub fn load(cid: &Cid, block_store: BS) -> Result<Self, Error> {
         // Load root bytes from database
@@ -92,25 +140,6 @@ where
         }
 
         Ok(Self { root, block_store })
-    }
-
-    /// Gets the height of the `Amt`.
-    pub fn height(&self) -> u32 {
-        self.root.height
-    }
-
-    /// Gets count of elements added in the `Amt`.
-    pub fn count(&self) -> u64 {
-        self.root.count
-    }
-
-    /// Generates an AMT with block store and array of cbor marshallable objects and returns Cid
-    pub fn new_from_iter(block_store: BS, vals: impl IntoIterator<Item = V>) -> Result<Cid, Error> {
-        let mut t = Self::new(block_store);
-
-        t.batch_set(vals)?;
-
-        t.flush()
     }
 
     /// Get value at index of AMT

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -456,3 +456,20 @@ fn delete_bug_test() {
 fn tbytes(bz: &[u8]) -> BytesDe {
     BytesDe(bz.to_vec())
 }
+
+#[test]
+fn new_from_iter() {
+    let mem = MemoryBlockstore::default();
+    let data: Vec<String> = (0..1000).map(|i| format!("thing{i}")).collect();
+    let k = Amt::<&str, _>::new_from_iter(&mem, data.iter().map(|s| &**s)).unwrap();
+
+    let a: Amt<String, _> = Amt::load(&k, &mem).unwrap();
+    let mut restored = Vec::new();
+    a.for_each(|k, v| {
+        restored.push((k as usize, v.clone()));
+        Ok(())
+    })
+    .unwrap();
+    let expected: Vec<_> = data.into_iter().enumerate().collect();
+    assert_eq!(expected, restored);
+}


### PR DESCRIPTION
This works because we never have to read or deserialize when creating an AMT from scratch.

Most of the code changes are actually just re-arranging the implementation into three sections:

1. The first that has no type restrictions (useful for avoiding type bounds where we don't need them).
2. The second for the newly changed function that doesn't have the `V: DeserializeOwned` requirement.
3. The third for everything else.