### PR TITLE
refactor: merge "context" kernel methods

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -36,6 +36,8 @@ pub struct InnerDefaultCallManager<M: Machine> {
     machine: M,
     /// The gas tracker.
     gas_tracker: GasTracker,
+    /// The gas premium paid by this message.
+    gas_premium: TokenAmount,
     /// The ActorID and the address of the original sender of the chain message that initiated
     /// this call stack.
     origin: ActorID,
@@ -90,7 +92,7 @@ where
         gas_premium: TokenAmount,
     ) -> Self {
         let limits = machine.new_limiter();
-        let mut gas_tracker = GasTracker::new(Gas::new(gas_limit), Gas::zero(), gas_premium);
+        let mut gas_tracker = GasTracker::new(Gas::new(gas_limit), Gas::zero());
 
         if machine.context().tracing {
             gas_tracker.enable_tracing()
@@ -99,6 +101,7 @@ where
         DefaultCallManager(Some(Box::new(InnerDefaultCallManager {
             machine,
             gas_tracker,
+            gas_premium,
             origin,
             origin_address,
             nonce,
@@ -235,6 +238,10 @@ where
 
     fn gas_tracker_mut(&mut self) -> &mut GasTracker {
         &mut self.gas_tracker
+    }
+
+    fn gas_premium(&self) -> &TokenAmount {
+        &self.gas_premium
     }
 
     // Other accessor methods

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -82,6 +82,9 @@ pub trait CallManager: 'static {
     /// Returns a mutable reference to the gas tracker.
     fn gas_tracker_mut(&mut self) -> &mut GasTracker;
 
+    /// Returns the gas premium paid by the currently executing message.
+    fn gas_premium(&self) -> &TokenAmount;
+
     /// Getter for origin actor.
     fn origin(&self) -> ActorID;
 

--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -4,7 +4,6 @@
 use std::fmt::{Debug, Display};
 use std::ops::{Add, AddAssign, Mul, Sub, SubAssign};
 
-use fvm_shared::econ::TokenAmount;
 use num_traits::Zero;
 
 pub use self::charge::GasCharge;
@@ -154,18 +153,16 @@ impl Mul<i32> for Gas {
 pub struct GasTracker {
     gas_limit: Gas,
     gas_used: Gas,
-    gas_premium: TokenAmount,
     trace: Option<Vec<GasCharge>>,
 }
 
 impl GasTracker {
     /// Gas limit and gas used are provided in protocol units (i.e. full units).
     /// They are converted to milligas for internal canonical accounting.
-    pub fn new(gas_limit: Gas, gas_used: Gas, gas_premium: TokenAmount) -> Self {
+    pub fn new(gas_limit: Gas, gas_used: Gas) -> Self {
         Self {
             gas_limit,
             gas_used,
-            gas_premium,
             trace: None,
         }
     }
@@ -221,11 +218,6 @@ impl GasTracker {
         self.gas_limit - self.gas_used
     }
 
-    /// Gettr for gas premium
-    pub fn gas_premium(&self) -> TokenAmount {
-        self.gas_premium.clone()
-    }
-
     pub fn drain_trace(&mut self) -> impl Iterator<Item = GasCharge> + '_ {
         self.trace
             .as_mut()
@@ -256,7 +248,7 @@ mod tests {
     #[test]
     #[allow(clippy::identity_op)]
     fn basic_gas_tracker() -> Result<()> {
-        let mut t = GasTracker::new(Gas::new(20), Gas::new(10), Zero::zero());
+        let mut t = GasTracker::new(Gas::new(20), Gas::new(10));
         t.apply_charge(GasCharge::new("", Gas::new(5), Gas::zero()))?;
         assert_eq!(t.gas_used(), Gas::new(15));
         t.apply_charge(GasCharge::new("", Gas::new(5), Gas::zero()))?;

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -14,7 +14,8 @@ use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, ReplicaUpdateInfo, SealVerifyInfo,
     WindowPoStVerifyInfo,
 };
-use fvm_shared::version::NetworkVersion;
+use fvm_shared::sys::out::network::NetworkContext;
+use fvm_shared::sys::out::vm::MessageContext;
 use fvm_shared::{ActorID, MethodNum};
 
 mod hash;
@@ -95,17 +96,8 @@ pub trait Kernel:
 
 /// Network-related operations.
 pub trait NetworkOps {
-    /// The current network epoch (constant).
-    fn network_epoch(&self) -> ChainEpoch;
-
-    /// The current network version (constant).
-    fn network_version(&self) -> NetworkVersion;
-
-    /// The current base-fee (constant).
-    fn network_base_fee(&self) -> &TokenAmount;
-
-    /// The current tipset timestamp (seconds since the unix epoch).
-    fn tipset_timestamp(&self) -> u64;
+    /// Network information (epoch, version, etc.).
+    fn network_context(&self) -> Result<NetworkContext>;
 
     /// The CID of the tipset at the specified epoch.
     fn tipset_cid(&self, epoch: ChainEpoch) -> Result<Cid>;
@@ -113,26 +105,8 @@ pub trait NetworkOps {
 
 /// Accessors to query attributes of the incoming message.
 pub trait MessageOps {
-    /// The calling actor (constant).
-    fn msg_caller(&self) -> ActorID;
-
-    /// The origin actor
-    fn msg_origin(&self) -> ActorID;
-
-    /// The receiving actor (this actor) (constant).
-    fn msg_receiver(&self) -> ActorID;
-
-    /// The method number used to invoke this actor (constant).
-    fn msg_method_number(&self) -> MethodNum;
-
-    /// The value received from the caller (constant).
-    fn msg_value_received(&self) -> TokenAmount;
-
-    /// The current message gas premium
-    fn msg_gas_premium(&self) -> TokenAmount;
-
-    /// The current message gas limit
-    fn msg_gas_limit(&self) -> u64;
+    /// Message information.
+    fn msg_context(&self) -> Result<MessageContext>;
 }
 
 /// The IPLD subset of the kernel.

--- a/fvm/src/syscalls/network.rs
+++ b/fvm/src/syscalls/network.rs
@@ -1,6 +1,6 @@
 use anyhow::Context as _;
 use fvm_shared::sys;
-use fvm_shared::sys::out::network::NetworkContext as SyscallNetworkContext;
+use fvm_shared::sys::out::network::NetworkContext;
 
 use super::Context;
 use crate::kernel::{ClassifyResult, Kernel, Result};
@@ -15,18 +15,8 @@ pub fn total_fil_circ_supply(context: Context<'_, impl Kernel>) -> Result<sys::T
         .or_fatal()
 }
 
-pub fn context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<SyscallNetworkContext> {
-    Ok(SyscallNetworkContext {
-        epoch: context.kernel.network_epoch(),
-        network_version: context.kernel.network_version() as u32,
-        timestamp: context.kernel.tipset_timestamp(),
-        base_fee: context
-            .kernel
-            .network_base_fee()
-            .try_into()
-            .context("base-fee exceeds u128 limit")
-            .or_fatal()?,
-    })
+pub fn context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<NetworkContext> {
+    context.kernel.network_context()
 }
 
 pub fn tipset_cid(

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -48,25 +48,5 @@ pub fn abort(
 }
 
 pub fn message_context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<MessageContext> {
-    use anyhow::Context as _;
-
-    Ok(MessageContext {
-        caller: context.kernel.msg_caller(),
-        origin: context.kernel.msg_origin(),
-        receiver: context.kernel.msg_receiver(),
-        method_number: context.kernel.msg_method_number(),
-        value_received: context
-            .kernel
-            .msg_value_received()
-            .try_into()
-            .context("invalid token amount")
-            .or_fatal()?,
-        gas_premium: context
-            .kernel
-            .msg_gas_premium()
-            .try_into()
-            .context("invalid gas premium")
-            .or_fatal()?,
-        gas_limit: context.kernel.msg_gas_limit(),
-    })
+    context.kernel.msg_context()
 }

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -432,7 +432,6 @@ mod ipld {
 mod gas {
     use fvm::gas::*;
     use fvm::kernel::GasOps;
-    use fvm_shared::econ::TokenAmount;
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -440,7 +439,7 @@ mod gas {
     #[test]
     fn test() -> anyhow::Result<()> {
         let avaliable = Gas::new(10);
-        let gas_tracker = GasTracker::new(avaliable, Gas::new(0), TokenAmount::zero());
+        let gas_tracker = GasTracker::new(avaliable, Gas::new(0));
 
         let (mut kern, _) = build_inspecting_gas_test(gas_tracker)?;
 
@@ -462,7 +461,7 @@ mod gas {
     #[test]
     fn used() -> anyhow::Result<()> {
         let used = Gas::new(123456);
-        let gas_tracker = GasTracker::new(Gas::new(i64::MAX), used, TokenAmount::zero());
+        let gas_tracker = GasTracker::new(Gas::new(i64::MAX), used);
 
         let (kern, _) = build_inspecting_gas_test(gas_tracker)?;
 
@@ -474,7 +473,7 @@ mod gas {
     #[test]
     fn available() -> anyhow::Result<()> {
         let avaliable = Gas::new(123456);
-        let gas_tracker = GasTracker::new(avaliable, Gas::new(0), TokenAmount::zero());
+        let gas_tracker = GasTracker::new(avaliable, Gas::new(0));
 
         let (kern, _) = build_inspecting_gas_test(gas_tracker)?;
 
@@ -487,7 +486,7 @@ mod gas {
     fn charge() -> anyhow::Result<()> {
         let test_gas = Gas::new(123456);
         let neg_test_gas = Gas::new(-123456);
-        let gas_tracker = GasTracker::new(test_gas, Gas::new(0), TokenAmount::zero());
+        let gas_tracker = GasTracker::new(test_gas, Gas::new(0));
 
         let (mut kern, _) = build_inspecting_gas_test(gas_tracker)?;
 
@@ -521,7 +520,7 @@ mod gas {
         );
 
         // kernel with 0 avaliable gas
-        let gas_tracker = GasTracker::new(Gas::new(0), Gas::new(0), TokenAmount::zero());
+        let gas_tracker = GasTracker::new(Gas::new(0), Gas::new(0));
         let (mut kern, _) = build_inspecting_gas_test(gas_tracker)?;
         expect_out_of_gas!(kern.charge_gas("spend more!", test_gas));
 

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -222,6 +222,7 @@ impl Machine for DummyMachine {
 pub struct DummyCallManager {
     pub machine: DummyMachine,
     pub gas_tracker: GasTracker,
+    pub gas_premium: TokenAmount,
     pub origin: ActorID,
     pub origin_address: Address,
     pub nonce: u64,
@@ -243,12 +244,13 @@ impl DummyCallManager {
         (
             Self {
                 machine: DummyMachine::new_stub().unwrap(),
-                gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0), TokenAmount::zero()),
+                gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0)),
                 origin: 0,
                 nonce: 0,
                 test_data: rc,
                 limits: DummyLimiter::default(),
                 origin_address: Address::new_id(0),
+                gas_premium: TokenAmount::zero(),
             },
             cell_ref,
         )
@@ -268,6 +270,7 @@ impl DummyCallManager {
                 test_data: rc,
                 limits: DummyLimiter::default(),
                 origin_address: Address::new_id(0),
+                gas_premium: TokenAmount::zero(),
             },
             cell_ref,
         )
@@ -291,7 +294,8 @@ impl CallManager for DummyCallManager {
         let limits = machine.new_limiter();
         Self {
             machine,
-            gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0), gas_premium),
+            gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0)),
+            gas_premium,
             origin,
             origin_address,
             nonce,
@@ -358,6 +362,10 @@ impl CallManager for DummyCallManager {
 
     fn origin(&self) -> ActorID {
         self.origin
+    }
+
+    fn gas_premium(&self) -> &TokenAmount {
+        &self.gas_premium
     }
 
     fn nonce(&self) -> u64 {

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -303,6 +303,10 @@ where
         self.0.gas_tracker_mut()
     }
 
+    fn gas_premium(&self) -> &TokenAmount {
+        self.0.gas_premium()
+    }
+
     fn origin(&self) -> ActorID {
         self.0.origin()
     }
@@ -639,32 +643,8 @@ where
     C: CallManager<Machine = TestMachine<M>>,
     K: Kernel<CallManager = TestCallManager<C>>,
 {
-    fn msg_caller(&self) -> ActorID {
-        self.0.msg_caller()
-    }
-
-    fn msg_origin(&self) -> ActorID {
-        self.0.msg_origin()
-    }
-
-    fn msg_receiver(&self) -> ActorID {
-        self.0.msg_receiver()
-    }
-
-    fn msg_method_number(&self) -> MethodNum {
-        self.0.msg_method_number()
-    }
-
-    fn msg_value_received(&self) -> TokenAmount {
-        self.0.msg_value_received()
-    }
-
-    fn msg_gas_premium(&self) -> TokenAmount {
-        self.0.msg_gas_premium()
-    }
-
-    fn msg_gas_limit(&self) -> u64 {
-        self.0.msg_gas_limit()
+    fn msg_context(&self) -> Result<fvm_shared::sys::out::vm::MessageContext> {
+        self.0.msg_context()
     }
 }
 
@@ -674,20 +654,8 @@ where
     C: CallManager<Machine = TestMachine<M>>,
     K: Kernel<CallManager = TestCallManager<C>>,
 {
-    fn network_epoch(&self) -> ChainEpoch {
-        self.0.network_epoch()
-    }
-
-    fn network_version(&self) -> NetworkVersion {
-        self.0.network_version()
-    }
-
-    fn network_base_fee(&self) -> &TokenAmount {
-        self.0.network_base_fee()
-    }
-
-    fn tipset_timestamp(&self) -> u64 {
-        self.0.tipset_timestamp()
+    fn network_context(&self) -> Result<fvm_shared::sys::out::network::NetworkContext> {
+        self.0.network_context()
     }
 
     fn tipset_cid(&self, epoch: ChainEpoch) -> Result<Cid> {


### PR DESCRIPTION
Remove the per-item functions and collapse them into single "context" functions. This will let us:

1. Enforce restrictions necessary for account abstraction.
2. Correctly charge gas.

Also: move the gas premium into the call manager and out of the gas tracker. The gas tracker is for tracking gas available/spent and doesn't care about price.