### PR TITLE
feat: use externs for tipset cid lookups

### DIFF
--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -208,7 +208,7 @@ where
                     msg.to,
                     msg.sequence,
                     msg.method_num,
-                    self.context().network_context.epoch,
+                    self.context().epoch,
                 ));
                 backtrace.set_cause(backtrace::Cause::from_fatal(err));
                 Receipt {
@@ -299,11 +299,11 @@ where
                     return Ok(Err(ApplyRet::prevalidation_fail(
                         ExitCode::SYS_OUT_OF_GAS,
                         format!("Out of gas ({} > {})", inclusion_total, msg.gas_limit),
-                        &self.context().network_context.base_fee * inclusion_total,
+                        &self.context().base_fee * inclusion_total,
                     )));
                 }
 
-                let miner_penalty_amount = &self.context().network_context.base_fee * msg.gas_limit;
+                let miner_penalty_amount = &self.context().base_fee * msg.gas_limit;
                 (inclusion_cost, miner_penalty_amount)
             }
         };
@@ -419,7 +419,7 @@ where
         } = GasOutputs::compute(
             receipt.gas_used,
             msg.gas_limit,
-            &self.context().network_context.base_fee,
+            &self.context().base_fee,
             &msg.gas_fee_cap,
             &msg.gas_premium,
         );

--- a/fvm/src/externs/mod.rs
+++ b/fvm/src/externs/mod.rs
@@ -1,8 +1,10 @@
 //! This module contains the logic to invoke the node by traversing Boundary A.
 
+use cid::Cid;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
-pub trait Externs: Rand + Consensus {}
+
+pub trait Externs: Rand + Consensus + Chain {}
 
 /// Consensus related methods.
 pub trait Consensus {
@@ -34,4 +36,10 @@ pub trait Rand {
         round: ChainEpoch,
         entropy: &[u8],
     ) -> anyhow::Result<[u8; 32]>;
+}
+
+/// Chain information provider.
+pub trait Chain {
+    /// Gets the CID for a given tipset.
+    fn get_tipset_cid(&self, epoch: ChainEpoch) -> anyhow::Result<Cid>;
 }

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -73,10 +73,7 @@ where
 
         debug!(
             "initializing a new machine, epoch={}, base_fee={}, nv={:?}, root={}",
-            context.network_context.epoch,
-            &context.network_context.base_fee,
-            context.network_version,
-            context.initial_state_root
+            context.epoch, &context.base_fee, context.network_version, context.initial_state_root
         );
 
         if !SUPPORTED_VERSIONS.contains(&context.network_version) {
@@ -155,7 +152,7 @@ where
             builtin_actors,
             id: format!(
                 "{}-{}",
-                context.network_context.epoch,
+                context.epoch,
                 cid::multibase::encode(cid::multibase::Base::Base32Lower, randomness)
             ),
         })

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -186,54 +186,23 @@ impl NetworkConfig {
         self
     }
 
-    /// Create a [`MachineContext`] for a given `epoch` with the specified `initial_state`.
-    pub fn for_epoch(&self, epoch: ChainEpoch, initial_state: Cid) -> MachineContext {
-        MachineContext {
-            network: self.clone(),
-            network_context: NetworkContext {
-                epoch,
-                // TODO #933
-                timestamp: 0,
-                tipsets: vec![],
-                base_fee: TokenAmount::zero(),
-            },
-            initial_state_root: initial_state,
-            circ_supply: fvm_shared::TOTAL_FILECOIN.clone(),
-            tracing: false,
-        }
-    }
-
-    /// Create a ['MachineContext'] for a given network context with the specified `initial_state`
-    pub fn for_network_context(
+    /// Create a ['MachineContext'] for a given epoch, timestamp, and initial state.
+    pub fn for_epoch(
         &self,
-        net_ctx: NetworkContext,
+        epoch: ChainEpoch,
+        timestamp: u64,
         initial_state: Cid,
     ) -> MachineContext {
         MachineContext {
             network: self.clone(),
-            network_context: net_ctx,
+            base_fee: TokenAmount::zero(),
+            epoch,
+            timestamp,
             initial_state_root: initial_state,
             circ_supply: fvm_shared::TOTAL_FILECOIN.clone(),
             tracing: false,
         }
     }
-}
-
-#[derive(Clone, Debug)]
-pub struct NetworkContext {
-    /// The network epoch at which the Machine runs.
-    pub epoch: ChainEpoch,
-
-    /// The UNIX timestamp (in seconds) of the current tipset
-    pub timestamp: u64,
-
-    /// The tipset CIDs for the last finality
-    pub tipsets: Vec<Cid>,
-
-    /// The base fee that's in effect when the Machine runs.
-    ///
-    /// Default: 0.
-    pub base_fee: TokenAmount,
 }
 
 /// Per-epoch machine context.
