### PR TITLE
fix: charge for the first page of gas

### DIFF
--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -849,10 +849,7 @@ impl PriceList {
 
     /// Returns the gas required for initializing memory.
     pub fn init_memory_gas(&self, min_memory_bytes: usize) -> Gas {
-        // FIP-0037: The first page is free.
-        let free_memory_bytes = wasmtime_environ::WASM_PAGE_SIZE as usize;
-        let charge_memory_bytes = (min_memory_bytes - free_memory_bytes).max(0) as i64;
-        self.wasm_rules.memory_expansion_per_byte_cost * charge_memory_bytes
+        self.wasm_rules.memory_expansion_per_byte_cost * (min_memory_bytes as i64)
     }
 
     /// Returns the gas required for growing memory.

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -458,6 +458,24 @@ fn out_of_stack() {
 }
 
 #[test]
+fn no_memory() {
+    // Make sure we can construct a module with 0 memory pages.
+    test_exitcode(
+        r#"(module
+             (type (;0;) (func (param i32) (result i32)))
+             (func (;0;) (type 0) (param i32) (result i32)
+               i32.const 0
+             )
+             (memory (;0;) 0)
+             (export "invoke" (func 0))
+             (export "memory" (memory 0))
+           )
+           "#,
+        ExitCode::OK,
+    );
+}
+
+#[test]
 fn backtraces() {
     // Note: this test **does not actually assert anything**, but it's useful to
     // let us peep into FVM backtrace generation under different scenarios.


### PR DESCRIPTION
Part of https://github.com/filecoin-project/ref-fvm/issues/1072

Also fixes the underflow reported in https://github.com/filecoin-project/Fuzzing-FVM/issues/38