### PR TITLE
feat: refactor actor creation logic

### DIFF
--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,12 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+- Replace `new_actor_address` with `next_actor_address`. `next_actor_address` has no side effects (until the actor is actually created).
+- Change `next_actor_address` to always use the origin address from the message, as specified. For abstract accounts, we _can't_ lookup a key address (they may only have an f0 and f2 address).
+- Move account creation logic to the call manager.
+  - The call manager owns the relevant state.
+  - The call manager will eventually invoke the constructor directly when creating the actor.
+
 ## 3.0.0-alpha.10 [2022-11-17]
 
 - Refactor network/message contexts to reduce the number of syscalls.

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -1,3 +1,4 @@
+use cid::Cid;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -46,6 +47,7 @@ pub trait CallManager: 'static {
         machine: Self::Machine,
         gas_limit: i64,
         origin: ActorID,
+        origin_address: Address,
         nonce: u64,
         gas_premium: TokenAmount,
     ) -> Self;
@@ -83,11 +85,23 @@ pub trait CallManager: 'static {
     /// Getter for origin actor.
     fn origin(&self) -> ActorID;
 
+    /// Get the actor address (f2) that will should be assigned to the next actor created.
+    ///
+    /// This method doesn't have any side-effects and will continue to return the same address until
+    /// `create_actor` is called next.
+    fn next_actor_address(&self) -> Address;
+
+    /// Create a new actor with the given code CID, actor ID, and predictable address. This method
+    /// does not register the actor with the init actor. It just creates it in the state-tree.
+    fn create_actor(
+        &mut self,
+        code_id: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) -> Result<()>;
+
     /// Getter for message nonce.
     fn nonce(&self) -> u64;
-
-    /// Gets and increment the call-stack actor creation index.
-    fn next_actor_idx(&mut self) -> u64;
 
     /// Gets the total invocations done on this call stack.
     fn invocation_count(&self) -> u64;

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -83,6 +83,7 @@ where
                 machine,
                 msg.gas_limit,
                 sender_id,
+                msg.from,
                 msg.sequence,
                 msg.gas_premium.clone(),
             );

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -4,11 +4,10 @@ use std::panic::{self, UnwindSafe};
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Context as _};
-use byteorder::{BigEndian, WriteBytesExt};
 use cid::Cid;
 use filecoin_proofs_api::{self as proofs, ProverId, PublicReplicaInfo, SectorId};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::{bytes_32, to_vec};
+use fvm_ipld_encoding::bytes_32;
 use fvm_shared::address::{Payload, Protocol};
 use fvm_shared::bigint::Zero;
 use fvm_shared::consensus::ConsensusFault;
@@ -716,28 +715,10 @@ where
             .code)
     }
 
