### PR TITLE
feat: add a read-only mode to sends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,6 +1929,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_readonly_actor"
+version = "0.1.0"
+dependencies = [
+ "cid",
+ "fvm_ipld_encoding 0.3.0",
+ "fvm_sdk 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.12",
+ "substrate-wasm-builder",
+]
+
+[[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
@@ -2394,6 +2405,7 @@ dependencies = [
  "fil_integer_overflow_actor",
  "fil_ipld_actor",
  "fil_malformed_syscall_actor",
+ "fil_readonly_actor",
  "fil_stack_overflow_actor",
  "fil_syscall_actor",
  "futures",

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -66,6 +66,7 @@ pub trait CallManager: 'static {
     /// Execute some operation (usually a send) within a transaction.
     fn with_transaction(
         &mut self,
+        read_only: bool,
         f: impl FnOnce(&mut Self) -> Result<InvocationResult>,
     ) -> Result<InvocationResult>;
 

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -98,7 +98,7 @@ where
                 Some(Block::new(DAG_CBOR, msg.params.bytes()))
             };
 
-            let result = cm.with_transaction(|cm| {
+            let result = cm.with_transaction(false, |cm| {
                 // Invoke the message.
                 let ret = cm.send::<K>(sender_id, msg.to, msg.method_num, params, &msg.value)?;
 

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -16,6 +16,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::piece::{zero_piece_commitment, PaddedPieceSize};
 use fvm_shared::sector::SectorInfo;
+use fvm_shared::sys::out::vm::ContextFlags;
 use fvm_shared::{commcid, ActorID};
 use lazy_static::lazy_static;
 use multihash::MultihashDigest;
@@ -322,6 +323,11 @@ where
                 .or_fatal()
                 .context("invalid gas premium")?,
             gas_limit: self.call_manager.gas_tracker().gas_limit().round_down() as u64,
+            flags: if self.call_manager.state_tree().is_read_only() {
+                ContextFlags::READ_ONLY
+            } else {
+                ContextFlags::empty()
+            },
         })
     }
 }

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -336,6 +336,7 @@ where
         method: MethodNum,
         params_id: BlockId,
         value: &TokenAmount,
+        flags: SendFlags,
     ) -> Result<SendResult> {
         let from = self.actor_id;
 
@@ -354,7 +355,9 @@ where
         // Send.
         let result = self
             .call_manager
-            .with_transaction(|cm| cm.send::<Self>(from, *recipient, method, params, value))?;
+            .with_transaction(flags.read_only(), |cm| {
+                cm.send::<Self>(from, *recipient, method, params, value)
+            })?;
 
         // Store result and return.
         Ok(match result {

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -16,6 +16,7 @@ use fvm_shared::sector::{
 };
 use fvm_shared::sys::out::network::NetworkContext;
 use fvm_shared::sys::out::vm::MessageContext;
+use fvm_shared::sys::SendFlags;
 use fvm_shared::{ActorID, MethodNum};
 
 mod hash;
@@ -213,6 +214,7 @@ pub trait SendOps {
         method: u64,
         params: BlockId,
         value: &TokenAmount,
+        flags: SendFlags,
     ) -> Result<SendResult>;
 }
 

--- a/fvm/src/syscalls/send.rs
+++ b/fvm/src/syscalls/send.rs
@@ -1,13 +1,15 @@
+use anyhow::Context as _;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::sys;
+use fvm_shared::sys::{self, SendFlags};
 
 use super::Context;
-use crate::kernel::{Result, SendResult};
+use crate::kernel::{ClassifyResult, Result, SendResult};
 use crate::Kernel;
 
 /// Send a message to another actor. The result is placed as a CBOR-encoded
 /// receipt in the block registry, and can be retrieved by the returned BlockId.
+#[allow(clippy::too_many_arguments)]
 pub fn send(
     context: Context<'_, impl Kernel>,
     recipient_off: u32,
@@ -16,16 +18,22 @@ pub fn send(
     params_id: u32,
     value_hi: u64,
     value_lo: u64,
+    flags: u64,
 ) -> Result<sys::out::send::Send> {
     let recipient: Address = context.memory.read_address(recipient_off, recipient_len)?;
     let value = TokenAmount::from_atto((value_hi as u128) << 64 | value_lo as u128);
+    let flags = SendFlags::from_bits(flags)
+        .with_context(|| format!("invalid send flags: {flags}"))
+        .or_illegal_argument()?;
     // An execution error here means that something went wrong in the FVM.
     // Actor errors are communicated in the receipt.
     let SendResult {
         block_id,
         block_stat,
         exit_code,
-    } = context.kernel.send(&recipient, method, params_id, &value)?;
+    } = context
+        .kernel
+        .send(&recipient, method, params_id, &value, flags)?;
     Ok(sys::out::send::Send {
         exit_code: exit_code.value(),
         return_id: block_id,

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -318,6 +318,7 @@ impl CallManager for DummyCallManager {
 
     fn with_transaction(
         &mut self,
+        _read_only: bool,
         _f: impl FnOnce(&mut Self) -> kernel::Result<InvocationResult>,
     ) -> kernel::Result<InvocationResult> {
         // Ok(InvocationResult::Return(None))

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -1,18 +1,28 @@
 use thiserror::Error;
 
 #[derive(Copy, Clone, Debug, Error)]
-#[error("actor does not exist in state-tree")]
-pub struct NoStateError;
+#[error("actor has been deleted")]
+pub struct StateReadError;
 
-#[derive(Copy, Clone, Debug, Error)]
+#[derive(Copy, Clone, Debug, Error, Eq, PartialEq)]
+pub enum StateUpdateError {
+    #[error("actor has been deleted")]
+    ActorDeleted,
+    #[error("current execution context is read-only")]
+    ReadOnly,
+}
+
+#[derive(Copy, Clone, Debug, Error, Eq, PartialEq)]
 pub enum ActorDeleteError {
     #[error("deletion beneficiary is the current actor")]
     BeneficiaryIsSelf,
     #[error("deletion beneficiary does not exist")]
     BeneficiaryDoesNotExist,
+    #[error("current execution context is read-only")]
+    ReadOnly,
 }
 
-#[derive(Copy, Clone, Debug, Error)]
+#[derive(Copy, Clone, Debug, Error, Eq, PartialEq)]
 pub enum EpochBoundsError {
     #[error("the requested epoch isn't valid")]
     Invalid,

--- a/sdk/src/sself.rs
+++ b/sdk/src/sself.rs
@@ -4,16 +4,16 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::MAX_CID_LEN;
 
-use crate::error::{ActorDeleteError, NoStateError};
+use crate::error::{ActorDeleteError, StateReadError, StateUpdateError};
 use crate::sys;
 
 /// Get the IPLD root CID. Fails if the actor doesn't have state (before the first call to
 /// `set_root` and after actor deletion).
-pub fn root() -> Result<Cid, NoStateError> {
+pub fn root() -> Result<Cid, StateReadError> {
     let mut buf = [0u8; MAX_CID_LEN];
     unsafe {
         let len = sys::sself::root(buf.as_mut_ptr(), buf.len() as u32).map_err(|e| match e {
-            ErrorNumber::IllegalOperation => NoStateError,
+            ErrorNumber::IllegalOperation => StateReadError,
             e => panic!("unexpected error from `self::root` syscall: {}", e),
         })? as usize;
 
@@ -27,14 +27,15 @@ pub fn root() -> Result<Cid, NoStateError> {
 ///
 /// - The new root is not in the actor's "reachable" set.
 /// - Fails if the actor has been deleted.
-pub fn set_root(cid: &Cid) -> Result<(), NoStateError> {
+pub fn set_root(cid: &Cid) -> Result<(), StateUpdateError> {
     let mut buf = [0u8; MAX_CID_LEN];
     cid.write_bytes(&mut buf[..])
         .expect("CID encoding should not fail");
 
     unsafe {
         sys::sself::set_root(buf.as_ptr()).map_err(|e| match e {
-            ErrorNumber::IllegalOperation => NoStateError,
+            ErrorNumber::IllegalOperation => StateUpdateError::ActorDeleted,
+            ErrorNumber::ReadOnly => StateUpdateError::ReadOnly,
             e => panic!("unexpected error from `self::set_root` syscall: {}", e),
         })
     }
@@ -59,6 +60,7 @@ pub fn self_destruct(beneficiary: &Address) -> Result<(), ActorDeleteError> {
     unsafe {
         sys::sself::self_destruct(bytes.as_ptr(), bytes.len() as u32).map_err(|e| match e {
             ErrorNumber::Forbidden => ActorDeleteError::BeneficiaryIsSelf,
+            ErrorNumber::ReadOnly => ActorDeleteError::ReadOnly,
             ErrorNumber::NotFound => ActorDeleteError::BeneficiaryDoesNotExist,
             _ => panic!("unexpected error from `self::self_destruct` syscall: {}", e),
         })

--- a/sdk/src/sys/send.rs
+++ b/sdk/src/sys/send.rs
@@ -2,6 +2,8 @@
 
 #[doc(inline)]
 pub use fvm_shared::sys::out::send::*;
+#[doc(inline)]
+pub use fvm_shared::sys::SendFlags;
 
 // for documentation links
 #[cfg(doc)]
@@ -21,6 +23,7 @@ super::fvm_syscalls! {
     /// - `params` is the IPLD block handle of the method parameters.
     /// - `value_hi` are the "high" bits of the token value to send (little-endian) in attoFIL.
     /// - `value_lo` are the "high" bits of the token value to send (little-endian) in attoFIL.
+    /// - `send_flags` are additional send flags.
     ///
     /// **NOTE**: This syscall will transfer `(value_hi << 64) | (value_lo)` attoFIL to the
     /// recipient.
@@ -38,6 +41,7 @@ super::fvm_syscalls! {
     /// | [`InvalidHandle`]     | parameters block not found.                          |
     /// | [`LimitExceeded`]     | recursion limit reached.                             |
     /// | [`IllegalArgument`]   | invalid recipient address buffer.                    |
+    /// | [`ReadOnly`]          | the send would mutate state in read-only mode.       |
     pub fn send(
         recipient_off: *const u8,
         recipient_len: u32,
@@ -45,5 +49,6 @@ super::fvm_syscalls! {
         params: u32,
         value_hi: u64,
         value_lo: u64,
+        flags: SendFlags,
     ) -> Result<Send>;
 }

--- a/sdk/src/vm.rs
+++ b/sdk/src/vm.rs
@@ -8,6 +8,16 @@ use crate::sys;
 /// BlockID representing nil parameters or return data.
 pub const NO_DATA_BLOCK_ID: u32 = 0;
 
+/// Returns true if the invocation context is read-only. In read-only mode:
+///
+/// - State-tree updates `sself::set_root` are forbidden.
+/// - Actor creation is forbidden.
+/// - Value transfers are forbidden.
+/// - Events are discarded.
+pub fn read_only() -> bool {
+    super::message::MESSAGE_CONTEXT.flags.read_only()
+}
+
 /// Abort execution; exit code must be non zero.
 pub fn abort(code: u32, message: Option<&str>) -> ! {
     if code == 0 {

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -147,6 +147,8 @@ pub enum ErrorNumber {
     Forbidden = 11,
     /// The passed buffer is too small.
     BufferTooSmall = 12,
+    /// The actor is executing in a read-only context.
+    ReadOnly = 13,
 }
 
 impl std::fmt::Display for ErrorNumber {
@@ -165,6 +167,7 @@ impl std::fmt::Display for ErrorNumber {
             Serialization => "serialization error",
             Forbidden => "operation forbidden",
             BufferTooSmall => "buffer too small",
+            ReadOnly => "execution context is read-only",
         })
     }
 }

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -102,6 +102,8 @@ impl ExitCode {
     pub const USR_UNSPECIFIED: ExitCode = ExitCode::new(23);
     /// The actor failed a user-level assertion.
     pub const USR_ASSERTION_FAILED: ExitCode = ExitCode::new(24);
+    /// The requested operation cannot be performed in "read-only" mode.
+    pub const USR_READ_ONLY: ExitCode = ExitCode::new(25);
     // pub const RESERVED_25: ExitCode = ExitCode::new(25);
     // pub const RESERVED_26: ExitCode = ExitCode::new(26);
     // pub const RESERVED_27: ExitCode = ExitCode::new(27);

--- a/shared/src/sys/mod.rs
+++ b/shared/src/sys/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains types exchanged at the syscall layer between actors
 //! (usually through the SDK) and the FVM.
 
+use bitflags::bitflags;
 use num_bigint::TryFromBigIntError;
 
 pub mod out;
@@ -43,6 +44,24 @@ impl<'a> TryFrom<&'a crate::econ::TokenAmount> for TokenAmount {
             hi: (v >> u64::BITS) as u64,
             lo: v as u64,
         })
+    }
+}
+
+bitflags! {
+    /// Flags passed to the send syscall.
+    #[derive(Default)]
+    #[repr(transparent)]
+    // note: this is 64 bits because I don't want to hate my past self, not because we need them
+    // right now. It doesn't really cost anything anyways.
+    pub struct SendFlags: u64 {
+        /// Send in "read-only" mode.
+        const READ_ONLY = 0b00000001;
+    }
+}
+
+impl SendFlags {
+    pub fn read_only(self) -> bool {
+        self.intersects(Self::READ_ONLY)
     }
 }
 

--- a/shared/src/sys/out.rs
+++ b/shared/src/sys/out.rs
@@ -57,8 +57,27 @@ pub mod crypto {
 }
 
 pub mod vm {
+    use bitflags::bitflags;
+
     use crate::sys::TokenAmount;
     use crate::{ActorID, MethodNum};
+
+    bitflags! {
+        /// Invocation flags pertaining to the currently executing actor.
+        #[derive(Default)]
+        #[repr(transparent)]
+        pub struct ContextFlags: u64 {
+            /// Invocation is in "read-only" mode. Any balance transfers, sends that would create
+            /// actors, and calls to `sself::set_root` and `sself::self_destruct` will be rejected.
+            const READ_ONLY = 0b00000001;
+        }
+    }
+
+    impl ContextFlags {
+        pub fn read_only(self) -> bool {
+            self.intersects(Self::READ_ONLY)
+        }
+    }
 
     #[derive(Debug, Copy, Clone)]
     #[repr(packed, C)]
@@ -77,6 +96,8 @@ pub mod vm {
         pub gas_premium: TokenAmount,
         /// The current gas limit
         pub gas_limit: u64,
+        /// Flags pertaining to the currently executing actor's invocation context.
+        pub flags: ContextFlags,
     }
 }
 

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -30,6 +30,7 @@ use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, ReplicaUpdateInfo, SealVerifyInfo,
     WindowPoStVerifyInfo,
 };
+use fvm_shared::sys::SendFlags;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum, TOTAL_FILECOIN};
 use multihash::MultihashGeneric;
@@ -269,11 +270,12 @@ where
 
     fn with_transaction(
         &mut self,
+        read_only: bool,
         f: impl FnOnce(&mut Self) -> Result<InvocationResult>,
     ) -> Result<InvocationResult> {
         // This transmute is _safe_ because this type is "repr transparent".
         let inner_ptr = &mut self.0 as *mut C;
-        self.0.with_transaction(|inner: &mut C| unsafe {
+        self.0.with_transaction(read_only, |inner: &mut C| unsafe {
             // Make sure that we've got the right pointer. Otherwise, this cast definitely isn't
             // safe.
             assert_eq!(inner_ptr, inner as *mut C);
@@ -721,8 +723,9 @@ where
         method: u64,
         params: BlockId,
         value: &TokenAmount,
+        flags: SendFlags,
     ) -> Result<SendResult> {
-        self.0.send(recipient, method, params, value)
+        self.0.send(recipient, method, params, value, flags)
     }
 }
 

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -47,6 +47,7 @@ fil_syscall_actor = { path = "tests/fil-syscall-actor" }
 fil_address_actor = { path = "tests/fil-address-actor" }
 fil_events_actor = { path = "tests/fil-events-actor" }
 fil_exit_data_actor = { path = "tests/fil-exit-data-actor" }
+fil_readonly_actor = { path = "tests/fil-readonly-actor" }
 
 actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 

--- a/testing/integration/tests/fil-readonly-actor/Cargo.toml
+++ b/testing/integration/tests/fil-readonly-actor/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fil_readonly_actor"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+fvm_sdk = { version = "3.0.0-alpha.14", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.12", path = "../../../../shared" }
+fvm_ipld_encoding = { version = "0.3.0", path = "../../../../ipld/encoding" }
+cid = { version = "0.8.5", default-features = false }
+
+[build-dependencies]
+substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-readonly-actor/build.rs
+++ b/testing/integration/tests/fil-readonly-actor/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    use substrate_wasm_builder::WasmBuilder;
+    WasmBuilder::new()
+        .with_current_project()
+        .import_memory()
+        .append_to_rust_flags("-Ctarget-feature=+crt-static")
+        .append_to_rust_flags("-Cpanic=abort")
+        .append_to_rust_flags("-Coverflow-checks=true")
+        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Copt-level=z")
+        .build()
+}

--- a/testing/integration/tests/fil-readonly-actor/src/lib.rs
+++ b/testing/integration/tests/fil-readonly-actor/src/lib.rs
@@ -1,0 +1,134 @@
+#[cfg(not(target_arch = "wasm32"))]
+include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+
+use cid::multihash::{Code, MultihashDigest};
+use cid::Cid;
+use fvm_ipld_encoding::{to_vec, RawBytes, DAG_CBOR};
+use fvm_sdk as sdk;
+use fvm_shared::address::{Address, SECP_PUB_LEN};
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::event::{Entry, Flags};
+use fvm_shared::METHOD_SEND;
+use sdk::error::{ActorDeleteError, StateUpdateError};
+use sdk::sys::ErrorNumber;
+
+/// Placeholder invoke for testing
+#[no_mangle]
+#[cfg(target_arch = "wasm32")]
+pub fn invoke(blk: u32) -> u32 {
+    invoke_method(blk, sdk::message::method_number())
+}
+
+#[allow(dead_code)]
+fn invoke_method(blk: u32, method: u64) -> u32 {
+    let account = Address::new_secp256k1(&[0u8; SECP_PUB_LEN]).unwrap();
+    match method {
+        2 => {
+            // Can't create actors when read-only.
+            let resp = sdk::send::send_read_only(&account, METHOD_SEND, RawBytes::default());
+            assert_eq!(resp, Err(ErrorNumber::ReadOnly));
+
+            // But can still create them when not read-only.
+            assert!(sdk::send::send(
+                &account,
+                METHOD_SEND,
+                Default::default(),
+                Default::default(),
+            )
+            .unwrap()
+            .exit_code
+            .is_success());
+
+            // Now recurse.
+            assert!(sdk::send::send_read_only(
+                &Address::new_id(sdk::message::receiver()),
+                3,
+                Default::default(),
+            )
+            .unwrap()
+            .exit_code
+            .is_success());
+        }
+        3 => {
+            // should now be in read-only mode.
+
+            // Sending value fails.
+            let resp = sdk::send::send(&account, 0, Default::default(), TokenAmount::from_atto(1));
+            assert_eq!(resp, Err(ErrorNumber::ReadOnly));
+
+            // Sending nothing succeeds.
+            assert!(
+                sdk::send::send(&account, 0, Default::default(), Default::default())
+                    .unwrap()
+                    .exit_code
+                    .is_success()
+            );
+
+            // Writing should succeed.
+            let cid = sdk::ipld::put(0xb220, 32, 0x55, b"foo").unwrap();
+
+            // Setting root should fail.
+            let err = sdk::sself::set_root(&cid).expect_err("successfully set root");
+            assert_eq!(err, StateUpdateError::ReadOnly);
+
+            // Root should not be updated.
+            let empty = to_vec::<[(); 0]>(&[]).unwrap();
+            let expected_root = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));
+            let root = sdk::sself::root().unwrap();
+            assert_eq!(root, expected_root);
+
+            // Send should be able to pass values.
+            let output = sdk::send::send(
+                &Address::new_id(sdk::message::receiver()),
+                4,
+                RawBytes::new("input".into()),
+                Default::default(),
+            )
+            .unwrap();
+            assert!(output.exit_code.is_success());
+            assert_eq!(output.return_data.bytes(), b"output");
+
+            // Aborts should work.
+            let output = sdk::send::send(
+                &Address::new_id(sdk::message::receiver()),
+                5,
+                RawBytes::default(),
+                Default::default(),
+            )
+            .unwrap();
+            assert_eq!(output.exit_code.value(), 42);
+
+            // Should be able to recursivly send in read-only mode.
+            let output = sdk::send::send_read_only(
+                &Address::new_id(sdk::message::receiver()),
+                4,
+                RawBytes::new("input".into()),
+            )
+            .unwrap();
+            assert!(output.exit_code.is_success());
+            assert_eq!(output.return_data.bytes(), b"output");
+
+            // Should be able to emit events.
+            let evt = vec![Entry {
+                flags: Flags::all(),
+                key: "foo".to_owned(),
+                value: RawBytes::new(empty),
+            }];
+            sdk::event::emit_event(&evt.into()).unwrap();
+
+            // Should not be able to delete self.
+            let err =
+                sdk::sself::self_destruct(&Address::new_id(sdk::message::origin())).unwrap_err();
+            assert_eq!(err, ActorDeleteError::ReadOnly);
+        }
+        4 => {
+            // read params and return value entirely in read-only mode.
+            let input = sdk::ipld::get_block(blk, None).unwrap();
+            assert_eq!(input, b"input");
+            return sdk::ipld::put_block(0x55, b"output").unwrap();
+        }
+        5 => sdk::vm::abort(42, None),
+        _ => panic!("unexpected method"),
+    }
+    0
+}

--- a/testing/integration/tests/readonly_test.rs
+++ b/testing/integration/tests/readonly_test.rs
@@ -1,0 +1,63 @@
+mod bundles;
+use bundles::*;
+use fil_readonly_actor::WASM_BINARY;
+use fvm::executor::{ApplyKind, Executor};
+use fvm_integration_tests::dummy::DummyExterns;
+use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_shared::address::Address;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::message::Message;
+use fvm_shared::state::StateTreeVersion;
+use fvm_shared::version::NetworkVersion;
+use num_traits::Zero;
+
+#[test]
+fn readonly_actor_tests() {
+    // Instantiate tester
+    let mut tester = new_tester(
+        NetworkVersion::V18,
+        StateTreeVersion::V5,
+        MemoryBlockstore::default(),
+    )
+    .unwrap();
+
+    let [(_sender_id, sender_address)] = tester.create_accounts().unwrap();
+
+    let wasm_bin = WASM_BINARY.unwrap();
+
+    // Set actor state
+    let actor_state = [(); 0];
+    let state_cid = tester.set_state(&actor_state).unwrap();
+
+    // Set actor
+    let actor_address = Address::new_id(10000);
+
+    tester
+        .set_actor_from_bin(wasm_bin, state_cid, actor_address, TokenAmount::zero())
+        .unwrap();
+
+    // Instantiate machine
+    tester.instantiate_machine(DummyExterns).unwrap();
+
+    let executor = tester.executor.as_mut().unwrap();
+
+    let message = Message {
+        from: sender_address,
+        to: actor_address,
+        gas_limit: 1000000000,
+        method_num: 2,
+        sequence: 0,
+        value: TokenAmount::from_atto(100),
+        ..Message::default()
+    };
+
+    let res = executor
+        .execute_message(message, ApplyKind::Explicit, 100)
+        .unwrap();
+    assert!(
+        res.msg_receipt.exit_code.is_success(),
+        "{:?}",
+        res.failure_info
+    );
+    assert!(res.msg_receipt.events_root.is_none());
+}


### PR DESCRIPTION
Adds a read-only mode for sends.

1. Adds "flags" to the sends syscall. We can extend it in the future to support additional flags.
2. Adds the concept of "read-only" layers to both the event accumulator and the state tree. This means we can track the read-only state at the _lowest_ level.

The general approach here is to reject mutations _at_ the mutation site instead of early. That means we'll charge gas first. The alternative would be to check up-front at the top of the syscall, but that's non-trivial because a send may automatically create an actor in some cases.