### PR TITLE
feat: replace wat2wasm with the pure-rust wat crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c521c26a784d5c4bcd98d483a7d3518376e9ff1efbcfa9e2d456ab8183752303"
 dependencies = [
  "cc",
- "glob 0.3.0",
+ "glob",
  "threadpool",
  "which",
  "zeroize",
@@ -761,15 +761,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1127,7 +1118,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
 dependencies = [
- "glob 0.3.0",
+ "glob",
 ]
 
 [[package]]
@@ -2412,8 +2403,8 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "thiserror",
- "wabt",
  "wasmtime",
+ "wat",
 ]
 
 [[package]]
@@ -2845,12 +2836,6 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-
-[[package]]
-name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
@@ -3139,6 +3124,12 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin 0.5.2",
 ]
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -4705,6 +4696,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4731,29 +4728,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wabt"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bef93d5e6c81a293bccf107cf43aa47239382f455ba14869d36695d8963b9c"
-dependencies = [
- "serde",
- "serde_derive",
- "serde_json",
- "wabt-sys",
-]
-
-[[package]]
-name = "wabt-sys"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a4e043159f63e16986e713e9b5e1c06043df4848565bf672e27c523864c7791"
-dependencies = [
- "cc",
- "cmake",
- "glob 0.2.11",
-]
 
 [[package]]
 name = "waker-fn"
@@ -4843,6 +4817,15 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9424cdab516a16d4ea03c8f4a01b14e7b2d04a129dcc2bcdde5bcc5f68f06c41"
+dependencies = [
+ "leb128",
+]
 
 [[package]]
 name = "wasm-gc-api"
@@ -5009,6 +4992,27 @@ dependencies = [
  "serde",
  "thiserror",
  "wasmparser",
+]
+
+[[package]]
+name = "wast"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ef81fcd60d244cafffeafac3d17615fdb2fddda6aca18f34a8ae233353587c"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c347c4460ffb311e95aafccd8c29e4888f241b9e4b3bb0e0ccbd998de2c8c0d"
+dependencies = [
+ "wast",
 ]
 
 [[package]]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -36,7 +36,7 @@ default-features = false
 features = ["cranelift", "parallel-compilation"]
 
 [dev-dependencies]
-wabt = "0.10.0"
+wat = "1.0.51"
 serde = { version = "1.0", features = ["derive"] }
 fil_hello_world_actor = { path = 'tests/fil-hello-world-actor' }
 fil_stack_overflow_actor = { path = 'tests/fil-stack-overflow-actor' }

--- a/testing/integration/examples/integration.rs
+++ b/testing/integration/examples/integration.rs
@@ -10,7 +10,6 @@ use fvm_shared::message::Message;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use num_traits::Zero;
-use wabt::wat2wasm;
 
 const WAT: &str = r#"
 ;; Mock invoke function
@@ -36,7 +35,7 @@ pub fn main() {
     let sender: [Account; 1] = tester.create_accounts().unwrap();
 
     // Get wasm bin
-    let wasm_bin = wat2wasm(WAT).unwrap();
+    let wasm_bin = wat::parse_str(WAT).unwrap();
 
     // Set actor state
     let actor_state = State { empty: true };

--- a/testing/integration/tests/fil_syscall.rs
+++ b/testing/integration/tests/fil_syscall.rs
@@ -13,7 +13,6 @@ use fvm_shared::message::Message;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use num_traits::Zero;
-use wabt::wat2wasm;
 
 mod bundles;
 use bundles::*;
@@ -68,7 +67,7 @@ fn instantiate_tester(
 #[test]
 fn non_existing_syscall() {
     // Get wasm bin
-    let wasm_bin = wat2wasm(WAT_UNKNOWN_SYSCALL).unwrap();
+    let wasm_bin = wat::parse_str(WAT_UNKNOWN_SYSCALL).unwrap();
 
     // Instantiate tester
     let (sender, mut tester, actor_address) = instantiate_tester(&wasm_bin);

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -20,7 +20,6 @@ use fvm_shared::message::Message;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use num_traits::Zero;
-use wabt::wat2wasm;
 
 mod bundles;
 use bundles::*;
@@ -267,7 +266,7 @@ fn test_exitcode(wat: &str, code: ExitCode) {
     let sender: [Account; 1] = tester.create_accounts().unwrap();
 
     // Get wasm bin
-    let wasm_bin = wat2wasm(wat).unwrap();
+    let wasm_bin = wat::parse_str(wat).unwrap();
 
     // Set actor state
     let actor_state = State { count: 0 };
@@ -427,7 +426,10 @@ fn backtraces() {
     let state_cid = tester.set_state(&State { count: 0 }).unwrap();
 
     // Set an actor that aborts.
-    let (wasm_abort, wasm_fatal) = (wat2wasm(WAT_ABORT).unwrap(), wat2wasm(WAT_FAIL).unwrap());
+    let (wasm_abort, wasm_fatal) = (
+        wat::parse_str(WAT_ABORT).unwrap(),
+        wat::parse_str(WAT_FAIL).unwrap(),
+    );
     let (abort_address, fatal_address) = (Address::new_id(10000), Address::new_id(10001));
     tester
         .set_actor_from_bin(&wasm_abort, state_cid, abort_address, TokenAmount::zero())


### PR DESCRIPTION
`wat` is built and maintained by the bytecode alliance, and is pure rust. Importantly, it doesn't invoke cmake.