### PR TITLE
v3: Change SDK::send's params to take new type IpldBlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -1513,14 +1513,14 @@ dependencies = [
 [[package]]
 name = "fil_actor_account"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "anyhow",
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive",
  "num-traits",
  "serde",
@@ -1548,12 +1548,12 @@ dependencies = [
 [[package]]
 name = "fil_actor_cron"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "num-derive",
  "num-traits",
@@ -1563,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_datacap"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "cid 0.8.6",
  "fil_actors_runtime",
@@ -1573,7 +1573,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "num-derive",
@@ -1584,20 +1584,20 @@ dependencies = [
 [[package]]
 name = "fil_actor_embryo"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
- "fvm_sdk 3.0.0-alpha.17",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_sdk 3.0.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fil_actor_ethaccount"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",
  "num-derive",
  "num-traits",
@@ -1607,7 +1607,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_evm"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.2",
@@ -1619,7 +1619,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_kamt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "hex-literal",
  "impl-serde",
@@ -1629,6 +1629,7 @@ dependencies = [
  "near-blake2",
  "num-derive",
  "num-traits",
+ "once_cell",
  "rlp",
  "serde",
  "serde_tuple",
@@ -1641,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_init"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1650,7 +1651,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "num-derive",
  "num-traits",
@@ -1660,7 +1661,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_market"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1671,7 +1672,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding",
  "libipld-core 0.13.1",
  "log",
@@ -1683,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_miner"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1695,7 +1696,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -1708,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_multisig"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1717,7 +1718,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap",
  "integer-encoding",
  "num-derive",
@@ -1728,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_paych"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1736,7 +1737,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive",
  "num-traits",
  "serde",
@@ -1745,7 +1746,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_power"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1754,7 +1755,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -1767,12 +1768,12 @@ dependencies = [
 [[package]]
 name = "fil_actor_reward"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "num-derive",
@@ -1783,14 +1784,14 @@ dependencies = [
 [[package]]
 name = "fil_actor_system"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive",
  "num-traits",
  "serde",
@@ -1799,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_verifreg"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1809,7 +1810,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "num-derive",
@@ -1820,7 +1821,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1829,8 +1830,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 3.0.0-alpha.17",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_sdk 3.0.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
  "log",
  "multihash 0.16.3",
@@ -1859,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "fil_builtin_actors_bundle"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#90d0c0c4672b207b9c3d6167bc651526243b8544"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#0a3b57816f67da16587d9a2cd6e0352a6da54438"
 dependencies = [
  "cid 0.8.6",
  "clap",
@@ -2822,13 +2823,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6f88e45b7984efbc2add1c98ca24155a454a21513d4c1d9ee40a1a109d4181"
+version = "3.0.0-alpha.18"
 dependencies = [
  "cid 0.8.6",
- "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.14",
+ "fvm_ipld_encoding 0.3.0",
+ "fvm_shared 3.0.0-alpha.15",
  "lazy_static",
  "log",
  "num-traits",
@@ -2838,10 +2837,12 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.0.0-alpha.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd17da863e532445289d3a277db8ff7e25ffcb16c9e869ebe42acc7f50dbf07"
 dependencies = [
  "cid 0.8.6",
- "fvm_ipld_encoding 0.3.0",
- "fvm_shared 3.0.0-alpha.15",
+ "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "num-traits",
@@ -2863,35 +2864,6 @@ dependencies = [
  "data-encoding-macro",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.2.3",
- "lazy_static",
- "log",
- "multihash 0.16.3",
- "num-bigint",
- "num-derive",
- "num-integer",
- "num-traits",
- "serde",
- "serde_repr",
- "serde_tuple",
- "thiserror",
- "unsigned-varint",
-]
-
-[[package]]
-name = "fvm_shared"
-version = "3.0.0-alpha.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4c82720bd5a315560cb724b4806e371fede40a203955ca17690b5b668a1db5"
-dependencies = [
- "anyhow",
- "bitflags",
- "blake2b_simd",
- "byteorder",
- "cid 0.8.6",
- "data-encoding",
- "data-encoding-macro",
- "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "multihash 0.16.3",
@@ -2938,6 +2910,35 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "sha3",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "fvm_shared"
+version = "3.0.0-alpha.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dea3259a0e147bcd22c5670441c1cbc2452e70763bf6688fb14e96f36cee2c2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "blake2b_simd",
+ "byteorder",
+ "cid 0.8.6",
+ "data-encoding",
+ "data-encoding-macro",
+ "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "log",
+ "multihash 0.16.3",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "serde_repr",
+ "serde_tuple",
  "thiserror",
  "unsigned-varint",
 ]
@@ -4368,9 +4369,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
@@ -4395,9 +4396,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ipld/encoding/src/cbor.rs
+++ b/ipld/encoding/src/cbor.rs
@@ -11,8 +11,6 @@ use serde::{Deserialize, Serialize};
 use super::errors::Error;
 use crate::{de, from_slice, ser, strict_bytes, to_vec};
 
-pub const DAG_CBOR: u64 = 0x71;
-
 /// Cbor utility functions for serializable objects
 pub trait Cbor: ser::Serialize + de::DeserializeOwned {
     /// Marshalls cbor encodable object into cbor bytes

--- a/ipld/encoding/src/errors.rs
+++ b/ipld/encoding/src/errors.rs
@@ -57,14 +57,19 @@ impl From<Error> for io::Error {
 /// This is used with the encoding errors, to detail the encoding protocol or any other
 /// information about how the data was encoded or decoded
 #[derive(Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum CodecProtocol {
+    Unsupported,
     Cbor,
+    Raw,
 }
 
 impl fmt::Display for CodecProtocol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
+            CodecProtocol::Unsupported => write!(f, "Unsupported"),
             CodecProtocol::Cbor => write!(f, "Cbor"),
+            CodecProtocol::Raw => write!(f, "Raw"),
         }
     }
 }

--- a/ipld/encoding/src/ipld_block.rs
+++ b/ipld/encoding/src/ipld_block.rs
@@ -1,0 +1,59 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use serde::de::value;
+use {serde, serde_ipld_dagcbor};
+
+use crate::{CodecProtocol, Error, RawBytes, DAG_CBOR, IPLD_RAW};
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct IpldBlock {
+    pub codec: u64,
+    pub data: Vec<u8>,
+}
+
+impl IpldBlock {
+    pub fn deserialize<'de, T>(&'de self) -> Result<T, Error>
+    where
+        T: serde::Deserialize<'de>,
+    {
+        match self.codec {
+            IPLD_RAW => T::deserialize(value::BytesDeserializer::<value::Error>::new(
+                self.data.as_slice(),
+            ))
+            .map_err(|e| Error {
+                description: e.to_string(),
+                protocol: CodecProtocol::Raw,
+            }),
+            DAG_CBOR => Ok(serde_ipld_dagcbor::from_slice(self.data.as_slice())?),
+            _ => Err(Error {
+                description: "unsupported protocol".to_string(),
+                protocol: CodecProtocol::Unsupported,
+            }),
+        }
+    }
+    pub fn serialize<T: serde::Serialize + ?Sized>(codec: u64, value: &T) -> Result<Self, Error> {
+        let data = match codec {
+            IPLD_RAW => crate::raw::to_vec(value)?,
+            DAG_CBOR => crate::to_vec(value)?,
+            _ => {
+                return Err(Error {
+                    description: "unsupported protocol".to_string(),
+                    protocol: CodecProtocol::Unsupported,
+                });
+            }
+        };
+        Ok(IpldBlock { codec, data })
+    }
+    pub fn serialize_cbor<T: serde::Serialize + ?Sized>(value: &T) -> Result<Self, Error> {
+        IpldBlock::serialize(DAG_CBOR, value)
+    }
+}
+
+impl From<RawBytes> for Option<IpldBlock> {
+    fn from(other: RawBytes) -> Self {
+        (!other.is_empty()).then(|| IpldBlock {
+            codec: DAG_CBOR,
+            data: other.into(),
+        })
+    }
+}

--- a/ipld/encoding/src/lib.rs
+++ b/ipld/encoding/src/lib.rs
@@ -6,6 +6,8 @@ mod bytes;
 mod cbor;
 mod cbor_store;
 mod errors;
+pub mod ipld_block;
+mod raw;
 mod vec;
 use std::io;
 
@@ -16,6 +18,9 @@ pub use self::cbor::*;
 pub use self::cbor_store::CborStore;
 pub use self::errors::*;
 pub use self::vec::*;
+
+pub const DAG_CBOR: u64 = 0x71;
+pub const IPLD_RAW: u64 = 0x55;
 
 // TODO: these really don't work all that well in a shared context like this as anyone importing
 // them also need to _explicitly_ import the serde_tuple & serde_repr crates. These are _macros_,

--- a/ipld/encoding/src/raw.rs
+++ b/ipld/encoding/src/raw.rs
@@ -1,0 +1,169 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use thiserror::Error;
+
+/// Serialize the given value to a vec. This method rejects all types except "raw bytes".
+pub fn to_vec<T: serde::Serialize + ?Sized>(value: &T) -> Result<Vec<u8>, super::Error> {
+    serde::Serialize::serialize(value, Serializer).map_err(|e| super::Error {
+        description: e.to_string(),
+        protocol: crate::CodecProtocol::Raw,
+    })
+}
+
+#[derive(Error, Debug)]
+enum Error {
+    #[error("IPLD kind not supported by the raw codec")]
+    KindNotSupported,
+    #[error("i/o error when serializing: {0}")]
+    Other(String),
+}
+
+impl serde::ser::Error for Error {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: std::fmt::Display,
+    {
+        Error::Other(msg.to_string())
+    }
+}
+
+struct Serializer;
+
+macro_rules! reject {
+    ($($method:ident $t:ty),*) => {
+        $(
+            fn $method(self, _: $t) -> Result<Self::Ok, Self::Error> {
+                Err(Error::KindNotSupported)
+            }
+        )*
+    };
+}
+
+impl serde::ser::Serializer for Serializer {
+    type Ok = Vec<u8>;
+    type Error = Error;
+    type SerializeSeq = serde::ser::Impossible<Vec<u8>, Error>;
+    type SerializeTuple = serde::ser::Impossible<Vec<u8>, Error>;
+    type SerializeTupleStruct = serde::ser::Impossible<Vec<u8>, Error>;
+    type SerializeTupleVariant = serde::ser::Impossible<Vec<u8>, Error>;
+    type SerializeMap = serde::ser::Impossible<Vec<u8>, Error>;
+    type SerializeStruct = serde::ser::Impossible<Vec<u8>, Error>;
+    type SerializeStructVariant = serde::ser::Impossible<Vec<u8>, Error>;
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_owned())
+    }
+
+    reject! {
+        serialize_bool bool,
+        serialize_i8 i8,
+        serialize_i16 i16,
+        serialize_i32 i32,
+        serialize_i64 i64,
+        serialize_u8 u8,
+        serialize_u16 u16,
+        serialize_u32 u32,
+        serialize_u64 u64,
+        serialize_f32 f32,
+        serialize_f64 f64,
+        serialize_char char,
+        serialize_str &str,
+        serialize_unit_struct &'static str
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::KindNotSupported)
+    }
+
+    fn serialize_some<T: ?Sized>(self, _: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::KindNotSupported)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::KindNotSupported)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Error::KindNotSupported)
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _: &'static str,
+        _: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::KindNotSupported)
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::KindNotSupported)
+    }
+
+    fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(Error::KindNotSupported)
+    }
+
+    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(Error::KindNotSupported)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(Error::KindNotSupported)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(Error::KindNotSupported)
+    }
+
+    fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(Error::KindNotSupported)
+    }
+
+    fn serialize_struct(
+        self,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(Error::KindNotSupported)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(Error::KindNotSupported)
+    }
+}

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use std::convert::TryInto;
 
