### PR TITLE
feat: use actor IDs and remove some fatal errors

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -287,7 +287,7 @@ where
         }
 
         // Check to make sure the actor doesn't exist, or is an embryo.
-        let actor = match self.machine.state_tree().get_actor_id(actor_id)? {
+        let actor = match self.machine.state_tree().get_actor(actor_id)? {
             // Replace the embryo
             Some(mut act) if self.machine.builtin_actors().is_embryo_actor(&act.code) => {
                 if act.address.is_none() {
@@ -318,7 +318,7 @@ where
             }
         };
 
-        self.state_tree_mut().set_actor_id(actor_id, actor)?;
+        self.state_tree_mut().set_actor(actor_id, actor)?;
         self.num_actors_created += 1;
         Ok(())
     }
@@ -426,7 +426,7 @@ where
                 // Validate that there's an actor at the target ID (we don't care what is there,
                 // just that something is there).
                 Payload::Delegated(da)
-                    if self.state_tree().get_actor_id(da.namespace())?.is_some() =>
+                    if self.state_tree().get_actor(da.namespace())?.is_some() =>
                 {
                     self.create_embryo_actor::<K>(&to)?
                 }
@@ -454,7 +454,7 @@ where
         // Lookup the actor.
         let state = self
             .state_tree()
-            .get_actor_id(to)?
+            .get_actor(to)?
             .ok_or_else(|| syscall_error!(NotFound; "actor does not exist: {}", to))?;
 
         // Charge the method gas. Not sure why this comes second, but it does.

--- a/fvm/src/init_actor.rs
+++ b/fvm/src/init_actor.rs
@@ -24,7 +24,7 @@ use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
 
 use crate::state_tree::{ActorState, StateTree};
 
-pub const INIT_ACTOR_ADDR: Address = Address::new_id(1);
+pub const INIT_ACTOR_ID: ActorID = 1;
 
 use crate::kernel::{ClassifyResult, Result};
 
@@ -71,7 +71,7 @@ impl State {
         B: Blockstore,
     {
         let init_act = state_tree
-            .get_actor(&INIT_ACTOR_ADDR)?
+            .get_actor(INIT_ACTOR_ID)?
             .context("init actor address could not be resolved")
             .or_fatal()?;
 
@@ -123,8 +123,13 @@ impl State {
         }
 
         let map = Hamt::<B, _>::load_with_bit_width(&self.address_map, store, HAMT_BIT_WIDTH)
+            .context("failed to load init actor address map")
             .or_fatal()?;
 
-        Ok(map.get(&addr.to_bytes()).or_fatal()?.copied())
+        Ok(map
+            .get(&addr.to_bytes())
+            .context("failed to read init actor address map")
+            .or_fatal()?
+            .copied())
     }
 }

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -106,7 +106,7 @@ where
     fn get_self(&self) -> Result<Option<ActorState>> {
         self.call_manager
             .state_tree()
-            .get_actor_id(self.actor_id)
+            .get_actor(self.actor_id)
             .or_fatal()
             .context("error when finding current actor")
     }
@@ -182,7 +182,7 @@ where
         // Delete the executing actor
         self.call_manager
             .state_tree_mut()
-            .delete_actor_id(self.actor_id)
+            .delete_actor(self.actor_id)
     }
 }
 
@@ -719,7 +719,7 @@ where
         Ok(self
             .call_manager
             .state_tree()
-            .get_actor_id(id)
+            .get_actor(id)
             .context("failed to lookup actor to get code CID")
             .or_fatal()?
             .ok_or_else(|| syscall_error!(NotFound; "actor not found"))?
@@ -750,7 +750,7 @@ where
         }
 
         // Check to make sure the actor doesn't exist, or is an embryo.
