### PR TITLE
chore: release sdk, fvm, shared, and integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,7 +1528,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "num-derive",
  "num-traits",
  "serde",
@@ -1561,7 +1561,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "log",
  "num-derive",
  "num-traits",
@@ -1581,7 +1581,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "lazy_static",
  "log",
  "num-derive",
@@ -1594,8 +1594,8 @@ name = "fil_actor_embryo"
 version = "10.0.0-alpha.1"
 source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#ee12a8c1c4b19442041d7db2560bd0b738d68467"
 dependencies = [
- "fvm_sdk 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 3.0.0-alpha.11",
+ "fvm_shared 3.0.0-alpha.11",
 ]
 
 [[package]]
@@ -1613,7 +1613,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "hex",
  "hex-literal",
  "impl-serde",
@@ -1643,7 +1643,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "log",
  "num-derive",
  "num-traits",
@@ -1663,7 +1663,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "integer-encoding",
  "libipld-core 0.13.1",
  "log",
@@ -1686,7 +1686,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -1708,7 +1708,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "indexmap",
  "integer-encoding",
  "num-derive",
@@ -1726,7 +1726,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "num-derive",
  "num-traits",
  "serde",
@@ -1743,7 +1743,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -1761,7 +1761,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "lazy_static",
  "log",
  "num-derive",
@@ -1779,7 +1779,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "num-derive",
  "num-traits",
  "serde",
@@ -1798,7 +1798,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.11",
  "lazy_static",
  "log",
  "num-derive",
@@ -1818,8 +1818,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 3.0.0-alpha.11",
+ "fvm_shared 3.0.0-alpha.11",
  "itertools 0.10.5",
  "log",
  "multihash",
@@ -1839,8 +1839,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.0",
- "fvm_sdk 3.0.0-alpha.11",
- "fvm_shared 3.0.0-alpha.11",
+ "fvm_sdk 3.0.0-alpha.12",
+ "fvm_shared 3.0.0-alpha.12",
  "serde",
  "substrate-wasm-builder",
 ]
@@ -1876,8 +1876,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.0",
- "fvm_sdk 3.0.0-alpha.11",
- "fvm_shared 3.0.0-alpha.11",
+ "fvm_sdk 3.0.0-alpha.12",
+ "fvm_shared 3.0.0-alpha.12",
  "serde",
  "serde_tuple",
  "substrate-wasm-builder",
@@ -1887,8 +1887,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.0.0-alpha.11",
- "fvm_shared 3.0.0-alpha.11",
+ "fvm_sdk 3.0.0-alpha.12",
+ "fvm_shared 3.0.0-alpha.12",
  "substrate-wasm-builder",
 ]
 
@@ -1900,8 +1900,8 @@ dependencies = [
  "cid",
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_encoding 0.3.0",
- "fvm_sdk 3.0.0-alpha.11",
- "fvm_shared 3.0.0-alpha.11",
+ "fvm_sdk 3.0.0-alpha.12",
+ "fvm_shared 3.0.0-alpha.12",
  "serde",
  "serde_tuple",
  "substrate-wasm-builder",
@@ -1912,8 +1912,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.0",
- "fvm_sdk 3.0.0-alpha.11",
- "fvm_shared 3.0.0-alpha.11",
+ "fvm_sdk 3.0.0-alpha.12",
+ "fvm_shared 3.0.0-alpha.12",
  "minicov",
  "substrate-wasm-builder",
 ]
@@ -1922,8 +1922,8 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.0.0-alpha.11",
- "fvm_shared 3.0.0-alpha.11",
+ "fvm_sdk 3.0.0-alpha.12",
+ "fvm_shared 3.0.0-alpha.12",
  "substrate-wasm-builder",
 ]
 
@@ -1931,8 +1931,8 @@ dependencies = [
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.0.0-alpha.11",
- "fvm_shared 3.0.0-alpha.11",
+ "fvm_sdk 3.0.0-alpha.12",
+ "fvm_shared 3.0.0-alpha.12",
  "substrate-wasm-builder",
 ]
 
@@ -1942,8 +1942,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.3.0",
- "fvm_sdk 3.0.0-alpha.11",
- "fvm_shared 3.0.0-alpha.11",
+ "fvm_sdk 3.0.0-alpha.12",
+ "fvm_shared 3.0.0-alpha.12",
  "minicov",
  "multihash",
  "substrate-wasm-builder",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.0.0-alpha.9"
+version = "3.0.0-alpha.10"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2284,7 +2284,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_encoding 0.3.0",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.11",
+ "fvm_shared 3.0.0-alpha.12",
  "lazy_static",
  "log",
  "multihash",