-use fvm_ipld_encoding::DAG_CBOR;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::sys::out::vm::MessageContext;
-use fvm_shared::sys::{BlockId, Codec};
+use fvm_shared::sys::BlockId;
 use fvm_shared::{ActorID, MethodNum};
 
 use crate::{sys, SyscallResult, NO_DATA_BLOCK_ID};
@@ -65,13 +65,16 @@ pub fn gas_premium() -> TokenAmount {
         .expect("invalid bigint")
 }
 
-/// Returns the message codec and parameters.
-pub fn params_raw(id: BlockId) -> SyscallResult<(Codec, Vec<u8>)> {
+/// Returns the message parameters as an Option<IpldBlock>.
+pub fn params_raw(id: BlockId) -> SyscallResult<Option<IpldBlock>> {
     if id == NO_DATA_BLOCK_ID {
-        return Ok((DAG_CBOR, Vec::default())); // DAG_CBOR is a lie, but we have no nil codec.
+        return Ok(None);
     }
     unsafe {
         let fvm_shared::sys::out::ipld::IpldStat { codec, size } = sys::ipld::block_stat(id)?;
-        Ok((codec, crate::ipld::get_block(id, Some(size))?))
+        Ok(Some(IpldBlock {
+            codec,
+            data: crate::ipld::get_block(id, Some(size))?,
+        }))
     }
 }

--- a/sdk/src/send.rs
+++ b/sdk/src/send.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use std::convert::TryInto;
 
-use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
@@ -18,7 +19,7 @@ use crate::{sys, SyscallResult, NO_DATA_BLOCK_ID};
 pub fn send(
     to: &Address,
     method: MethodNum,
-    params: RawBytes,
+    params: Option<IpldBlock>,
     value: TokenAmount,
     gas_limit: Option<u64>,
     flags: SendFlags,
@@ -30,10 +31,9 @@ pub fn send(
     unsafe {
         // Insert parameters as a block. Nil parameters is represented as the
         // NO_DATA_BLOCK_ID block ID in the FFI interface.
-        let params_id = if params.len() > 0 {
-            sys::ipld::block_create(DAG_CBOR, params.as_ptr(), params.len() as u32)?
-        } else {
-            NO_DATA_BLOCK_ID
+        let params_id = match params {
+            Some(p) => sys::ipld::block_create(p.codec, p.data.as_ptr(), p.data.len() as u32)?,
+            None => NO_DATA_BLOCK_ID,
         };
 
         // Perform the syscall to send the message.

--- a/testing/calibration/contract/fil-gas-calibration-actor/src/lib.rs
+++ b/testing/calibration/contract/fil-gas-calibration-actor/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::{anyhow, Result};
 use cid::multihash::Code;
-use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::DAG_CBOR;
 use fvm_sdk::message::params_raw;
 use fvm_sdk::vm::abort;
 use fvm_shared::address::{Address, Protocol};
@@ -225,7 +225,7 @@ fn lcg8(seed: u64) -> impl Iterator<Item = u8> {
 }
 
 fn read_params<T: DeserializeOwned>(params_ptr: u32) -> Result<T> {
-    let params = params_raw(params_ptr)?.1;
-    let value = RawBytes::new(params).deserialize()?;
+    let params = params_raw(params_ptr).unwrap().unwrap();
+    let value = params.deserialize()?;
     Ok(value)
 }

--- a/testing/integration/tests/fil-gaslimit-actor/src/actor.rs
+++ b/testing/integration/tests/fil-gaslimit-actor/src/actor.rs
@@ -26,9 +26,9 @@ pub fn invoke(params_id: u32) -> u32 {
 
     // Gas limit to use is supplied as a param.
     let params: Params = {
-        let (codec, data) = sdk::message::params_raw(params_id).unwrap();
-        assert_eq!(codec, fvm_ipld_encoding::DAG_CBOR);
-        fvm_ipld_encoding::from_slice(&data).unwrap()
+        let msg_params = sdk::message::params_raw(params_id).unwrap().unwrap();
+        assert_eq!(msg_params.codec, fvm_ipld_encoding::DAG_CBOR);
+        fvm_ipld_encoding::from_slice(msg_params.data.as_slice()).unwrap()
     };
 
     // If we're self-calling, send to the origin.
@@ -89,11 +89,11 @@ pub fn invoke(params_id: u32) -> u32 {
     };
 
     // send to self with the supplied gas_limit, propagating params.
-    let (_, data) = sdk::message::params_raw(params_id).unwrap();
+    let msg_params = sdk::message::params_raw(params_id).unwrap();
     let ret = sdk::send::send(
         &self_addr,
         2,
-        data.into(),
+        msg_params,
         Zero::zero(),
         gas_limit,
         Default::default(),

--- a/testing/integration/tests/fil-integer-overflow-actor/src/actor/mod.rs
+++ b/testing/integration/tests/fil-integer-overflow-actor/src/actor/mod.rs
@@ -77,8 +77,8 @@ pub fn invoke(params_pointer: u32) -> u32 {
     let ret: Option<RawBytes> = match fvm_sdk::message::method_number() {
         // Set initial value
         1 => {
-            let params = params_raw(params_pointer).unwrap().1;
-            let x: i64 = RawBytes::new(params).deserialize().unwrap();
+            let params = params_raw(params_pointer).unwrap().unwrap();
+            let x: i64 = params.deserialize().unwrap();
 
             let mut state = State::load();
             state.value = x;

--- a/testing/integration/tests/fil-readonly-actor/src/lib.rs
+++ b/testing/integration/tests/fil-readonly-actor/src/lib.rs
@@ -5,6 +5,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::{to_vec, RawBytes, DAG_CBOR};
 use fvm_sdk as sdk;
 use fvm_shared::address::{Address, SECP_PUB_LEN};
@@ -32,7 +33,7 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
             let resp = sdk::send::send(
                 &account,
                 METHOD_SEND,
-                RawBytes::default(),
+                None,
                 TokenAmount::default(),
                 None,
                 SendFlags::READ_ONLY,
@@ -87,7 +88,7 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
                 Default::default(),
                 Default::default(),
                 None,
-                Default::default()
+                Default::default(),
             )
             .unwrap()
             .exit_code
@@ -110,7 +111,10 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
             let output = sdk::send::send(
                 &Address::new_id(sdk::message::receiver()),
                 4,
-                RawBytes::new("input".into()),
+                Some(IpldBlock {
+                    codec: DAG_CBOR,
+                    data: "input".into(),
+                }),
                 Default::default(),
                 None,
                 Default::default(),
@@ -123,7 +127,7 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
             let output = sdk::send::send(
                 &Address::new_id(sdk::message::receiver()),
                 5,
-                RawBytes::default(),
+                None,
                 Default::default(),
                 None,
                 Default::default(),
@@ -135,7 +139,10 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
             let output = sdk::send::send(
                 &Address::new_id(sdk::message::receiver()),
                 4,
-                RawBytes::new("input".into()),
+                Some(IpldBlock {
+                    codec: DAG_CBOR,
+                    data: "input".into(),
+                }),
                 Default::default(),
                 None,
                 SendFlags::READ_ONLY,

--- a/testing/integration/tests/fil-stack-overflow-actor/src/actor.rs
+++ b/testing/integration/tests/fil-stack-overflow-actor/src/actor.rs
@@ -60,7 +60,7 @@ pub fn do_send(m: u64) -> u32 {
     let r = sdk::send::send(
         &Address::new_id(10000),
         m + 1,
-        Vec::new().into(),
+        None,
         TokenAmount::zero(),
         None,
         Default::default(),


### PR DESCRIPTION
Towards #987, but doesn't close it.

Introduces a new IpldBlock type that can support various codecs (currently DAG_CBOR and IPLD_RAW), and switches the SDK::send method to use `Option<IpldBlock>` for params.
