### PR TITLE
fix: BufferedBlockstore#flush should not reset the write buffer.

### DIFF
--- a/fvm/src/blockstore/buffered.rs
+++ b/fvm/src/blockstore/buffered.rs
@@ -42,14 +42,13 @@ where
 {
     /// Flushes the buffered cache based on the root node.
     /// This will recursively traverse the cache and write all data connected by links to this
-    /// root Cid.
+    /// root Cid. Calling flush will not reset the write buffer.
     fn flush(&self, root: &Cid) -> Result<()> {
         let mut buffer = Vec::new();
         let mut s = self.write.borrow_mut();
         copy_rec(&s, *root, &mut buffer)?;
 
         self.base.put_many_keyed(buffer)?;
-        *s = Default::default();
 
         Ok(())
     }


### PR DESCRIPTION
Resetting the buffer was never advertised as a behaviour of this method.

This makes it possible to call flush multiple times to selectively flush roots during its lifetime. Selective flushes are used to flush the event AMTs as they are being produced.