### PR TITLE
fix: make sure exit never fails

### DIFF
--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -4,7 +4,7 @@ use fvm_shared::sys::SyscallSafe;
 
 use super::error::Abort;
 use super::Context;
-use crate::kernel::{ClassifyResult, Kernel};
+use crate::kernel::Kernel;
 
 /// An uninhabited type. We use this in `abort` to make sure there's no way to return without
 /// returning an error.
@@ -21,8 +21,6 @@ pub fn exit(
     message_off: u32,
     message_len: u32,
 ) -> Result<Never, Abort> {
-    use crate::kernel::Context as _;
-
     let code = ExitCode::new(code);
     if code.is_system_error() {
         return Err(Abort::Exit(
@@ -35,16 +33,10 @@ pub fn exit(
     let message = if message_len == 0 {
         "actor aborted".to_owned()
     } else {
-        std::str::from_utf8(
-            context
-                .memory
-                .try_slice(message_off, message_len)
-                .map_err(|e| Abort::from_error(code, e))?,
-        )
-        .or_illegal_argument()
-        .context("error message was not utf8")
-        .map_err(|e| Abort::from_error(code, e))?
-        .to_owned()
+        match context.memory.try_slice(message_off, message_len) {
+            Ok(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+            Err(e) => format!("failed to extract error message: {e}"),
+        }
     };
     Err(Abort::Exit(code, message, blk))
 }


### PR DESCRIPTION
Even if we pass it an invalid message, we shouldn't fail.