-    // TODO(M2) merge new_actor_address and create_actor into a single syscall.
-    fn new_actor_address(&mut self) -> Result<Address> {
-        // base the address on the predictable address, or the id address if none exists.
-        let oa = self
-            .lookup_address(self.call_manager.origin())
-            .or_fatal()? // actor not found
-            .unwrap_or_else(|| Address::new_id(self.call_manager.origin()));
-
-        let mut b = to_vec(&oa)
-            .or_fatal()
-            .context("could not serialize address in new_actor_address")?;
-        b.write_u64::<BigEndian>(self.call_manager.nonce())
-            .or_fatal()
-            .context("writing nonce into a buffer")?;
-        b.write_u64::<BigEndian>(self.call_manager.next_actor_idx())
-            .or_fatal()
-            .context("writing actor index in buffer")?;
-        let addr = Address::new_actor(&b);
-        Ok(addr)
+    fn next_actor_address(&self) -> Result<Address> {
+        Ok(self.call_manager.next_actor_address())
     }
 
-    // TODO(M2) merge new_actor_address and create_actor into a single syscall.
     fn create_actor(
         &mut self,
         code_id: Cid,

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -205,7 +205,7 @@ pub trait ActorOps {
     /// the actor even in the event of a chain re-org (whereas an ID-address might refer to a
     /// different actor after messages are re-ordered).
     /// Always an ActorExec address.
-    fn new_actor_address(&mut self) -> Result<Address>;
+    fn next_actor_address(&self) -> Result<Address>;
 
     /// Creates an actor with given `code_cid`, `actor_id`, `predictable_address` (if specified),
     /// and an empty state.

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -52,12 +52,9 @@ pub fn get_actor_code_cid(
 
 /// Generates a new actor address, and writes it into the supplied output buffer.
 ///
-/// The output buffer must be at least 21 bytes long, which is the length of a
-/// class 2 address (protocol-generated actor address). This will change in the
-/// future when we introduce class 4 addresses to accommodate larger hashes.
-///
-/// TODO(M2): this method will be merged with create_actor.
-pub fn new_actor_address(
+/// The output buffer must be at least 21 bytes long, which is the length of a class 2 address
+/// (protocol-generated actor address).
+pub fn next_actor_address(
     context: Context<'_, impl Kernel>,
     obuf_off: u32, // Address (out)
     obuf_len: u32,
@@ -74,7 +71,7 @@ pub fn new_actor_address(
     }
 
     // Create the address.
-    let addr = context.kernel.new_actor_address()?;
+    let addr = context.kernel.next_actor_address()?;
 
     // And return it.
     let bytes = addr.to_bytes();

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -182,7 +182,7 @@ pub fn bind_syscalls(
     linker.bind("actor", "resolve_address", actor::resolve_address)?;
     linker.bind("actor", "lookup_address", actor::lookup_address)?;
     linker.bind("actor", "get_actor_code_cid", actor::get_actor_code_cid)?;
-    linker.bind("actor", "new_actor_address", actor::new_actor_address)?;
+    linker.bind("actor", "next_actor_address", actor::next_actor_address)?;
     linker.bind("actor", "create_actor", actor::create_actor)?;
     linker.bind(
         "actor",

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -214,6 +214,7 @@ pub struct DummyCallManager {
     pub machine: DummyMachine,
     pub gas_tracker: GasTracker,
     pub origin: ActorID,
+    pub origin_address: Address,
     pub nonce: u64,
     pub test_data: Rc<RefCell<TestData>>,
     limits: DummyLimiter,
@@ -238,6 +239,7 @@ impl DummyCallManager {
                 nonce: 0,
                 test_data: rc,
                 limits: DummyLimiter::default(),
+                origin_address: Address::new_id(0),
             },
             cell_ref,
         )
@@ -256,6 +258,7 @@ impl DummyCallManager {
                 nonce: 0,
                 test_data: rc,
                 limits: DummyLimiter::default(),
+                origin_address: Address::new_id(0),
             },
             cell_ref,
         )
@@ -269,6 +272,7 @@ impl CallManager for DummyCallManager {
         machine: Self::Machine,
         _gas_limit: i64,
         origin: ActorID,
+        origin_address: Address,
         nonce: u64,
         gas_premium: TokenAmount,
     ) -> Self {
@@ -280,6 +284,7 @@ impl CallManager for DummyCallManager {
             machine,
             gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0), gas_premium),
             origin,
+            origin_address,
             nonce,
             test_data: rc,
             limits,
@@ -350,7 +355,16 @@ impl CallManager for DummyCallManager {
         self.nonce
     }
 
-    fn next_actor_idx(&mut self) -> u64 {
+    fn next_actor_address(&self) -> Address {
+        todo!()
+    }
+
+    fn create_actor(
+        &mut self,
+        _code_id: Cid,
+        _actor_id: ActorID,
+        _predictable_address: Option<Address>,
+    ) -> kernel::Result<()> {
         todo!()
     }
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Replace `new_actor_address` with `next_actor_address`. `next_actor_address` has no side effects (until the actor is actually created).
+
 ## 3.0.0-alpha.13 [2022-11-17]
 
 - Re-export a tipset_timestamp function.

--- a/sdk/src/actor.rs
+++ b/sdk/src/actor.rs
@@ -75,10 +75,10 @@ pub fn get_actor_code_cid(addr: &Address) -> Option<Cid> {
 }
 
 /// Generates a new actor address for an actor deployed by the calling actor.
-pub fn new_actor_address() -> Address {
+pub fn next_actor_address() -> Address {
     let mut buf = [0u8; MAX_ADDRESS_LEN];
     unsafe {
-        let len = sys::actor::new_actor_address(buf.as_mut_ptr(), MAX_ADDRESS_LEN as u32)
+        let len = sys::actor::next_actor_address(buf.as_mut_ptr(), MAX_ADDRESS_LEN as u32)
             .expect("failed to create a new actor address");
         Address::from_bytes(&buf[..len as usize]).expect("syscall returned invalid address")
     }

--- a/sdk/src/sys/actor.rs
+++ b/sdk/src/sys/actor.rs
@@ -108,12 +108,11 @@ super::fvm_syscalls! {
     /// | [`IllegalArgument`] | if the type is invalid, or the outupt buffer isn't large enough |
     pub fn get_code_cid_for_type(typ: i32, obuf_off: *mut u8, obuf_len: u32) -> Result<u32>;
 
-    /// Generates a new actor address for an actor deployed
-    /// by the calling actor.
+    /// Generates a new actor address for an actor deployed by the calling actor.
     ///
     /// **Privileged:** May only be called by the init actor.
     #[doc(hidden)]
-    pub fn new_actor_address(obuf_off: *mut u8, obuf_len: u32) -> Result<u32>;
+    pub fn next_actor_address(obuf_off: *mut u8, obuf_len: u32) -> Result<u32>;
 
     /// Creates a new actor in the state-tree with the specified actor ID, recording the specified
     /// "predictable" address in the actor root if non-empty, and returning a new stable address.

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -239,10 +239,18 @@ where
         machine: Self::Machine,
         gas_limit: i64,
         origin: ActorID,
+        origin_address: Address,
         nonce: u64,
         gas_premium: TokenAmount,
     ) -> Self {
-        TestCallManager(C::new(machine, gas_limit, origin, nonce, gas_premium))
+        TestCallManager(C::new(
+            machine,
+            gas_limit,
+            origin,
+            origin_address,
+            nonce,
+            gas_premium,
+        ))
     }
 
     fn send<K: Kernel<CallManager = Self>>(
@@ -303,8 +311,17 @@ where
         self.0.nonce()
     }
 
-    fn next_actor_idx(&mut self) -> u64 {
-        self.0.next_actor_idx()
+    fn next_actor_address(&self) -> Address {
+        self.0.next_actor_address()
+    }
+
+    fn create_actor(
+        &mut self,
+        code_id: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) -> Result<()> {
+        self.0.create_actor(code_id, actor_id, predictable_address)
     }
 
     fn price_list(&self) -> &fvm::gas::PriceList {
@@ -413,8 +430,8 @@ where
         self.0.get_actor_code_cid(id)
     }
 
-    fn new_actor_address(&mut self) -> Result<Address> {
-        self.0.new_actor_address()
+    fn next_actor_address(&self) -> Result<Address> {
+        self.0.next_actor_address()
     }
 
     fn create_actor(


### PR DESCRIPTION
1. Use the origin as specified in the top-level message without trying to resolve it. This is necessary for account abstraction because, per-finality, we should use the _stable_ address (f1-f3) to compute new `f2` addresses. Unfortunately, we have no way to lookup an actor's "stable" (`f2`) address. Unfortunately, we can't just use the actor's `f4` address because not all abstract accounts will have one (thinking beyond the EVM here).
2. Replace the `new_actor_address` syscall with `next_actor_address`. We now update the "num actors created" _after_ creating the next actor (see https://github.com/filecoin-project/ref-fvm/issues/941).

All these changes are a bit intertwined because I didn't want to expose a new `origin_address` method on the CallManager, only to remove it later.

fixes #941