### PR TITLE
EVM-892: HAMT min_data_depth option

### DIFF
--- a/ipld/hamt/CHANGELOG.md
+++ b/ipld/hamt/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- ...
+- Add `min_data_depth` option to reserve the top levels of the HAMT for links, free of key-value pairs.
 
 ## 0.6.1 [2022-11-14]
 

--- a/ipld/hamt/fuzz/Cargo.toml
+++ b/ipld/hamt/fuzz/Cargo.toml
@@ -26,3 +26,9 @@ name = "simple"
 path = "fuzz_targets/simple.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "extensions"
+path = "fuzz_targets/extensions.rs"
+test = false
+doc = false

--- a/ipld/hamt/fuzz/fuzz_targets/extensions.rs
+++ b/ipld/hamt/fuzz/fuzz_targets/extensions.rs
@@ -7,11 +7,11 @@ use libfuzzer_sys::fuzz_target;
 
 mod common;
 
-fuzz_target!(|data: (u8, Vec<common::Operation>)| {
-    let (flush_rate, operations) = data;
+fuzz_target!(|data: (u8, u32, u32, Vec<common::Operation>)| {
+    let (flush_rate, bit_width, min_data_depth, operations) = data;
     let conf = Config {
-        bit_width: 2,
-        min_data_depth: 1,
+        bit_width: 1 + bit_width % 8,
+        min_data_depth: 0 + min_data_depth % 3,
     };
     common::run(flush_rate, operations, conf);
 });

--- a/ipld/hamt/fuzz/fuzz_targets/extensions.rs
+++ b/ipld/hamt/fuzz/fuzz_targets/extensions.rs
@@ -1,0 +1,17 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+#![no_main]
+use fvm_ipld_hamt::Config;
+use libfuzzer_sys::fuzz_target;
+
+mod common;
+
+fuzz_target!(|data: (u8, Vec<common::Operation>)| {
+    let (flush_rate, operations) = data;
+    let conf = Config {
+        bit_width: 2,
+        min_data_depth: 1,
+    };
+    common::run(flush_rate, operations, conf);
+});

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -85,7 +85,13 @@ where
 
     /// Construct hamt with a bit width
     pub fn new_with_bit_width(store: BS, bit_width: u32) -> Self {
-        Self::new_with_config(store, Config { bit_width })
+        Self::new_with_config(
+            store,
+            Config {
+                bit_width,
+                ..Default::default()
+            },
+        )
     }
 
     /// Lazily instantiate a hamt from this root Cid.
@@ -108,7 +114,14 @@ where
     }
     /// Lazily instantiate a hamt from this root Cid with a specified bit width.
     pub fn load_with_bit_width(cid: &Cid, store: BS, bit_width: u32) -> Result<Self, Error> {
-        Self::load_with_config(cid, store, Config { bit_width })
+        Self::load_with_config(
+            cid,
+            store,
+            Config {
+                bit_width,
+                ..Default::default()
+            },
+        )
     }
 
     /// Sets the root based on the Cid of the root node using the Hamt store

--- a/ipld/hamt/src/lib.rs
+++ b/ipld/hamt/src/lib.rs
@@ -39,12 +39,31 @@ pub struct Config {
     /// Each node in the tree will have `2^bit_width` number of slots for child nodes,
     /// and consume `bit_width` number of bits from the hashed keys at each level.
     pub bit_width: u32,
+
+    /// The minimum depth at which the HAMT can store key-value pairs in a `Node`.
+    ///
+    /// Storing values in the nodes means we have to read and write larger chunks of data
+    /// whenever we're accessing something (be it a link or values) in any other bucket.
+    /// This is particularly costly in the root node, which is always retrieved as soon
+    /// as the HAMT is instantiated.
+    ///
+    /// This setting allows us to keep the root, and possibly a few more levels, free of
+    /// data, reserved for links. A sufficiently saturated tree will tend to contain only
+    /// links in the first levels anyway, once all the buckets have been filled and pushed
+    /// further down.
+    ///
+    /// A value of 0 means data can be put in the root node, which is the default behaviour.
+    ///
+    /// The setting makes most sense when the size of values outweigh the size of the link
+    /// pointing at them. When storing small, hash-sized values, it might not matter.
+    pub min_data_depth: u32,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             bit_width: DEFAULT_BIT_WIDTH,
+            min_data_depth: 0,
         }
     }
 }

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -260,7 +260,7 @@ where
 
         // No existing values at this point.
         if !self.bitfield.test_bit(idx) {
-            if conf.min_data_depth <= depth {
+            if depth >= conf.min_data_depth {
                 self.insert_child(idx, key, value);
             } else {
                 // Need to insert some empty nodes reserved for links.

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -95,6 +95,7 @@ where
         self.modify_value(
             &mut HashBits::new(&hash),
             conf,
+            0,
             key,
             value,
             store,
@@ -129,7 +130,7 @@ where
         S: Blockstore,
     {
         let hash = H::hash(k);
-        self.rm_value(&mut HashBits::new(&hash), conf, k, store)
+        self.rm_value(&mut HashBits::new(&hash), conf, 0, k, store)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -246,6 +247,7 @@ where
         &mut self,
         hashed_key: &mut HashBits,
         conf: &Config,
+        depth: u32,
         key: K,
         value: V,
         store: &S,
@@ -258,7 +260,14 @@ where
 
         // No existing values at this point.
         if !self.bitfield.test_bit(idx) {
-            self.insert_child(idx, key, value);
+            if conf.min_data_depth <= depth {
+                self.insert_child(idx, key, value);
+            } else {
+                // Need to insert some empty nodes reserved for links.
+                let mut sub = Node::<K, V, H>::default();
+                sub.modify_value(hashed_key, conf, depth + 1, key, value, store, overwrite)?;
+                self.insert_child_dirty(idx, Box::new(sub));
+            }
             return Ok((None, true));
         }
 
@@ -274,15 +283,22 @@ where
                 })?;
                 let child_node = cache.get_mut().expect("filled line above");
 
-                let (old, modified) =
-                    child_node.modify_value(hashed_key, conf, key, value, store, overwrite)?;
+                let (old, modified) = child_node.modify_value(
+                    hashed_key,
+                    conf,
+                    depth + 1,
+                    key,
+                    value,
+                    store,
+                    overwrite,
+                )?;
                 if modified {
                     *child = Pointer::Dirty(std::mem::take(child_node));
                 }
                 Ok((old, modified))
             }
             Pointer::Dirty(node) => {
-                node.modify_value(hashed_key, conf, key, value, store, overwrite)
+                node.modify_value(hashed_key, conf, depth + 1, key, value, store, overwrite)
             }
             Pointer::Values(vals) => {
                 // Update, if the key already exists.
@@ -315,13 +331,21 @@ where
 
                     let consumed = hashed_key.consumed;
                     let mut sub = Node::<K, V, H>::default();
-                    let modified =
-                        sub.modify_value(hashed_key, conf, key, value, store, overwrite)?;
+                    let modified = sub.modify_value(
+                        hashed_key,
+                        conf,
+                        depth + 1,
+                        key,
+                        value,
+                        store,
+                        overwrite,
+                    )?;
 
                     for (k, v, hash) in hashed_kvs {
                         sub.modify_value(
                             &mut HashBits::new_at_index(&hash, consumed),
                             conf,
+                            depth + 1,
                             k,
                             v,
                             store,
@@ -351,6 +375,7 @@ where
         &mut self,
         hashed_key: &mut HashBits,
         conf: &Config,
+        depth: u32,
         key: &Q,
         store: &S,
     ) -> Result<Option<(K, V)>, Error>
@@ -377,23 +402,23 @@ where
                 })?;
                 let child_node = cache.get_mut().expect("filled line above");
 
-                let deleted = child_node.rm_value(hashed_key, conf, key, store)?;
+                let deleted = child_node.rm_value(hashed_key, conf, depth + 1, key, store)?;
 
                 if deleted.is_some() {
                     *child = Pointer::Dirty(std::mem::take(child_node));
-                    // Clean to retrieve canonical form
-                    child.clean()?;
+                    if Self::clean(child, conf, depth)? {
+                        self.rm_child(cindex, idx);
+                    }
                 }
 
                 Ok(deleted)
             }
             Pointer::Dirty(node) => {
                 // Delete value and return deleted value
-                let deleted = node.rm_value(hashed_key, conf, key, store)?;
+                let deleted = node.rm_value(hashed_key, conf, depth + 1, key, store)?;
 
-                if deleted.is_some() {
-                    // Clean to ensure canonical form
-                    child.clean()?;
+                if deleted.is_some() && Self::clean(child, conf, depth)? {
+                    self.rm_child(cindex, idx);
                 }
 
                 Ok(deleted)
@@ -451,6 +476,12 @@ where
         self.pointers.insert(i, Pointer::from_key_value(key, value))
     }
 
+    fn insert_child_dirty(&mut self, idx: u32, node: Box<Node<K, V, H>>) {
+        let i = self.index_for_bit_pos(idx);
+        self.bitfield.set_bit(idx);
+        self.pointers.insert(i, Pointer::Dirty(node))
+    }
+
     fn index_for_bit_pos(&self, bp: u32) -> usize {
         let mask = Bitfield::zero().set_bits_le(bp);
         assert_eq!(mask.count_ones(), bp as usize);
@@ -463,5 +494,17 @@ where
 
     fn get_child(&self, i: usize) -> &Pointer<K, V, H> {
         &self.pointers[i]
+    }
+
+    /// Clean after delete to retrieve canonical form.
+    ///
+    /// Returns true if the child pointer is completely empty and can be removed,
+    /// which can happen if we artificially inserted nodes during insertion.
+    fn clean(child: &mut Pointer<K, V, H>, conf: &Config, depth: u32) -> Result<bool, Error> {
+        match child.clean(conf, depth) {
+            Ok(()) => Ok(false),
+            Err(Error::ZeroPointers) if depth < conf.min_data_depth => Ok(true),
+            Err(err) => Err(err),
+        }
     }
 }

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -119,9 +119,7 @@ where
                 _ if depth < conf.min_data_depth => {
                     // We are in the shallows where we don't want key-value pairs, just links,
                     // so as long as they are pointing at non-empty nodes we can keep them.
-                    // The rest of the rules would either move key-value pairs up, or undo a split.
-                    // But if we use extensions and minimum data depth, splits will only happen after
-                    // the minimum data depth as well, and these don't need undoing. So we can skip.
+                    // The rest of the rules would move key-value pairs up.
                     Ok(())
                 }
                 1 => {

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -13,6 +13,7 @@ use serde::{ser, Deserialize, Deserializer, Serialize, Serializer};
 
 use super::node::Node;
 use super::{Error, Hash, HashAlgorithm, KeyValuePair, MAX_ARRAY_WIDTH};
+use crate::Config;
 
 /// Pointer to index values or a link to another child node.
 #[derive(Debug)]
@@ -111,10 +112,18 @@ where
 
     /// Internal method to cleanup children, to ensure consistent tree representation
     /// after deletes.
-    pub(crate) fn clean(&mut self) -> Result<(), Error> {
+    pub(crate) fn clean(&mut self, conf: &Config, depth: u32) -> Result<(), Error> {
         match self {
             Pointer::Dirty(n) => match n.pointers.len() {
                 0 => Err(Error::ZeroPointers),
+                _ if depth < conf.min_data_depth => {
+                    // We are in the shallows where we don't want key-value pairs, just links,
+                    // so as long as they are pointing at non-empty nodes we can keep them.
+                    // The rest of the rules would either move key-value pairs up, or undo a split.
+                    // But if we use extensions and minimum data depth, splits will only happen after
+                    // the minimum data depth as well, and these don't need undoing. So we can skip.
+                    Ok(())
+                }
                 1 => {
                     // Node has only one pointer, swap with parent node
                     if let Pointer::Values(vals) = &mut n.pointers[0] {

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -46,8 +46,10 @@ impl HamtFactory {
         K: Hash + Eq + PartialOrd + Serialize + DeserializeOwned,
         V: Serialize + DeserializeOwned,
     {
-        let mut conf = self.conf.clone();
-        conf.bit_width = bit_width;
+        let conf = Config {
+            bit_width,
+            ..self.conf
+        };
         Hamt::new_with_config(store, conf)
     }
 
@@ -71,8 +73,10 @@ impl HamtFactory {
         K: Hash + Eq + PartialOrd + Serialize + DeserializeOwned,
         V: Serialize + DeserializeOwned,
     {
-        let mut conf = self.conf.clone();
-        conf.bit_width = bit_width;
+        let conf = Config {
+            bit_width,
+            ..self.conf
+        };
         Hamt::load_with_config(cid, store, conf)
     }
 }
@@ -874,6 +878,19 @@ macro_rules! test_hamt_mod {
 test_hamt_mod!(
     test_binary_tree,
     HamtFactory {
-        conf: Config { bit_width: 1 },
+        conf: Config {
+            bit_width: 1,
+            min_data_depth: 0,
+        },
+    }
+);
+
+test_hamt_mod!(
+    test_min_data_depth,
+    HamtFactory {
+        conf: Config {
+            bit_width: 4,
+            min_data_depth: 2,
+        },
     }
 );

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -542,6 +542,44 @@ fn clean_child_ordering(factory: HamtFactory, stats: Option<BSStats>, mut cids: 
     }
 }
 
+#[test]
+fn min_data_depth_reduces_root_size() {
+    let mk_factory = |min_data_depth| HamtFactory {
+        conf: Config {
+            min_data_depth,
+            ..Default::default()
+        },
+    };
+
+    let factory1 = mk_factory(0);
+    let factory2 = mk_factory(1);
+
+    let mem = MemoryBlockstore::default();
+    let mut hamt1 = factory1.new(&mem);
+    let mut hamt2 = factory2.new(&mem);
+
+    for i in 0..100 {
+        hamt1.set(i, vec![1u8; 1000]).unwrap();
+        hamt2.set(i, vec![1u8; 1000]).unwrap();
+    }
+    let c1 = hamt1.flush().unwrap();
+    let c2 = hamt2.flush().unwrap();
+
+    assert!(c1 != c2);
+
+    let bytes_read_during_load = |c, f: &HamtFactory| {
+        let store = TrackingBlockstore::new(&mem);
+        let _: Hamt<_, Vec<u8>, i32> = f.load(c, &store).unwrap();
+        let stats = store.stats.borrow();
+        stats.br
+    };
+
+    let br1 = bytes_read_during_load(&c1, &factory1);
+    let br2 = bytes_read_during_load(&c2, &factory2);
+
+    assert!(br2 < br1);
+}
+
 /// List of key value pairs with unique keys.
 ///
 /// Uniqueness is used so insert order doesn't cause overwrites.


### PR DESCRIPTION
This PR contains some refactorings on the HAMT tests and the `min_data_depth` option from https://github.com/filecoin-project/ref-fvm/pull/935 which is the only one identified as a common good that we want to keep independent of the EVM footprint optimisation, which we'll carry on with a separate data structure.