### PR TITLE
fix: avoid treating some instantiation errors as fatal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,7 @@ dependencies = [
  "thiserror",
  "wasmtime",
  "wasmtime-environ",
+ "wasmtime-runtime",
  "yastl",
 ]
 

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -55,6 +55,10 @@ features = ["cranelift", "pooling-allocator", "parallel-compilation", "memory-in
 [dependencies.wasmtime-environ]
 version = "1.0.1"
 
+[dependencies.wasmtime-runtime]
+version = "1.0.1"
+default-features = false
+
 [features]
 f4-as-account = ["fvm_shared/f4-as-account"]
 default = ["opencl"]

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -432,11 +432,33 @@ where
 
             // From this point on, there are no more syscall errors, only aborts.
             let result: std::result::Result<BlockId, Abort> = (|| {
+                use wasmtime_runtime::InstantiationError;
                 // Instantiate the module.
                 let instance = engine
                     .get_instance(&mut store, &state.code)
                     .and_then(|i| i.context("actor code not found"))
-                    .map_err(Abort::Fatal)?;
+                    .map_err(|e| match e.downcast::<InstantiationError>() {
+                        Ok(e) => match e {
+                            // This will be handled in validation.
+                            InstantiationError::Link(e) => Abort::Fatal(anyhow!(e)),
+                            // TODO: We may want a separate OOM exit code? However, normal ooms will usually exit with SYS_ILLEGAL_INSTRUCTION.
+                            InstantiationError::Resource(e) => {
+                                Abort::Exit(ExitCode::SYS_ILLEGAL_INSTRUCTION, e.to_string())
+                            }
+                            // TODO: we probably shouldn't hit this unless we're running code? We
+                            // should check if we can "validate away" this case.
+                            InstantiationError::Trap(e) => Abort::Exit(
+                                ExitCode::SYS_ILLEGAL_INSTRUCTION,
+                                format!("actor initialization failed: {:?}", e),
+                            ),
+                            // TODO: Consider using the instance limit instead of an explicit stack depth?
+                            InstantiationError::Limit(limit) => Abort::Fatal(anyhow!(
+                                "did not expect to hit wasmtime instance limit: {}",
+                                limit
+                            )),
+                        },
+                        Err(e) => Abort::Fatal(e),
+                    })?;
 
                 // Resolve and store a reference to the exported memory.
                 let memory = instance


### PR DESCRIPTION
Specifically, OOM and TRAPs during instantiation are _not_ fatal.

fixes #1102