### PR TITLE
fix: raise the maximum memory limit from 512MiB to 2GiB

### DIFF
--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -127,7 +127,7 @@ pub struct NetworkConfig {
 
     /// Maximum size of memory used during the entire (recursive) message execution.
     ///
-    /// DEFAULT: 512MiB
+    /// DEFAULT: 2GiB
     pub max_exec_memory_bytes: u64,
 
     /// An override for builtin-actors. If specified, this should be the CID of a builtin-actors
@@ -158,7 +158,7 @@ impl NetworkConfig {
             max_call_depth: 1024,
             max_wasm_stack: 2048,
             max_inst_memory_bytes: 512 * (1 << 20),
-            max_exec_memory_bytes: 512 * (1 << 20),
+            max_exec_memory_bytes: 2 * (1 << 30),
             actor_debugging: false,
             builtin_actors_override: None,
             price_list: price_list_by_network_version(network_version),

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -311,13 +311,7 @@ fn native_stack_overflow() {
         .unwrap();
 
     // Instantiate machine
-    tester
-        .instantiate_machine_with_config(DummyExterns, |nc| {
-            // The stack overflow test consumed the default 512MiB before it hit the recursion limit.
-            nc.max_exec_memory_bytes = 4 * (1 << 30);
-            nc.max_inst_memory_bytes = 4 * (1 << 30);
-        })
-        .unwrap();
+    tester.instantiate_machine(DummyExterns).unwrap();
 
     let exec_test =
         |exec: &mut ThreadedExecutor<IntegrationExecutor<MemoryBlockstore, DummyExterns>>,


### PR DESCRIPTION
see https://github.com/filecoin-project/ref-fvm/issues/369#issuecomment-1329573938

This allows us to hit the maximum recursion limit even if we have 1MiB stacks (plus some other memory).