### PR TITLE
feat: remove the gas limit from the context

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -335,7 +335,6 @@ where
                 .try_into()
                 .or_fatal()
                 .context("invalid gas premium")?,
-            gas_limit: self.call_manager.gas_tracker().gas_limit().round_down() as u64,
             flags: if self.call_manager.state_tree().is_read_only() {
                 ContextFlags::READ_ONLY
             } else {

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -49,12 +49,6 @@ pub fn value_received() -> TokenAmount {
         .expect("invalid bigint")
 }
 
-/// Returns the execution gas limit
-#[inline(always)]
-pub fn gas_limit() -> u64 {
-    MESSAGE_CONTEXT.gas_limit
-}
-
 /// Returns the execution gas premium
 pub fn gas_premium() -> TokenAmount {
     MESSAGE_CONTEXT

--- a/shared/src/sys/out.rs
+++ b/shared/src/sys/out.rs
@@ -94,8 +94,6 @@ pub mod vm {
         pub value_received: TokenAmount,
         /// The current gas premium
         pub gas_premium: TokenAmount,
-        /// The current gas limit
-        pub gas_limit: u64,
         /// Flags pertaining to the currently executing actor's invocation context.
         pub flags: ContextFlags,
     }

--- a/testing/integration/tests/fil-gaslimit-actor/src/actor.rs
+++ b/testing/integration/tests/fil-gaslimit-actor/src/actor.rs
@@ -31,9 +31,9 @@ pub fn invoke(params_id: u32) -> u32 {
 
     // If we're self-calling, send to the origin.
     if Address::new_id(sdk::message::caller()) == self_addr {
-        // Check that the observed gas limit is the one set.
+        // Check that we successfully lowered the gas limit.
         if params.inner_gas_limit > 0 {
-            assert_eq!(sdk::message::gas_limit(), params.inner_gas_limit);
+            assert!(sdk::gas::available() <= params.inner_gas_limit);
         }
 
         // This send will never be committed if we exhaust gas.

--- a/testing/integration/tests/fil-syscall-actor/src/actor.rs
+++ b/testing/integration/tests/fil-syscall-actor/src/actor.rs
@@ -229,6 +229,5 @@ fn test_message_context() {
     assert_eq!(sdk::message::receiver(), 10000);
     assert_eq!(sdk::message::method_number(), 1);
     assert!(sdk::message::value_received().is_zero());
-    assert_eq!(sdk::message::gas_limit(), 1000000000);
     assert!(sdk::message::gas_premium().is_zero());
 }


### PR DESCRIPTION
We don't actually need this, and users should use `gas::available`.

fixes #1168