### PR TITLE
Generalize Abort to Exit with data

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -527,34 +527,29 @@ where
                     }
 
                     let (code, message, res) = match abort {
-                        Abort::Exit(code, message, blk_id) => {
-                            if blk_id > 0 {
-                                match block_registry.get(blk_id) {
-                                    Err(e) => (
-                                        ExitCode::SYS_MISSING_RETURN,
-                                        "error getting exit data block".to_owned(),
-                                        Err(ExecutionError::Fatal(anyhow!(e))),
-                                    ),
-                                    Ok(blk) => (
-                                        code,
-                                        message,
-                                        Ok(InvocationResult {
-                                            exit_code: code,
-                                            value: Some(blk.clone()),
-                                        }),
-                                    ),
-                                }
-                            } else {
-                                (
-                                    code,
-                                    message,
-                                    Ok(InvocationResult {
-                                        exit_code: code,
-                                        value: None,
-                                    }),
-                                )
-                            }
-                        }
+                        Abort::Exit(code, message, NO_DATA_BLOCK_ID) => (
+                            code,
+                            message,
+                            Ok(InvocationResult {
+                                exit_code: code,
+                                value: None,
+                            }),
+                        ),
+                        Abort::Exit(code, message, blk_id) => match block_registry.get(blk_id) {
+                            Err(e) => (
+                                ExitCode::SYS_MISSING_RETURN,
+                                "error getting exit data block".to_owned(),
+                                Err(ExecutionError::Fatal(anyhow!(e))),
+                            ),
+                            Ok(blk) => (
+                                code,
+                                message,
+                                Ok(InvocationResult {
+                                    exit_code: code,
+                                    value: Some(blk.clone()),
+                                }),
+                            ),
+                        },
                         Abort::OutOfGas => (
                             ExitCode::SYS_OUT_OF_GAS,
                             "out of gas".to_owned(),

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -137,26 +137,18 @@ pub trait CallManager: 'static {
 
 /// The result of a method invocation.
 #[derive(Clone, Debug)]
-pub enum InvocationResult {
-    /// Indicates that the actor successfully returned. The value may be empty.
-    Return(Option<kernel::Block>),
-    /// Indicates that the actor aborted with the given exit code and data.
-    Exit(ExitCode, Option<kernel::Block>),
+pub struct InvocationResult {
+    /// The exit code (0 for success).
+    pub exit_code: ExitCode,
+    /// The return value, if any.
+    pub value: Option<kernel::Block>,
 }
 
 impl Default for InvocationResult {
     fn default() -> Self {
-        Self::Return(Default::default())
-    }
-}
-
-impl InvocationResult {
-    /// Get the exit code for the invocation result. [`ExitCode::Ok`] on success, or the exit code
-    /// from the [`Failure`](InvocationResult::Failure) variant otherwise.
-    pub fn exit_code(&self) -> ExitCode {
-        match self {
-            Self::Return(_) => ExitCode::OK,
-            Self::Exit(e, _) => *e,
+        Self {
+            value: None,
+            exit_code: ExitCode::OK,
         }
     }
 }

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -140,8 +140,8 @@ pub trait CallManager: 'static {
 pub enum InvocationResult {
     /// Indicates that the actor successfully returned. The value may be empty.
     Return(Option<kernel::Block>),
-    /// Indicates that the actor aborted with the given exit code.
-    Failure(ExitCode),
+    /// Indicates that the actor aborted with the given exit code and data.
+    Exit(ExitCode, Option<kernel::Block>),
 }
 
 impl Default for InvocationResult {
@@ -156,7 +156,7 @@ impl InvocationResult {
     pub fn exit_code(&self) -> ExitCode {
         match self {
             Self::Return(_) => ExitCode::OK,
-            Self::Failure(e) => *e,
+            Self::Exit(e, _) => *e,
         }
     }
 }

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -158,13 +158,16 @@ where
                     events_root,
                 }
             }
-            Ok(InvocationResult::Failure(exit_code)) => {
+            Ok(InvocationResult::Exit(exit_code, maybe_data)) => {
+                let return_data = maybe_data
+                    .map(|blk| RawBytes::from(blk.data().to_vec()))
+                    .unwrap_or_default();
                 if exit_code.is_success() {
-                    return Err(anyhow!("actor failed with status OK"));
+                    backtrace.clear();
                 }
                 Receipt {
                     exit_code,
-                    return_data: Default::default(),
+                    return_data,
                     gas_used,
                     events_root,
                 }

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -366,38 +366,30 @@ where
 
         // Store result and return.
         Ok(match result {
-            InvocationResult::Return(None) => {
-                SendResult::Return(NO_DATA_BLOCK_ID, BlockStat { codec: 0, size: 0 })
-            }
-            InvocationResult::Return(Some(blk)) => {
-                let stat = blk.stat();
-                let ret_id = self
+            InvocationResult {
+                exit_code,
+                value: Some(blk),
+            } => {
+                let block_stat = blk.stat();
+                let block_id = self
                     .blocks
                     .put(blk)
                     .or_fatal()
                     .context("failed to store a valid return value")?;
-                SendResult::Return(ret_id, stat)
-            }
-            InvocationResult::Exit(code, None) => {
-                if code.is_success() {
-                    SendResult::Return(NO_DATA_BLOCK_ID, BlockStat { codec: 0, size: 0 })
-                } else {
-                    SendResult::Abort(code, NO_DATA_BLOCK_ID, BlockStat { codec: 0, size: 0 })
+                SendResult {
+                    block_id,
+                    block_stat,
+                    exit_code,
                 }
             }
-            InvocationResult::Exit(code, Some(blk)) => {
-                let stat = blk.stat();
-                let ret_id = self
-                    .blocks
-                    .put(blk)
-                    .or_fatal()
-                    .context("failed to store a valid return value")?;
-                if code.is_success() {
-                    SendResult::Return(ret_id, stat)
-                } else {
-                    SendResult::Abort(code, ret_id, stat)
-                }
-            }
+            InvocationResult {
+                exit_code,
+                value: None,
+            } => SendResult {
+                block_id: NO_DATA_BLOCK_ID,
+                block_stat: BlockStat { codec: 0, size: 0 },
+                exit_code,
+            },
         })
     }
 }

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -34,9 +34,10 @@ use crate::gas::{Gas, PriceList};
 use crate::machine::limiter::ExecMemory;
 use crate::machine::Machine;
 
-pub enum SendResult {
-    Return(BlockId, BlockStat),
-    Abort(ExitCode, BlockId, BlockStat),
+pub struct SendResult {
+    pub block_id: BlockId,
+    pub block_stat: BlockStat,
+    pub exit_code: ExitCode,
 }
 
 /// The "kernel" implements the FVM interface as presented to the actors. It:

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -36,7 +36,7 @@ use crate::machine::Machine;
 
 pub enum SendResult {
     Return(BlockId, BlockStat),
-    Abort(ExitCode),
+    Abort(ExitCode, BlockId, BlockStat),
 }
 
 /// The "kernel" implements the FVM interface as presented to the actors. It:

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -6,8 +6,8 @@ use derive_more::Display;
 use fvm_shared::error::ExitCode;
 use wasmtime::Trap;
 
+use crate::call_manager::NO_DATA_BLOCK_ID;
 use crate::kernel::{BlockId, ExecutionError};
-use crate::call_manager::{NO_DATA_BLOCK_ID};
 
 /// Represents an actor "abort".
 #[derive(Debug)]
@@ -67,7 +67,11 @@ impl From<Trap> for Abort {
 
         // Actor panic/wasm error.
         if let Some(code) = t.trap_code() {
-            return Abort::Exit(ExitCode::SYS_ILLEGAL_INSTRUCTION, code.to_string(), NO_DATA_BLOCK_ID);
+            return Abort::Exit(
+                ExitCode::SYS_ILLEGAL_INSTRUCTION,
+                code.to_string(),
+                NO_DATA_BLOCK_ID,
+            );
         }
 
         // Try to get a smuggled error back.

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -46,11 +46,6 @@ impl Abort {
             ExecutionError::Syscall(e) => Abort::Fatal(anyhow!("unexpected syscall error: {}", e)),
         }
     }
-
-    /// Convert a generalized exit "jump" into an "abort".
-    pub fn from_exit(code: ExitCode, msg: String, blk: BlockId) -> Self {
-        Abort::Exit(code, msg, blk)
-    }
 }
 
 /// Wraps an execution error in a Trap.

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -157,7 +157,7 @@ use self::error::Abort;
 pub fn bind_syscalls(
     linker: &mut Linker<InvocationData<impl Kernel + 'static>>,
 ) -> anyhow::Result<()> {
-    linker.bind("vm", "abort", vm::abort)?;
+    linker.bind("vm", "exit", vm::exit)?;
     linker.bind("vm", "message_context", vm::message_context)?;
 
     linker.bind(

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -159,6 +159,8 @@ pub fn bind_syscalls(
 ) -> anyhow::Result<()> {
     linker.bind("vm", "exit", vm::exit)?;
     linker.bind("vm", "message_context", vm::message_context)?;
+    // TODO remove this once the bundles in integration test have been upgraded
+    linker.bind("vm", "abort", vm::abort)?;
 
     linker.bind(
         "network",

--- a/fvm/src/syscalls/send.rs
+++ b/fvm/src/syscalls/send.rs
@@ -30,11 +30,11 @@ pub fn send(
                 return_codec: stat.codec,
                 return_size: stat.size,
             },
-            SendResult::Abort(code) => sys::out::send::Send {
+            SendResult::Abort(code, id, stat) => sys::out::send::Send {
                 exit_code: code.value(),
-                return_id: 0,
-                return_codec: 0,
-                return_size: 0,
+                return_id: id,
+                return_codec: stat.codec,
+                return_size: stat.size,
             },
         },
     )

--- a/fvm/src/syscalls/send.rs
+++ b/fvm/src/syscalls/send.rs
@@ -1,6 +1,5 @@
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::error::ExitCode;
 use fvm_shared::sys;
 
 use super::Context;
@@ -22,20 +21,15 @@ pub fn send(
     let value = TokenAmount::from_atto((value_hi as u128) << 64 | value_lo as u128);
     // An execution error here means that something went wrong in the FVM.
     // Actor errors are communicated in the receipt.
-    Ok(
-        match context.kernel.send(&recipient, method, params_id, &value)? {
-            SendResult::Return(id, stat) => sys::out::send::Send {
-                exit_code: ExitCode::OK.value(),
-                return_id: id,
-                return_codec: stat.codec,
-                return_size: stat.size,
-            },
-            SendResult::Abort(code, id, stat) => sys::out::send::Send {
-                exit_code: code.value(),
-                return_id: id,
-                return_codec: stat.codec,
-                return_size: stat.size,
-            },
-        },
-    )
+    let SendResult {
+        block_id,
+        block_stat,
+        exit_code,
+    } = context.kernel.send(&recipient, method, params_id, &value)?;
+    Ok(sys::out::send::Send {
+        exit_code: exit_code.value(),
+        return_id: block_id,
+        return_codec: block_stat.codec,
+        return_size: block_stat.size,
+    })
 }

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -4,6 +4,7 @@ use fvm_shared::sys::SyscallSafe;
 
 use super::error::Abort;
 use super::Context;
+use crate::call_manager::NO_DATA_BLOCK_ID;
 use crate::kernel::{ClassifyResult, Kernel};
 
 /// An uninhabited type. We use this in `abort` to make sure there's no way to return without
@@ -47,6 +48,17 @@ pub fn exit(
         .to_owned()
     };
     Err(Abort::Exit(code, message, blk))
+}
+
+// TODO remove this once the bundles in integration have been updated; right now it is necessary
+//      due to circular dependency
+pub fn abort(
+    context: Context<'_, impl Kernel>,
+    code: u32,
+    message_off: u32,
+    message_len: u32,
+) -> Result<Never, Abort> {
+    exit(context, code, NO_DATA_BLOCK_ID, message_off, message_len)
 }
 
 pub fn message_context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<MessageContext> {

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -17,9 +17,9 @@ unsafe impl SyscallSafe for Never {}
 pub fn exit(
     context: Context<'_, impl Kernel>,
     code: u32,
+    blk: u32,
     message_off: u32,
     message_len: u32,
-    blk: u32,
 ) -> Result<Never, Abort> {
     use crate::kernel::Context as _;
 

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -14,11 +14,12 @@ pub enum Never {}
 unsafe impl SyscallSafe for Never {}
 
 // NOTE: this won't clobber the last syscall error because it directly returns a "trap".
-pub fn abort(
+pub fn exit(
     context: Context<'_, impl Kernel>,
     code: u32,
     message_off: u32,
     message_len: u32,
+    blk: u32,
 ) -> Result<Never, Abort> {
     use crate::kernel::Context as _;
 
@@ -27,6 +28,7 @@ pub fn abort(
         return Err(Abort::Exit(
             ExitCode::SYS_ILLEGAL_EXIT_CODE,
             format!("actor aborted with code {}", code),
+            blk,
         ));
     }
 
@@ -44,7 +46,7 @@ pub fn abort(
         .map_err(|e| Abort::from_error(code, e))?
         .to_owned()
     };
-    Err(Abort::Exit(code, message))
+    Err(Abort::Exit(code, message, blk))
 }
 
 pub fn message_context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<MessageContext> {

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -24,7 +24,6 @@ pub enum ExecutionEvent {
         params: RawBytes,
         value: TokenAmount,
     },
-    CallReturn(RawBytes),
-    CallAbort(ExitCode),
+    CallReturn(ExitCode, RawBytes),
     CallError(SyscallError),
 }

--- a/sdk/src/sys/vm.rs
+++ b/sdk/src/sys/vm.rs
@@ -6,8 +6,8 @@ pub use fvm_shared::sys::out::vm::MessageContext;
 super::fvm_syscalls! {
     module = "vm";
 
-    /// Abort execution with the given code and optional message and data.
-    /// The code is recorded in the receipt, the message is for debugging only.
+    /// Abort execution with the given code and optional message and data for the return value.
+    /// The code and return value are recorded in the receipt, the message is for debugging only.
     ///
     /// # Arguments
     ///
@@ -17,16 +17,16 @@ super::fvm_syscalls! {
     ///   If this code is not zero and less than the [minimum "user" exit
     ///   code][fvm_shared::error::ExitCode::FIRST_USER_EXIT_CODE], it will be replaced with
     ///   [`SYS_ILLEGAL_EXIT_CODE`][fvm_shared::error::ExitCode::SYS_ILLEGAL_EXIT_CODE].
+    /// - `blk_id` is the optional data block id; it should be 0 if there are no data attached to
+    ///   this exit.
     /// - `message_off` and `message_len` specify the offset and length (in wasm memory) of an
     ///   optional debug message associated with this abort. These parameters may be null/0 and will
     ///   be ignored if invalid.
-    /// - `blk_id` is the optional data block id; it should be 0 if there are no data attached to
-    ///   this exit.
     ///
     /// # Errors
     ///
     /// None. This function doesn't return.
-    pub fn exit(code: u32, message_off: *const u8, message_len: u32, blk_id: u32) -> !;
+    pub fn exit(code: u32, blk_id: u32, message_off: *const u8, message_len: u32) -> !;
 
 
     /// Returns the details about the message causing this invocation.

--- a/sdk/src/sys/vm.rs
+++ b/sdk/src/sys/vm.rs
@@ -28,9 +28,6 @@ super::fvm_syscalls! {
     /// None. This function doesn't return.
     pub fn exit(code: u32, blk_id: u32, message_off: *const u8, message_len: u32) -> !;
 
-    // TODO remove this once the integration bundles have been upgraded
-    pub fn abort(code: u32,  message_off: *const u8, message_len: u32) -> !;
-
     /// Returns the details about the message causing this invocation.
     ///
     /// # Errors

--- a/sdk/src/sys/vm.rs
+++ b/sdk/src/sys/vm.rs
@@ -28,6 +28,8 @@ super::fvm_syscalls! {
     /// None. This function doesn't return.
     pub fn exit(code: u32, blk_id: u32, message_off: *const u8, message_len: u32) -> !;
 
+    // TODO remove this once the integration bundles have been upgraded
+    pub fn abort(code: u32,  message_off: *const u8, message_len: u32) -> !;
 
     /// Returns the details about the message causing this invocation.
     ///

--- a/sdk/src/sys/vm.rs
+++ b/sdk/src/sys/vm.rs
@@ -6,23 +6,27 @@ pub use fvm_shared::sys::out::vm::MessageContext;
 super::fvm_syscalls! {
     module = "vm";
 
-    /// Abort execution with the given code and message. The code is recorded in the receipt, the
-    /// message is for debugging only.
+    /// Abort execution with the given code and optional message and data.
+    /// The code is recorded in the receipt, the message is for debugging only.
     ///
     /// # Arguments
     ///
-    /// - `code` is the [`ExitCode`][fvm_shared::error::ExitCode] to abort with. If this code is
-    ///   less than the [minimum "user" exit
+    /// - `code` is the [`ExitCode`][fvm_shared::error::ExitCode] to abort with.
+    ///   If this code is zero, then the exit indicates a successful non-local return from
+    ///   the current execution context.
+    ///   If this code is not zero and less than the [minimum "user" exit
     ///   code][fvm_shared::error::ExitCode::FIRST_USER_EXIT_CODE], it will be replaced with
     ///   [`SYS_ILLEGAL_EXIT_CODE`][fvm_shared::error::ExitCode::SYS_ILLEGAL_EXIT_CODE].
     /// - `message_off` and `message_len` specify the offset and length (in wasm memory) of an
     ///   optional debug message associated with this abort. These parameters may be null/0 and will
     ///   be ignored if invalid.
+    /// - `blk_id` is the optional data block id; it should be 0 if there are no data attached to
+    ///   this exit.
     ///
     /// # Errors
     ///
     /// None. This function doesn't return.
-    pub fn abort(code: u32, message_off: *const u8, message_len: u32) -> !;
+    pub fn exit(code: u32, message_off: *const u8, message_len: u32, blk_id: u32) -> !;
 
 
     /// Returns the details about the message causing this invocation.

--- a/sdk/src/vm.rs
+++ b/sdk/src/vm.rs
@@ -1,5 +1,6 @@
 use std::ptr;
 
+use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
 use fvm_shared::error::ExitCode;
 
 use crate::sys;
@@ -9,6 +10,11 @@ pub const NO_DATA_BLOCK_ID: u32 = 0;
 
 /// Abort execution.
 pub fn abort(code: u32, message: Option<&str>) -> ! {
+    exit(code, message, None)
+}
+
+/// Exit from current message execution, with the specified code and an optional message and data.
+pub fn exit(code: u32, message: Option<&str>, data: Option<RawBytes>) -> ! {
     unsafe {
         let (message, message_len) = if let Some(m) = message {
             (m.as_ptr(), m.len())
@@ -16,7 +22,19 @@ pub fn abort(code: u32, message: Option<&str>) -> ! {
             (ptr::null(), 0)
         };
 
-        sys::vm::abort(code, message, message_len as u32);
+        // Ideally we would write this double if as if let Some(bytes) = data && bytes.len() > 0
+        // but the compiler doexn't accept it.
+        let blk_id = if let Some(bytes) = data {
+            if bytes.len() > 0 {
+                sys::ipld::block_create(DAG_CBOR, bytes.as_ptr(), bytes.len() as u32).unwrap()
+            } else {
+                NO_DATA_BLOCK_ID
+            }
+        } else {
+            NO_DATA_BLOCK_ID
+        };
+
+        sys::vm::exit(code, message, message_len as u32, blk_id);
     }
 }
 

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -362,9 +362,9 @@ fn backtraces() {
       ;; ipld::open
       (type (;0;) (func (param i32 i32) (result i32)))
       (import "ipld" "open" (func $fvm_sdk::sys::ipld::open::syscall (type 0)))
-      ;; vm::abort
-      (type (;1;) (func (param i32 i32 i32) (result i32)))
-      (import "vm" "abort" (func $fvm_sdk::sys::vm::abort::syscall (type 1)))
+      ;; vm::abort -> vm::exit
+      (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
+      (import "vm" "exit" (func $fvm_sdk::sys::vm::exit::syscall (type 1)))
       (memory (export "memory") 1)
       (func (export "invoke") (param $x i32) (result i32)
         (i32.const 123)
@@ -372,7 +372,8 @@ fn backtraces() {
         (call $fvm_sdk::sys::ipld::open::syscall)
         (i32.const 0)
         (i32.const 0)
-        (call $fvm_sdk::sys::vm::abort::syscall)
+        (i32.const 0)
+        (call $fvm_sdk::sys::vm::exit::syscall)
         unreachable
       )
     )
@@ -383,9 +384,9 @@ fn backtraces() {
       ;; ipld::open
       (type (;0;) (func (param i32 i32) (result i32)))
       (import "ipld" "open" (func $fvm_sdk::sys::ipld::open::syscall (type 0)))
-      ;; vm::abort
-      (type (;1;) (func (param i32 i32 i32) (result i32)))
-      (import "vm" "abort" (func $fvm_sdk::sys::vm::abort::syscall (type 1)))
+      ;; vm::abort -> vm::exit
+      (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
+      (import "vm" "exit" (func $fvm_sdk::sys::vm::exit::syscall (type 1)))
       (memory (export "memory") 1)
       (func (export "invoke") (param $x i32) (result i32)
         (i32.const 128)
@@ -400,7 +401,8 @@ fn backtraces() {
         (call $fvm_sdk::sys::ipld::open::syscall)
         (i32.const 0)
         (i32.const 0)
-        (call $fvm_sdk::sys::vm::abort::syscall)
+        (i32.const 0)
+        (call $fvm_sdk::sys::vm::exit::syscall)
         unreachable
       )
     )


### PR DESCRIPTION
Implements generalized aborts as exits, which can carry data and also allow non-local returns (exit(0)).

Closes #986.