### PR TITLE
fix: allow f0 addresses to be used to generate new actor addresses

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -718,11 +718,11 @@ where
 
     // TODO(M2) merge new_actor_address and create_actor into a single syscall.
     fn new_actor_address(&mut self) -> Result<Address> {
+        // base the address on the predictable address, or the id address if none exists.
         let oa = self
             .lookup_address(self.call_manager.origin())
             .or_fatal()? // actor not found
-            .context("origin does not have a predictable address")
-            .or_fatal()?; // actor doesn't have a predictable address.
+            .unwrap_or_else(|| Address::new_id(self.call_manager.origin()));
 
         let mut b = to_vec(&oa)
             .or_fatal()


### PR DESCRIPTION
This is a stop-gap to ensure that we can deploy actors when the "origin" doesn't have a predictable address.

Future work: https://github.com/filecoin-project/FIPs/discussions/388#discussioncomment-4163159