@@ -244,8 +213,20 @@ pub struct MachineContext {
     #[deref_mut]
     pub network: NetworkConfig,
 
-    /// The network context with which the Machine runs.
-    pub network_context: NetworkContext,
+    /// The current epoch
+    ///
+    /// Default: 0
+    pub epoch: ChainEpoch,
+
+    /// The UNIX timestamp (in seconds) of the current tipset
+    ///
+    /// Default: 0
+    pub timestamp: u64,
+
+    /// The base fee that's in effect when the Machine runs.
+    ///
+    /// Default: 0.
+    pub base_fee: TokenAmount,
 
     /// The initial state root on which this block is based.
     pub initial_state_root: Cid,
@@ -265,7 +246,7 @@ pub struct MachineContext {
 impl MachineContext {
     /// Sets [`MachineContext::base_fee`].
     pub fn set_base_fee(&mut self, amt: TokenAmount) -> &mut Self {
-        self.network_context.base_fee = amt;
+        self.base_fee = amt;
         self
     }
 

--- a/testing/conformance/src/externs.rs
+++ b/testing/conformance/src/externs.rs
@@ -1,4 +1,4 @@
-use fvm::externs::{Consensus, Externs, Rand};
+use fvm::externs::{Chain, Consensus, Externs, Rand};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
 
@@ -49,6 +49,12 @@ impl Consensus for TestExterns {
         _h2: &[u8],
         _extra: &[u8],
     ) -> anyhow::Result<(Option<ConsensusFault>, i64)> {
+        todo!()
+    }
+}
+
+impl Chain for TestExterns {
+    fn get_tipset_cid(&self, _epoch: ChainEpoch) -> anyhow::Result<cid::Cid> {
         todo!()
     }
 }

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -107,7 +107,7 @@ impl TestMachine<Box<DefaultMachine<MemoryBlockstore, TestExterns>>> {
 
         let mut nc = NetworkConfig::new(network_version);
         nc.override_actors(builtin_actors);
-        let mut mc = nc.for_epoch(epoch, state_root);
+        let mut mc = nc.for_epoch(epoch, (epoch * 30) as u64, state_root);
         mc.set_base_fee(base_fee);
 
         let engine = engines.get(&mc.network).map_err(|e| anyhow!(e))?;

--- a/testing/integration/src/dummy.rs
+++ b/testing/integration/src/dummy.rs
@@ -1,4 +1,8 @@
-use fvm::externs::{Consensus, Externs, Rand};
+use cid::Cid;
+use fvm::externs::{Chain, Consensus, Externs, Rand};
+use fvm_ipld_encoding::DAG_CBOR;
+use fvm_shared::IDENTITY_HASH;
+use multihash::Multihash;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 pub struct DummyExterns;
@@ -45,5 +49,14 @@ impl Consensus for DummyExterns {
         _extra: &[u8],
     ) -> anyhow::Result<(Option<fvm_shared::consensus::ConsensusFault>, i64)> {
         Ok((None, 0))
+    }
+}
+
+impl Chain for DummyExterns {
+    fn get_tipset_cid(&self, epoch: fvm_shared::clock::ChainEpoch) -> anyhow::Result<Cid> {
+        Ok(Cid::new_v1(
+            DAG_CBOR,
+            Multihash::wrap(IDENTITY_HASH, &epoch.to_be_bytes()).unwrap(),
+        ))
     }
 }

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -225,7 +225,7 @@ where
         // Custom configuration.
         configure(&mut nc);
 
-        let mut mc = nc.for_epoch(0, state_root);
+        let mut mc = nc.for_epoch(0, 0, state_root);
         mc.set_base_fee(TokenAmount::from_atto(DEFAULT_BASE_FEE))
             .enable_tracing();
 


### PR DESCRIPTION
So, @vyzo was right. This is the best way to do this.

It also means we don't need the whole network context thing.

part of https://github.com/filecoin-project/ref-fvm/issues/933
fixes https://github.com/filecoin-project/ref-fvm/issues/913 (by getting rid of the NetworkContext).