-        let actor = match self.call_manager.state_tree().get_actor_id(actor_id)? {
+        let actor = match self.call_manager.state_tree().get_actor(actor_id)? {
             // Replace the embryo
             Some(mut act)
                 if self
@@ -790,7 +790,7 @@ where
 
         self.call_manager
             .state_tree_mut()
-            .set_actor_id(actor_id, actor)
+            .set_actor(actor_id, actor)
     }
 
     fn get_builtin_actor_type(&self, code_cid: &Cid) -> u32 {
@@ -824,7 +824,7 @@ where
         let balance = self
             .call_manager
             .state_tree()
-            .get_actor_id(actor_id)
+            .get_actor(actor_id)
             .context("cannot find actor")?
             .map(|a| a.balance)
             .unwrap_or_default();
@@ -835,7 +835,7 @@ where
         Ok(self
             .call_manager
             .state_tree()
-            .get_actor_id(actor_id)?
+            .get_actor(actor_id)?
             .ok_or_else(|| syscall_error!(NotFound; "actor not found"))?
             .address)
     }

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -18,7 +18,7 @@ use crate::blockstore::BufferedBlockstore;
 use crate::externs::Externs;
 #[cfg(feature = "m2-native")]
 use crate::init_actor::State as InitActorState;
-use crate::kernel::{ClassifyResult, Context as _, Result};
+use crate::kernel::{ClassifyResult, Result};
 use crate::machine::limiter::ExecResourceLimiter;
 use crate::machine::Manifest;
 use crate::state_tree::{ActorState, StateTree};
@@ -211,15 +211,9 @@ where
     fn create_actor(&mut self, addr: &Address, act: ActorState) -> Result<ActorID> {
         let state_tree = self.state_tree_mut();
 
-        let addr_id = state_tree
-            .register_new_address(addr)
-            .context("failed to register new address")
-            .or_fatal()?;
+        let addr_id = state_tree.register_new_address(addr)?;
 
-        state_tree
-            .set_actor(&Address::new_id(addr_id), act)
-            .context("failed to set actor")
-            .or_fatal()?;
+        state_tree.set_actor(addr_id, act)?;
         Ok(addr_id)
     }
 
@@ -234,7 +228,7 @@ where
         // that and the case where the _receiving_ actor doesn't exist.
         let mut from_actor = self
             .state_tree
-            .get_actor_id(from)?
+            .get_actor(from)?
             .context("cannot transfer from non-existent sender")
             .or_error(ErrorNumber::InsufficientFunds)?;
 
@@ -249,15 +243,15 @@ where
 
         let mut to_actor = self
             .state_tree
-            .get_actor_id(to)?
+            .get_actor(to)?
             .context("cannot transfer to non-existent receiver")
             .or_error(ErrorNumber::NotFound)?;
 
         from_actor.deduct_funds(value)?;
         to_actor.deposit_funds(value);
 
-        self.state_tree.set_actor_id(from, from_actor)?;
-        self.state_tree.set_actor_id(to, to_actor)?;
+        self.state_tree.set_actor(from, from_actor)?;
+        self.state_tree.set_actor(to, to_actor)?;
 
         log::trace!("transferred {} from {} to {}", value, from, to);
 

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -32,10 +32,10 @@ use self::limiter::ExecMemory;
 
 mod boxed;
 
-pub const REWARD_ACTOR_ADDR: Address = Address::new_id(2);
+pub const REWARD_ACTOR_ID: ActorID = 2;
 
 /// Distinguished Account actor that is the destination of all burnt funds.
-pub const BURNT_FUNDS_ACTOR_ADDR: Address = Address::new_id(99);
+pub const BURNT_FUNDS_ACTOR_ID: ActorID = 99;
 
 /// The Machine is the top-level object of the FVM.
 ///

--- a/fvm/src/system_actor.rs
+++ b/fvm/src/system_actor.rs
@@ -3,12 +3,12 @@ use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
 use fvm_ipld_encoding::{Cbor, CborStore};
-use fvm_shared::address::Address;
+use fvm_shared::ActorID;
 
 use crate::kernel::{ClassifyResult, Result};
 use crate::state_tree::{ActorState, StateTree};
 
-pub const SYSTEM_ACTOR_ADDR: Address = Address::new_id(0);
+pub const SYSTEM_ACTOR_ID: ActorID = 0;
 
 #[derive(Default, Deserialize_tuple, Serialize_tuple)]
 pub struct State {
@@ -23,7 +23,7 @@ impl State {
         B: Blockstore,
     {
         let system_act = state_tree
-            .get_actor(&SYSTEM_ACTOR_ADDR)?
+            .get_actor(SYSTEM_ACTOR_ID)?
             .context("system actor address could not be resolved")
             .or_fatal()?;
 

--- a/testing/conformance/benches/bench_conformance_overhead.rs
+++ b/testing/conformance/benches/bench_conformance_overhead.rs
@@ -4,10 +4,11 @@ use std::path::Path;
 use std::time::Duration;
 
 use criterion::*;
-use fvm::machine::{MultiEngine, BURNT_FUNDS_ACTOR_ADDR};
+use fvm::machine::{MultiEngine, BURNT_FUNDS_ACTOR_ID};
 use fvm_conformance_tests::driver::*;
 use fvm_conformance_tests::vector::{ApplyMessage, MessageVector};
 use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::message::Message;
 use num_traits::Zero;
@@ -50,8 +51,8 @@ fn bench_500_simple_state_access(
         .map(|i| ApplyMessage {
             bytes: Message {
                 version: 0,
-                from: BURNT_FUNDS_ACTOR_ADDR,
-                to: BURNT_FUNDS_ACTOR_ADDR,
+                from: Address::new_id(BURNT_FUNDS_ACTOR_ID),
+                to: Address::new_id(BURNT_FUNDS_ACTOR_ID),
                 sequence: i,
                 value: TokenAmount::zero(),
                 method_num: 2,

--- a/testing/conformance/src/driver.rs
+++ b/testing/conformance/src/driver.rs
@@ -145,22 +145,22 @@ fn compare_state_roots(bs: &MemoryBlockstore, root: &Cid, vector: &MessageVector
 
     for m in &vector.apply_messages {
         let msg = Message::unmarshal_cbor(&m.bytes)?;
-        let actual_actor = actual_st.get_actor(&msg.from)?;
-        let expected_actor = expected_st.get_actor(&msg.from)?;
+        let actual_actor = actual_st.get_actor_by_address(&msg.from)?;
+        let expected_actor = expected_st.get_actor_by_address(&msg.from)?;
         compare_actors(bs, "sender", actual_actor, expected_actor)?;
 
-        let actual_actor = actual_st.get_actor(&msg.to)?;
-        let expected_actor = expected_st.get_actor(&msg.to)?;
+        let actual_actor = actual_st.get_actor_by_address(&msg.to)?;
+        let expected_actor = expected_st.get_actor_by_address(&msg.to)?;
         compare_actors(bs, "receiver", actual_actor, expected_actor)?;
     }
 
     // All system actors
     for id in 0..100 {
-        let expected_actor = match expected_st.get_actor_id(id) {
+        let expected_actor = match expected_st.get_actor(id) {
             Ok(act) => act,
             Err(_) => continue, // we don't expect it anyways.
         };
-        let actual_actor = actual_st.get_actor_id(id)?;
+        let actual_actor = actual_st.get_actor(id)?;
         compare_actors(
             bs,
             format_args!("builtin {}", id),

--- a/testing/integration/src/builtin.rs
+++ b/testing/integration/src/builtin.rs
@@ -5,7 +5,7 @@ use fvm::state_tree::{ActorState, StateTree};
 use fvm::{init_actor, system_actor};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
-use fvm_shared::address::Address;
+use fvm_shared::ActorID;
 use multihash::Code;
 
 use crate::error::Error::{FailedToLoadManifest, FailedToSetActor, FailedToSetState};
@@ -44,7 +44,7 @@ pub fn set_sys_actor(
         address: None,
     };
     state_tree
-        .set_actor(&system_actor::SYSTEM_ACTOR_ADDR, sys_actor_state)
+        .set_actor(system_actor::SYSTEM_ACTOR_ID, sys_actor_state)
         .map_err(anyhow::Error::from)
         .context(FailedToSetActor("system actor".to_owned()))
 }
@@ -68,13 +68,13 @@ pub fn set_init_actor(
     };
 
     state_tree
-        .set_actor(&init_actor::INIT_ACTOR_ADDR, init_actor_state)
+        .set_actor(init_actor::INIT_ACTOR_ID, init_actor_state)
         .map_err(anyhow::Error::from)
         .context(FailedToSetActor("init actor".to_owned()))
 }
 
 pub fn set_eam_actor(state_tree: &mut StateTree<impl Blockstore>, eam_code_cid: Cid) -> Result<()> {
-    const EAM_ACTOR_ADDR: Address = Address::new_id(10);
+    const EAM_ACTOR_ID: ActorID = 10;
 
     let eam_state_cid = state_tree
         .store()
@@ -90,7 +90,7 @@ pub fn set_eam_actor(state_tree: &mut StateTree<impl Blockstore>, eam_code_cid: 
     };
 
     state_tree
-        .set_actor(&EAM_ACTOR_ADDR, eam_actor_state)
+        .set_actor(EAM_ACTOR_ID, eam_actor_state)
         .map_err(anyhow::Error::from)
         .context(FailedToSetActor("eam actor".to_owned()))
 }

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -129,7 +129,7 @@ where
         };
 
         state_tree
-            .set_actor(&Address::new_id(id), actor_state)
+            .set_actor(id, actor_state)
             .map_err(anyhow::Error::from)
     }
 
@@ -156,13 +156,15 @@ where
         balance: TokenAmount,
     ) -> Result<Cid> {
         // Register actor address (unless it's an ID address)
-        if actor_address.id().is_err() {
-            self.state_tree
+        let actor_id = match actor_address.id() {
+            Ok(id) => id,
+            Err(_) => self
+                .state_tree
                 .as_mut()
                 .unwrap()
                 .register_new_address(&actor_address)
-                .unwrap();
-        }
+                .unwrap(),
+        };
 
         // Put the WASM code into the blockstore.
         let code_cid = put_wasm_code(self.state_tree.as_mut().unwrap().store(), wasm_bin)?;
@@ -186,7 +188,7 @@ where
         self.state_tree
             .as_mut()
             .unwrap()
-            .set_actor(&actor_address, actor_state)
+            .set_actor(actor_id, actor_state)
             .map_err(anyhow::Error::from)?;
 
         Ok(code_cid)
@@ -287,7 +289,7 @@ where
         };
 
         state_tree
-            .set_actor(&Address::new_id(assigned_addr), actor_state)
+            .set_actor(assigned_addr, actor_state)
             .map_err(anyhow::Error::from)?;
         Ok((assigned_addr, pub_key_addr))
     }

--- a/testing/integration/tests/embryo_sender_test.rs
+++ b/testing/integration/tests/embryo_sender_test.rs
@@ -64,7 +64,7 @@ fn embryo_as_sender() {
         .as_ref()
         .unwrap()
         .state_tree()
-        .get_actor(&receiver)
+        .get_actor_by_address(&receiver)
         .expect("couldn't find receiver actor")
         .expect("actor state didn't exist")
         .balance;
@@ -79,7 +79,7 @@ fn embryo_as_sender() {
         .as_ref()
         .unwrap()
         .state_tree()
-        .get_actor(&sender)
+        .get_actor_by_address(&sender)
         .expect("couldn't find receiver actor")
         .expect("actor state didn't exist")
         .balance;


### PR DESCRIPTION
This is in preparation for "readonly" mode. Basically, I'm:

- Changing all the actor get/set/modify methods to take actor IDs (removing any internal resolution). That way the caller has to handle all of the error cases and can chose what to do.
- Avoid marking failures in some state-tree modification functions as "fatal errors". This will let us enforce the readonly constraint at a very low-level (inside the state-tree).

Why didn't we do this in the first place? Basically, legacy code inherited from Forest (likely trying to be compatible with the lotus VM).