### PR TITLE
MEM-1051: Refactor CallManager to use internal mutability for GasTracker

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -259,7 +259,7 @@ where
         Ok(k)
     }
 
-    fn block_read(&mut self, id: BlockId, offset: u32, buf: &mut [u8]) -> Result<i32> {
+    fn block_read(&self, id: BlockId, offset: u32, buf: &mut [u8]) -> Result<i32> {
         // First, find the end of the _logical_ buffer (taking the offset into account).
         // This must fit into an i32.
 
@@ -292,7 +292,7 @@ where
         Ok((data.len() as i32) - end)
     }
 
-    fn block_stat(&mut self, id: BlockId) -> Result<BlockStat> {
+    fn block_stat(&self, id: BlockId) -> Result<BlockStat> {
         self.call_manager
             .charge_gas(self.call_manager.price_list().on_block_stat())?;
 
@@ -405,7 +405,7 @@ where
     C: CallManager,
 {
     fn verify_signature(
-        &mut self,
+        &self,
         sig_type: SignatureType,
         signature: &[u8],
         signer: &Address,
@@ -445,7 +445,7 @@ where
     }
 
     fn recover_secp_public_key(
-        &mut self,
+        &self,
         hash: &[u8; SECP_SIG_MESSAGE_HASH_SIZE],
         signature: &[u8; SECP_SIG_LEN],
     ) -> Result<[u8; SECP_PUB_LEN]> {
@@ -459,7 +459,7 @@ where
             })
     }
 
-    fn hash(&mut self, code: u64, data: &[u8]) -> Result<MultihashGeneric<64>> {
+    fn hash(&self, code: u64, data: &[u8]) -> Result<MultihashGeneric<64>> {
         self.call_manager
             .charge_gas(self.call_manager.price_list().on_hashing(data.len()))?;
 
@@ -474,7 +474,7 @@ where
     }
 
     fn compute_unsealed_sector_cid(
-        &mut self,
+        &self,
         proof_type: RegisteredSealProof,
         pieces: &[PieceInfo],
     ) -> Result<Cid> {
@@ -490,7 +490,7 @@ where
     }
 
     /// Verify seal proof for sectors. This proof verifies that a sector was sealed by the miner.
-    fn verify_seal(&mut self, vi: &SealVerifyInfo) -> Result<bool> {
+    fn verify_seal(&self, vi: &SealVerifyInfo) -> Result<bool> {
         self.call_manager
             .charge_gas(self.call_manager.price_list().on_verify_seal(vi))?;
 
@@ -499,7 +499,7 @@ where
         catch_and_log_panic("verifying seal", || verify_seal(vi))
     }
 
-    fn verify_post(&mut self, verify_info: &WindowPoStVerifyInfo) -> Result<bool> {
+    fn verify_post(&self, verify_info: &WindowPoStVerifyInfo) -> Result<bool> {
         self.call_manager
             .charge_gas(self.call_manager.price_list().on_verify_post(verify_info))?;
 
@@ -508,7 +508,7 @@ where
     }
 
     fn verify_consensus_fault(
-        &mut self,
+        &self,
         h1: &[u8],
         h2: &[u8],
         extra: &[u8],
@@ -527,7 +527,7 @@ where
         Ok(fault)
     }
 
-    fn batch_verify_seals(&mut self, vis: &[SealVerifyInfo]) -> Result<Vec<bool>> {
+    fn batch_verify_seals(&self, vis: &[SealVerifyInfo]) -> Result<Vec<bool>> {
         // NOTE: gas has already been charged by the power actor when the batch verify was enqueued.
         // Lotus charges "virtual" gas here for tracing only.
         log::debug!("batch verify seals start");
@@ -569,10 +569,7 @@ where
         Ok(out)
     }
 
-    fn verify_aggregate_seals(
-        &mut self,
-        aggregate: &AggregateSealVerifyProofAndInfos,
-    ) -> Result<bool> {
+    fn verify_aggregate_seals(&self, aggregate: &AggregateSealVerifyProofAndInfos) -> Result<bool> {
         self.call_manager.charge_gas(
             self.call_manager
                 .price_list()
@@ -583,7 +580,7 @@ where
         })
     }
 
-    fn verify_replica_update(&mut self, replica: &ReplicaUpdateInfo) -> Result<bool> {
+    fn verify_replica_update(&self, replica: &ReplicaUpdateInfo) -> Result<bool> {
         self.call_manager.charge_gas(
             self.call_manager
                 .price_list()
@@ -607,7 +604,7 @@ where
         self.call_manager.gas_tracker(|gt| gt.gas_available())
     }
 
-    fn charge_gas(&mut self, name: &str, compute: Gas) -> Result<()> {
+    fn charge_gas(&self, name: &str, compute: Gas) -> Result<()> {
         self.call_manager
             .gas_tracker_mut(|gt| gt.charge_gas(name, compute))
     }
@@ -664,7 +661,7 @@ where
     C: CallManager,
 {
     fn get_randomness_from_tickets(
-        &mut self,
+        &self,
         personalization: i64,
         rand_epoch: ChainEpoch,
         entropy: &[u8],
@@ -684,7 +681,7 @@ where
     }
 
     fn get_randomness_from_beacon(
-        &mut self,
+        &self,
         personalization: i64,
         rand_epoch: ChainEpoch,
         entropy: &[u8],

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -321,7 +321,9 @@ where
                 .try_into()
                 .or_fatal()
                 .context("invalid gas premium")?,
-            gas_limit: self.call_manager.gas_tracker().gas_limit().round_down() as u64,
+            gas_limit: self
+                .call_manager
+                .gas_tracker(|gt| gt.gas_limit().round_down() as u64),
         })
     }
 }
@@ -598,17 +600,16 @@ where
     C: CallManager,
 {
     fn gas_used(&self) -> Gas {
-        self.call_manager.gas_tracker().gas_used()
+        self.call_manager.gas_tracker(|gt| gt.gas_used())
     }
 
     fn gas_available(&self) -> Gas {
-        self.call_manager.gas_tracker().gas_available()
+        self.call_manager.gas_tracker(|gt| gt.gas_available())
     }
 
     fn charge_gas(&mut self, name: &str, compute: Gas) -> Result<()> {
         self.call_manager
-            .gas_tracker_mut()
-            .charge_gas(name, compute)
+            .gas_tracker_mut(|gt| gt.charge_gas(name, compute))
     }
 
     fn price_list(&self) -> &PriceList {

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -134,12 +134,12 @@ pub trait IpldBlockOps {
     /// Read data from a block.
     ///
     /// This method will fail if the block handle is invalid.
-    fn block_read(&mut self, id: BlockId, offset: u32, buf: &mut [u8]) -> Result<i32>;
+    fn block_read(&self, id: BlockId, offset: u32, buf: &mut [u8]) -> Result<i32>;
 
     /// Returns the blocks codec & size.
     ///
     /// This method will fail if the block handle is invalid.
-    fn block_stat(&mut self, id: BlockId) -> Result<BlockStat>;
+    fn block_stat(&self, id: BlockId) -> Result<BlockStat>;
 }
 
 /// Actor state access and manipulation.
@@ -239,7 +239,7 @@ pub trait GasOps {
 
     /// ChargeGas charges specified amount of `gas` for execution.
     /// `name` provides information about gas charging point.
-    fn charge_gas(&mut self, name: &str, compute: Gas) -> Result<()>;
+    fn charge_gas(&self, name: &str, compute: Gas) -> Result<()>;
 
     /// Returns the currently active gas price list.
     fn price_list(&self) -> &PriceList;
@@ -249,7 +249,7 @@ pub trait GasOps {
 pub trait CryptoOps {
     /// Verifies that a signature is valid for an address and plaintext.
     fn verify_signature(
-        &mut self,
+        &self,
         sig_type: SignatureType,
         signature: &[u8],
         signer: &Address,
@@ -258,7 +258,7 @@ pub trait CryptoOps {
 
     /// Given a message hash and its signature, recovers the public key of the signer.
     fn recover_secp_public_key(
-        &mut self,
+        &self,
         hash: &[u8; SECP_SIG_MESSAGE_HASH_SIZE],
         signature: &[u8; SECP_SIG_LEN],
     ) -> Result<[u8; SECP_PUB_LEN]>;
@@ -267,20 +267,20 @@ pub trait CryptoOps {
     /// `digest_out`, returning the size of the digest written to `digest_out`. If `digest_out` is
     /// to small to fit the entire digest, it will be truncated. If too large, the leftover space
     /// will not be overwritten.
-    fn hash(&mut self, code: u64, data: &[u8]) -> Result<MultihashGeneric<64>>;
+    fn hash(&self, code: u64, data: &[u8]) -> Result<MultihashGeneric<64>>;
 
     /// Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.
     fn compute_unsealed_sector_cid(
-        &mut self,
+        &self,
         proof_type: RegisteredSealProof,
         pieces: &[PieceInfo],
     ) -> Result<Cid>;
 
     /// Verifies a sector seal proof.
-    fn verify_seal(&mut self, vi: &SealVerifyInfo) -> Result<bool>;
+    fn verify_seal(&self, vi: &SealVerifyInfo) -> Result<bool>;
 
     /// Verifies a window proof of spacetime.
-    fn verify_post(&mut self, verify_info: &WindowPoStVerifyInfo) -> Result<bool>;
+    fn verify_post(&self, verify_info: &WindowPoStVerifyInfo) -> Result<bool>;
 
     /// Verifies that two block headers provide proof of a consensus fault:
     /// - both headers mined by the same actor
@@ -293,7 +293,7 @@ pub trait CryptoOps {
     /// blocks in the parent of h2 (i.e. h2's grandparent).
     /// Returns nil and an error if the headers don't prove a fault.
     fn verify_consensus_fault(
-        &mut self,
+        &self,
         h1: &[u8],
         h2: &[u8],
         extra: &[u8],
@@ -304,17 +304,14 @@ pub trait CryptoOps {
     ///
     /// Gas: This syscall intentionally _does not_ charge any gas (as said gas would be charged to
     /// cron). Instead, gas is pre-paid by the storage provider on pre-commit.
-    fn batch_verify_seals(&mut self, vis: &[SealVerifyInfo]) -> Result<Vec<bool>>;
+    fn batch_verify_seals(&self, vis: &[SealVerifyInfo]) -> Result<Vec<bool>>;
 
     /// Verify aggregate seals verifies an aggregated batch of prove-commits.
-    fn verify_aggregate_seals(
-        &mut self,
-        aggregate: &AggregateSealVerifyProofAndInfos,
-    ) -> Result<bool>;
+    fn verify_aggregate_seals(&self, aggregate: &AggregateSealVerifyProofAndInfos) -> Result<bool>;
 
     /// Verify replica update verifies a snap deal: an upgrade from a CC sector to a sector with
     /// deals.
-    fn verify_replica_update(&mut self, replica: &ReplicaUpdateInfo) -> Result<bool>;
+    fn verify_replica_update(&self, replica: &ReplicaUpdateInfo) -> Result<bool>;
 }
 
 /// Randomness queries.
@@ -323,7 +320,7 @@ pub trait RandomnessOps {
     /// ticket chain from a given epoch and incorporating requisite entropy.
     /// This randomness is fork dependant but also biasable because of this.
     fn get_randomness_from_tickets(
-        &mut self,
+        &self,
         personalization: i64,
         rand_epoch: ChainEpoch,
         entropy: &[u8],
@@ -333,7 +330,7 @@ pub trait RandomnessOps {
     /// beacon from a given epoch and incorporating requisite entropy.
     /// This randomness is not tied to any fork of the chain, and is unbiasable.
     fn get_randomness_from_beacon(
-        &mut self,
+        &self,
         personalization: i64,
         rand_epoch: ChainEpoch,
         entropy: &[u8],

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -105,7 +105,7 @@ mod ipld {
                 .on_block_create(block.len() as usize)
                 .total();
             assert_eq!(
-                call_manager.gas_tracker.gas_used(),
+                call_manager.gas_tracker.borrow().gas_used(),
                 expected_create_price,
                 "gas use creating a block does not match price list"
             );
@@ -190,7 +190,7 @@ mod ipld {
                 .total();
 
             assert_eq!(
-                call_manager.gas_tracker.gas_used(),
+                call_manager.gas_tracker.borrow().gas_used(),
                 expected_create_price + expected_link_price,
                 "gas use creating and linking a block does not match price list"
             )
@@ -336,7 +336,7 @@ mod ipld {
                 "charge_gas should be called exactly once in block_read"
             );
             assert_eq!(
-                call_manager.gas_tracker.gas_used(),
+                call_manager.gas_tracker.borrow().gas_used(),
                 expected_create_price + expected_read_price,
                 "gas use of creating and reading a block does not match price list"
             )
@@ -402,7 +402,7 @@ mod ipld {
                 "charge_gas should be called exactly once in block_stat"
             );
             assert_eq!(
-                call_manager.gas_tracker.gas_used(),
+                call_manager.gas_tracker.borrow().gas_used(),
                 expected_create_price + expected_stat_price,
                 "gas use of creating and 'stat'ing a block does not match price list"
             )
@@ -441,7 +441,7 @@ mod gas {
         let avaliable = Gas::new(10);
         let gas_tracker = GasTracker::new(avaliable, Gas::new(0));
 
-        let (mut kern, _) = build_inspecting_gas_test(gas_tracker)?;
+        let (kern, _) = build_inspecting_gas_test(gas_tracker)?;
 
         assert_eq!(kern.gas_available(), avaliable);
         assert_eq!(kern.gas_used(), Gas::new(0));
@@ -488,7 +488,7 @@ mod gas {
         let neg_test_gas = Gas::new(-123456);
         let gas_tracker = GasTracker::new(test_gas, Gas::new(0));
 
-        let (mut kern, _) = build_inspecting_gas_test(gas_tracker)?;
+        let (kern, _) = build_inspecting_gas_test(gas_tracker)?;
 
         // charge exactly as much as avaliable
         kern.charge_gas("test test 123", test_gas)?;
@@ -521,7 +521,7 @@ mod gas {
 
         // kernel with 0 avaliable gas
         let gas_tracker = GasTracker::new(Gas::new(0), Gas::new(0));
-        let (mut kern, _) = build_inspecting_gas_test(gas_tracker)?;
+        let (kern, _) = build_inspecting_gas_test(gas_tracker)?;
         expect_out_of_gas!(kern.charge_gas("spend more!", test_gas));
 
         Ok(())

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -493,11 +493,11 @@ where
         self.0.block_link(id, hash_fun, hash_len)
     }
 
-    fn block_read(&mut self, id: BlockId, offset: u32, buf: &mut [u8]) -> Result<i32> {
+    fn block_read(&self, id: BlockId, offset: u32, buf: &mut [u8]) -> Result<i32> {
         self.0.block_read(id, offset, buf)
     }
 
-    fn block_stat(&mut self, id: BlockId) -> Result<BlockStat> {
+    fn block_stat(&self, id: BlockId) -> Result<BlockStat> {
         self.0.block_stat(id)
     }
 }
@@ -521,13 +521,13 @@ where
     K: Kernel<CallManager = TestCallManager<C>>,
 {
     // forwarded
-    fn hash(&mut self, code: u64, data: &[u8]) -> Result<MultihashGeneric<64>> {
+    fn hash(&self, code: u64, data: &[u8]) -> Result<MultihashGeneric<64>> {
         self.0.hash(code, data)
     }
 
     // forwarded
     fn compute_unsealed_sector_cid(
-        &mut self,
+        &self,
         proof_type: RegisteredSealProof,
         pieces: &[PieceInfo],
     ) -> Result<Cid> {
@@ -536,7 +536,7 @@ where
 
     // forwarded
     fn verify_signature(
-        &mut self,
+        &self,
         sig_type: SignatureType,
         signature: &[u8],
         signer: &Address,
@@ -548,7 +548,7 @@ where
 
     // forwarded
     fn recover_secp_public_key(
-        &mut self,
+        &self,
         hash: &[u8; SECP_SIG_MESSAGE_HASH_SIZE],
         signature: &[u8; SECP_SIG_LEN],
     ) -> Result<[u8; SECP_PUB_LEN]> {
@@ -556,19 +556,19 @@ where
     }
 
     // NOT forwarded
-    fn batch_verify_seals(&mut self, vis: &[SealVerifyInfo]) -> Result<Vec<bool>> {
+    fn batch_verify_seals(&self, vis: &[SealVerifyInfo]) -> Result<Vec<bool>> {
         Ok(vec![true; vis.len()])
     }
 
     // NOT forwarded
-    fn verify_seal(&mut self, vi: &SealVerifyInfo) -> Result<bool> {
+    fn verify_seal(&self, vi: &SealVerifyInfo) -> Result<bool> {
         let charge = self.1.price_list.on_verify_seal(vi);
         self.0.charge_gas(&charge.name, charge.total())?;
         Ok(true)
     }
 
     // NOT forwarded
-    fn verify_post(&mut self, vi: &WindowPoStVerifyInfo) -> Result<bool> {
+    fn verify_post(&self, vi: &WindowPoStVerifyInfo) -> Result<bool> {
         let charge = self.1.price_list.on_verify_post(vi);
         self.0.charge_gas(&charge.name, charge.total())?;
         Ok(true)
@@ -576,7 +576,7 @@ where
 
     // NOT forwarded
     fn verify_consensus_fault(
-        &mut self,
+        &self,
         _h1: &[u8],
         _h2: &[u8],
         _extra: &[u8],
@@ -587,14 +587,14 @@ where
     }
 
     // NOT forwarded
-    fn verify_aggregate_seals(&mut self, agg: &AggregateSealVerifyProofAndInfos) -> Result<bool> {
+    fn verify_aggregate_seals(&self, agg: &AggregateSealVerifyProofAndInfos) -> Result<bool> {
         let charge = self.1.price_list.on_verify_aggregate_seals(agg);
         self.0.charge_gas(&charge.name, charge.total())?;
         Ok(true)
     }
 
     // NOT forwarded
-    fn verify_replica_update(&mut self, rep: &ReplicaUpdateInfo) -> Result<bool> {
+    fn verify_replica_update(&self, rep: &ReplicaUpdateInfo) -> Result<bool> {
         let charge = self.1.price_list.on_verify_replica_update(rep);
         self.0.charge_gas(&charge.name, charge.total())?;
         Ok(true)
@@ -630,7 +630,7 @@ where
         self.0.gas_used()
     }
 
-    fn charge_gas(&mut self, name: &str, compute: Gas) -> Result<()> {
+    fn charge_gas(&self, name: &str, compute: Gas) -> Result<()> {
         self.0.charge_gas(name, compute)
     }
 
@@ -676,7 +676,7 @@ where
     K: Kernel<CallManager = TestCallManager<C>>,
 {
     fn get_randomness_from_tickets(
-        &mut self,
+        &self,
         personalization: i64,
         rand_epoch: ChainEpoch,
         entropy: &[u8],
@@ -686,7 +686,7 @@ where
     }
 
     fn get_randomness_from_beacon(
-        &mut self,
+        &self,
         personalization: i64,
         rand_epoch: ChainEpoch,
         entropy: &[u8],

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -295,12 +295,18 @@ where
         self.0.machine_mut()
     }
 
-    fn gas_tracker(&self) -> &GasTracker {
-        self.0.gas_tracker()
+    fn gas_tracker<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&GasTracker) -> T,
+    {
+        self.0.gas_tracker(f)
     }
 
-    fn gas_tracker_mut(&mut self) -> &mut GasTracker {
-        self.0.gas_tracker_mut()
+    fn gas_tracker_mut<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&mut GasTracker) -> T,
+    {
+        self.0.gas_tracker_mut(f)
     }
 
     fn gas_premium(&self) -> &TokenAmount {
@@ -352,7 +358,7 @@ where
         self.0.state_tree_mut()
     }
 
-    fn charge_gas(&mut self, charge: fvm::gas::GasCharge) -> Result<()> {
+    fn charge_gas(&self, charge: fvm::gas::GasCharge) -> Result<()> {
         self.0.charge_gas(charge)
     }
 


### PR DESCRIPTION
Part of https://github.com/filecoin-project/ref-fvm/issues/1051

## What

The PR changes `CallManager` to keep the `GasTracker` in a `RefCell`, and allow mutable access to it even via non-mutable reference to itself. 

## Why

While working on https://github.com/filecoin-project/ref-fvm/pull/1139 I realised that with the way the `GasTracker` is exposed by the `CallManager` in `gas_tracker(&self)` and `gas_tracker_mut(&mut self)`, I'd have to change all methods on the `Kernel` to take `&mut self` to be able to charge gas for them. Many of these methods are read-only and take `&self` at the moment, for example `SelfOps::current_balance`. 

I think having them take `&self` is more expressive of their nature, ie. whether they mutate the state of the ledger, and worth keeping. Taking `&mut self` just for charging gas would make this distinction between operations disappear and would be a shame IMO.

Arguably charging for gas is orthogonal to the ledger semantics, since we have to charge for _everything_ - having to have a mutable reference for charging gas seems questionable.

## How

The PR changes `CallManager` to use a `RefCell` to hold the `GasTracker`, and take closures to apply on the tracker in either immutable or mutable fashion. I chose this approach over others I tried because:
* I don't want to return a `RefMut` from `gas_tracker_mut(&self)` for example. That would be rather unsafe as we'd lose the compiler not allowing simultaneous references and might result in a runtime panic. 
* There weren't that many places actually accessing these methods, so the syntactic churn turned out to be quite limited.
* I also decided against moving the internal mutability to the `GasTracker`, because there it felt more expressive the way it was.