### PR TITLE
refactor: move base-fee & timestamp into the network context

### DIFF
--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -160,15 +160,12 @@ pub fn bind_syscalls(
     linker.bind("vm", "abort", vm::abort)?;
     linker.bind("vm", "message_context", vm::message_context)?;
 
-    linker.bind("network", "base_fee", network::base_fee)?;
     linker.bind(
         "network",
         "total_fil_circ_supply",
         network::total_fil_circ_supply,
     )?;
     linker.bind("network", "context", network::context)?;
-
-    linker.bind("network", "tipset_timestamp", network::tipset_timestamp)?;
     linker.bind("network", "tipset_cid", network::tipset_cid)?;
 
     linker.bind("ipld", "block_open", ipld::block_open)?;

--- a/fvm/src/syscalls/network.rs
+++ b/fvm/src/syscalls/network.rs
@@ -5,16 +5,6 @@ use fvm_shared::sys::out::network::NetworkContext as SyscallNetworkContext;
 use super::Context;
 use crate::kernel::{ClassifyResult, Kernel, Result};
 
-/// Returns the base fee split as two u64 ordered in little endian.
-pub fn base_fee(context: Context<'_, impl Kernel>) -> Result<sys::TokenAmount> {
-    context
-        .kernel
-        .network_base_fee()
-        .try_into()
-        .context("base-fee exceeds u128 limit")
-        .or_fatal()
-}
-
 /// Returns the network circ supply split as two u64 ordered in little endian.
 pub fn total_fil_circ_supply(context: Context<'_, impl Kernel>) -> Result<sys::TokenAmount> {
     context
@@ -27,13 +17,16 @@ pub fn total_fil_circ_supply(context: Context<'_, impl Kernel>) -> Result<sys::T
 
 pub fn context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<SyscallNetworkContext> {
     Ok(SyscallNetworkContext {
-        network_curr_epoch: context.kernel.network_epoch(),
+        epoch: context.kernel.network_epoch(),
         network_version: context.kernel.network_version() as u32,
+        timestamp: context.kernel.tipset_timestamp(),
+        base_fee: context
+            .kernel
+            .network_base_fee()
+            .try_into()
+            .context("base-fee exceeds u128 limit")
+            .or_fatal()?,
     })
-}
-
-pub fn tipset_timestamp(context: Context<'_, impl Kernel>) -> Result<u64> {
-    Ok(context.kernel.tipset_timestamp())
 }
 
 pub fn tipset_cid(

--- a/sdk/src/network.rs
+++ b/sdk/src/network.rs
@@ -20,7 +20,7 @@ lazy_static::lazy_static! {
 }
 
 pub fn curr_epoch() -> ChainEpoch {
-    NETWORK_CONTEXT.network_curr_epoch
+    NETWORK_CONTEXT.epoch
 }
 
 pub fn version() -> NetworkVersion {
@@ -31,11 +31,7 @@ pub fn version() -> NetworkVersion {
 }
 
 pub fn base_fee() -> TokenAmount {
-    unsafe {
-        sys::network::base_fee()
-            .expect("failed to get base fee")
-            .into()
-    }
+    NETWORK_CONTEXT.base_fee.into()
 }
 
 pub fn total_fil_circ_supply() -> TokenAmount {
@@ -44,11 +40,6 @@ pub fn total_fil_circ_supply() -> TokenAmount {
             .expect("failed to get circulating supply")
             .into()
     }
-}
-
-/// Returns the current block time in seconds since the EPOCH.
-pub fn tipset_timestamp() -> u64 {
-    unsafe { sys::network::tipset_timestamp() }.expect("failed to get timestamp")
 }
 
 /// Returns the tipset CID of the specified epoch, if available. Allows querying from now up to

--- a/shared/src/sys/out.rs
+++ b/shared/src/sys/out.rs
@@ -82,12 +82,17 @@ pub mod vm {
 
 pub mod network {
     use crate::clock::ChainEpoch;
+    use crate::sys::TokenAmount;
 
     #[derive(Debug, Copy, Clone)]
     #[repr(packed, C)]
     pub struct NetworkContext {
         /// The current epoch.
-        pub network_curr_epoch: ChainEpoch,
+        pub epoch: ChainEpoch,
+        /// The current time (seconds since the unix epoch).
+        pub timestamp: u64,
+        /// The current base-fee.
+        pub base_fee: TokenAmount,
         /// The network version.
         pub network_version: u32,
     }


### PR DESCRIPTION
Now that we have a network context, there's no need to have separate syscalls for these. We've kept a separate syscall for the circulating supply, because we'd like to restrict that to special actors...

Also, rename network_curr_epoch to just epoch.