@@ -2356,7 +2356,7 @@ dependencies = [
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.0",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.11",
+ "fvm_shared 3.0.0-alpha.12",
  "itertools 0.10.5",
  "ittapi-rs",
  "lazy_static",
@@ -2380,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "0.1.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -2400,7 +2400,7 @@ dependencies = [
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.0",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.11",
+ "fvm_shared 3.0.0-alpha.12",
  "lazy_static",
  "libsecp256k1",
  "multihash",
@@ -2671,9 +2671,11 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.0.0-alpha.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee761116262c35151071675ec3345d821b0b90143616dec348c74e46116e150"
 dependencies = [
  "cid",
- "fvm_ipld_encoding 0.3.0",
+ "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 3.0.0-alpha.11",
  "lazy_static",
  "log",
@@ -2683,13 +2685,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee761116262c35151071675ec3345d821b0b90143616dec348c74e46116e150"
+version = "3.0.0-alpha.12"
 dependencies = [
  "cid",
- "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.3.0",
+ "fvm_shared 3.0.0-alpha.12",
  "lazy_static",
  "log",
  "num-traits",
@@ -2728,6 +2728,35 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.0.0-alpha.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66b85f8971273def3bb366008319f8dc855be3172210c3b83b7b20353709b29"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "blake2b_simd",
+ "byteorder",
+ "cid",
+ "data-encoding",
+ "data-encoding-macro",
+ "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "log",
+ "multihash",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "serde_repr",
+ "serde_tuple",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "fvm_shared"
+version = "3.0.0-alpha.12"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2756,35 +2785,6 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "sha3",
- "thiserror",
- "unsigned-varint",
-]
-
-[[package]]
-name = "fvm_shared"
-version = "3.0.0-alpha.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66b85f8971273def3bb366008319f8dc855be3172210c3b83b7b20353709b29"
-dependencies = [
- "anyhow",
- "bitflags",
- "blake2b_simd",
- "byteorder",
- "cid",
- "data-encoding",
- "data-encoding-macro",
- "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "log",
- "multihash",
- "num-bigint",
- "num-derive",
- "num-integer",
- "num-traits",
- "serde",
- "serde_repr",
- "serde_tuple",
  "thiserror",
  "unsigned-varint",
 ]

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 3.0.0-alpha.10 [2022-11-17]
+
+- Refactor network/message contexts to reduce the number of syscalls.
+
 ## 3.0.0-alpha.9 [2022-11-16]
 
 - fix: BufferedBlockstore#flush should not reset the write buffer.

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "3.0.0-alpha.9"
+version = "3.0.0-alpha.10"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -19,7 +19,7 @@ derive_builder = "0.11.2"
 num-derive = "0.3.3"
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.3", default-features = false }
-fvm_shared = { version = "3.0.0-alpha.11", path = "../shared", features = ["crypto"] }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.6.1", path = "../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.0", path = "../ipld/amt" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../ipld/blockstore" }

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 3.0.0-alpha.12 [2022-11-17]
+
+- Refactor network/message contexts to reduce the number of syscalls.
+
 ## 3.0.0-alpha.11 [2022-11-15]
 
 - Add support for actor events (FIP-0049).

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "3.0.0-alpha.11"
+version = "3.0.0-alpha.12"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { version = "0.8.5", default-features = false }
-fvm_shared = { version = "3.0.0-alpha.11", path = "../shared" }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = { version = "1.4.0", optional = true }

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - ...
 
+## 3.0.0-alpha.12 [2022-11-17]
+
+- Refactor network/message contexts to reduce the number of syscalls.
+
 ## 3.0.0-alpha.11 [2022-11-15]
 
 - Add support for actor events (FIP-0049).

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "3.0.0-alpha.11"
+version = "3.0.0-alpha.12"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "3.0.0-alpha.11", path = "../../shared" }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../../shared" }
 fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.0", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
@@ -50,7 +50,7 @@ actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/
 libipld-core = { version = "0.14.0", features = ["serde-codec"] }
 
 [dependencies.fvm]
-version = "3.0.0-alpha.9"
+version = "3.0.0-alpha.10"
 path = "../../fvm"
 default-features = false
 features = ["testing"]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "fvm_integration_tests"
 description = "Filecoin Virtual Machine integration tests framework"
-version = "0.1.0"
+version = "0.1.1-alpha.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs", "Polyphene"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "3.0.0-alpha.9", path = "../../fvm", default-features = false }
-fvm_shared = { version = "3.0.0-alpha.11", path = "../../shared" }
+fvm = { version = "3.0.0-alpha.10", path = "../../fvm", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../../shared" }
 fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.0", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }

--- a/testing/integration/tests/fil-address-actor/Cargo.toml
+++ b/testing/integration/tests/fil-address-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.11", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.11", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.12", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../../../../shared" }
 serde = "1.0.145"
 
 [build-dependencies]

--- a/testing/integration/tests/fil-events-actor/Cargo.toml
+++ b/testing/integration/tests/fil-events-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.11", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.11", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.12", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../../../../shared" }
 serde = {version = "1.0.145", features = ["derive"] }
 serde_tuple = "0.5.0"
 

--- a/testing/integration/tests/fil-hello-world-actor/Cargo.toml
+++ b/testing/integration/tests/fil-hello-world-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.11", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.11", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.12", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../../../../shared" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.11", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.11", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.12", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../../../ipld/blockstore" }
 

--- a/testing/integration/tests/fil-ipld-actor/Cargo.toml
+++ b/testing/integration/tests/fil-ipld-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.11", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.11", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.12", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../../../../shared" }
 
 [target.'cfg(coverage)'.dependencies]
 minicov = "0.2"

--- a/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_shared = { version = "3.0.0-alpha.11", path = "../../../../shared" }
-fvm_sdk = { version = "3.0.0-alpha.11", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.12", path = "../../../../sdk" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.11", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.11", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.12", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../../../../shared" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-syscall-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.11", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.11", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.12", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../../../../shared" }
 minicov = {version = "0.2", optional = true}
 actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 multihash = "0.16.3"


### PR DESCRIPTION
This release includes a breaking change to the message/network context syscalls.