### PR TITLE
CHORE-1170: Add license headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       with:
         command: fmt
         args: -- --check
+    - name: Check license headers
+      run: make license
+
   cargo:
     needs: [rustfmt]
     runs-on: ${{ matrix.os }}
@@ -131,7 +134,7 @@ jobs:
       uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
         command: cache
-        args: --autoclean  
+        args: --autoclean
     - name: Getting Cargo Cache Size
       if: ${{ matrix.push }}
       uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ build:
 clean:
 	cargo clean
 
-lint: clean
+lint: license clean
 	cargo fmt --all
 	cargo clippy --all -- -D warnings -A clippy::upper_case_acronyms
+
+license:
+	./scripts/add_license.sh

--- a/fvm/src/account_actor.rs
+++ b/fvm/src/account_actor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! This module contains the minimal logic for the FVM to handle account actor
 //! auto-creation (on first transfer).
 //!

--- a/fvm/src/blockstore/buffered.rs
+++ b/fvm/src/blockstore/buffered.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/fvm/src/blockstore/mod.rs
+++ b/fvm/src/blockstore/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Private blockstores for use in the FVM.
 
 mod buffered;

--- a/fvm/src/call_manager/backtrace.rs
+++ b/fvm/src/call_manager/backtrace.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::fmt::Display;
 
 use fvm_shared::address::Address;

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::mem;
 
 use anyhow::{anyhow, Context};

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::ops::{Deref, DerefMut};
 use std::result::Result as StdResult;
 

--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 mod default;
 mod threaded;
 

--- a/fvm/src/executor/threaded.rs
+++ b/fvm/src/executor/threaded.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::anyhow;
 use cid::Cid;
 use fvm_shared::message::Message;

--- a/fvm/src/externs/mod.rs
+++ b/fvm/src/externs/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! This module contains the logic to invoke the node by traversing Boundary A.
 
 use cid::Cid;

--- a/fvm/src/gas/charge.rs
+++ b/fvm/src/gas/charge.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/fvm/src/gas/outputs.rs
+++ b/fvm/src/gas/outputs.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::convert::TryFrom;
 
 use fvm_shared::bigint::BigInt;

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/fvm/src/init_actor.rs
+++ b/fvm/src/init_actor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! This module contains the types and functions to process the init actor's state.
 //! It does not contain the logic of the init actor: that lives on-chain as a WASM actor.
 //!

--- a/fvm/src/kernel/blocks.rs
+++ b/fvm/src/kernel/blocks.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::convert::TryInto;
 use std::rc::Rc;
 

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 use std::panic::{self, UnwindSafe};

--- a/fvm/src/kernel/error.rs
+++ b/fvm/src/kernel/error.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::fmt::Display;
 
 use derive_more::Display;

--- a/fvm/src/kernel/hash.rs
+++ b/fvm/src/kernel/hash.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use multihash::derive::Multihash;
 use multihash::{Blake2b256, Blake2b512, Keccak256, Ripemd160, Sha2_256};
 

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 pub use blocks::{Block, BlockId, BlockRegistry, BlockStat};
 use cid::Cid;
 use fvm_shared::address::Address;

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! (Proper package docs coming shortly; for now this is a holding pen for items
 //! we must mention).
 //!

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::ops::RangeInclusive;
 
 use anyhow::{anyhow, Context as _};

--- a/fvm/src/machine/engine.rs
+++ b/fvm/src/machine/engine.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::any::{Any, TypeId};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;

--- a/fvm/src/machine/limiter.rs
+++ b/fvm/src/machine/limiter.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use wasmtime::ResourceLimiter;
 
 use crate::machine::NetworkConfig;

--- a/fvm/src/machine/manifest.rs
+++ b/fvm/src/machine/manifest.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{anyhow, Context};

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
 use derive_more::{Deref, DerefMut};
 use fvm_ipld_blockstore::Blockstore;

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::{anyhow, Context as _};
 use fvm_shared::{sys, ActorID};
 

--- a/fvm/src/syscalls/bind.rs
+++ b/fvm/src/syscalls/bind.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::mem;
 
 use fvm_shared::error::ErrorNumber;

--- a/fvm/src/syscalls/context.rs
+++ b/fvm/src/syscalls/context.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::io::Cursor;
 use std::ops::{Deref, DerefMut};
 use std::panic;

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::cmp;
 
 use anyhow::{anyhow, Context as _};

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use crate::kernel::{ClassifyResult, Result};
 use crate::syscalls::context::Context;
 use crate::Kernel;

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! This module contains code used to convert errors to and from wasmtime traps.
 use std::sync::Mutex;
 

--- a/fvm/src/syscalls/event.rs
+++ b/fvm/src/syscalls/event.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_shared::event::ActorEvent;
 
 use super::Context;

--- a/fvm/src/syscalls/gas.rs
+++ b/fvm/src/syscalls/gas.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::str;
 
 use super::Context;

--- a/fvm/src/syscalls/ipld.rs
+++ b/fvm/src/syscalls/ipld.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_shared::sys;
 
 use super::Context;

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::mem;
 
 use anyhow::{anyhow, Context as _};

--- a/fvm/src/syscalls/network.rs
+++ b/fvm/src/syscalls/network.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::Context as _;
 use fvm_shared::sys;
 use fvm_shared::sys::out::network::NetworkContext;

--- a/fvm/src/syscalls/rand.rs
+++ b/fvm/src/syscalls/rand.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
 
 use super::Context;

--- a/fvm/src/syscalls/send.rs
+++ b/fvm/src/syscalls/send.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::Context as _;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;

--- a/fvm/src/syscalls/sself.rs
+++ b/fvm/src/syscalls/sself.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::Context as _;
 use fvm_shared::sys;
 

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_shared::error::ExitCode;
 use fvm_shared::sys::out::vm::MessageContext;
 use fvm_shared::sys::SyscallSafe;

--- a/fvm/src/system_actor.rs
+++ b/fvm/src/system_actor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::Context;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;

--- a/fvm/tests/default_kernel/mod.rs
+++ b/fvm/tests/default_kernel/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use super::*;
 
 mod ipld {

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/fvm/tests/fvm.rs
+++ b/fvm/tests/fvm.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 mod default_kernel;
 mod dummy;
 

--- a/ipld/amt/benches/amt_benchmark.rs
+++ b/ipld/amt/benches/amt_benchmark.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/amt/fuzz/fuzz_targets/equivalence.rs
+++ b/ipld/amt/fuzz/fuzz_targets/equivalence.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/amt/src/error.rs
+++ b/ipld/amt/src/error.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/amt/src/lib.rs
+++ b/ipld/amt/src/lib.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/amt/src/root.rs
+++ b/ipld/amt/src/root.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/amt/src/value_mut.rs
+++ b/ipld/amt/src/value_mut.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/bitfield/benches/benchmarks/examples.rs
+++ b/ipld/bitfield/benches/benchmarks/examples.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/bitfield/benches/benchmarks/main.rs
+++ b/ipld/bitfield/benches/benchmarks/main.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/bitfield/src/iter/combine.rs
+++ b/ipld/bitfield/src/iter/combine.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/bitfield/src/iter/mod.rs
+++ b/ipld/bitfield/src/iter/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/bitfield/src/lib.rs
+++ b/ipld/bitfield/src/lib.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/bitfield/src/ops.rs
+++ b/ipld/bitfield/src/ops.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 
 use crate::{BitField, RangeIterator};

--- a/ipld/bitfield/src/range.rs
+++ b/ipld/bitfield/src/range.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::ops::Range;
 
 /// A helper trait to get the size of ranges because Range.len doesn't work for ranges of u64.

--- a/ipld/bitfield/src/rleplus/error.rs
+++ b/ipld/bitfield/src/rleplus/error.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use thiserror::Error;
 
 #[derive(PartialEq, Eq, Clone, Debug, Error)]

--- a/ipld/bitfield/src/rleplus/mod.rs
+++ b/ipld/bitfield/src/rleplus/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/bitfield/src/rleplus/reader.rs
+++ b/ipld/bitfield/src/rleplus/reader.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/bitfield/src/rleplus/writer.rs
+++ b/ipld/bitfield/src/rleplus/writer.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/bitfield/src/unvalidated.rs
+++ b/ipld/bitfield/src/unvalidated.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/bitfield/tests/bitfield_tests.rs
+++ b/ipld/bitfield/tests/bitfield_tests.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/blockstore/src/block.rs
+++ b/ipld/blockstore/src/block.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use cid::multihash::{self, MultihashDigest};
 use cid::Cid;
 

--- a/ipld/blockstore/src/lib.rs
+++ b/ipld/blockstore/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::rc::Rc;
 
 use anyhow::Result;

--- a/ipld/blockstore/src/memory.rs
+++ b/ipld/blockstore/src/memory.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::cell::RefCell;
 use std::collections::HashMap;
 

--- a/ipld/blockstore/src/tracking.rs
+++ b/ipld/blockstore/src/tracking.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //#![cfg(feature = "tracking")]
 
 use std::cell::RefCell;

--- a/ipld/car/src/error.rs
+++ b/ipld/car/src/error.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/car/src/lib.rs
+++ b/ipld/car/src/lib.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/car/src/util.rs
+++ b/ipld/car/src/util.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/car/tests/car_file_test.rs
+++ b/ipld/car/tests/car_file_test.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/encoding/src/bytes.rs
+++ b/ipld/encoding/src/bytes.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems, David Tolnay (serde)
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/encoding/src/cbor.rs
+++ b/ipld/encoding/src/cbor.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/encoding/src/cbor_store.rs
+++ b/ipld/encoding/src/cbor_store.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use cid::{multihash, Cid};
 use fvm_ipld_blockstore::{Block, Blockstore};
 use serde::{de, ser};

--- a/ipld/encoding/src/errors.rs
+++ b/ipld/encoding/src/errors.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/encoding/src/lib.rs
+++ b/ipld/encoding/src/lib.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/encoding/src/vec.rs
+++ b/ipld/encoding/src/vec.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/hamt/benches/hamt_benchmark.rs
+++ b/ipld/hamt/benches/hamt_benchmark.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/hamt/fuzz/fuzz_targets/common.rs
+++ b/ipld/hamt/fuzz/fuzz_targets/common.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/hamt/fuzz/fuzz_targets/simple.rs
+++ b/ipld/hamt/fuzz/fuzz_targets/simple.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/hamt/src/bitfield.rs
+++ b/ipld/hamt/src/bitfield.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/hamt/src/error.rs
+++ b/ipld/hamt/src/error.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/hamt/src/hash_algorithm.rs
+++ b/ipld/hamt/src/hash_algorithm.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/hamt/src/hash_bits.rs
+++ b/ipld/hamt/src/hash_bits.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/hamt/src/lib.rs
+++ b/ipld/hamt/src/lib.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/scripts/add_license.sh
+++ b/scripts/add_license.sh
@@ -27,7 +27,7 @@ for file in $(git grep --cached -Il '' -- '*.rs'); do
 done
 
 # Look for changes that don't have the new copyright holder.
-for file in $(git diff --diff-filter=M --name-only master -- '*.rs'); do
+for file in $(git diff --diff-filter=d --name-only 5c13b82879c31c8a1e37e320b8a55fc736486e1a -- '*.rs'); do
   header=$(head -$LINES "$file")
 	if ! echo "$header" | grep -q -P "$PAT_PL"; then
 		echo "$file was missing Protocol Labs"

--- a/scripts/add_license.sh
+++ b/scripts/add_license.sh
@@ -27,7 +27,7 @@ for file in $(git grep --cached -Il '' -- '*.rs'); do
 done
 
 # Look for changes that don't have the new copyright holder.
-for file in $(git diff --diff-filter=d --name-only 5c13b82879c31c8a1e37e320b8a55fc736486e1a -- '*.rs'); do
+for file in $(git diff --diff-filter=d --name-only master -- '*.rs'); do
   header=$(head -$LINES "$file")
 	if ! echo "$header" | grep -q -P "$PAT_PL"; then
 		echo "$file was missing Protocol Labs"

--- a/scripts/add_license.sh
+++ b/scripts/add_license.sh
@@ -27,7 +27,7 @@ for file in $(git grep --cached -Il '' -- '*.rs'); do
 done
 
 # Look for changes that don't have the new copyright holder.
-for file in $(git diff --name-only master -- '*.rs'); do
+for file in $(git diff --diff-filter=M --name-only master -- '*.rs'); do
   header=$(head -$LINES "$file")
 	if ! echo "$header" | grep -q -P "$PAT_PL"; then
 		echo "$file was missing Protocol Labs"

--- a/scripts/add_license.sh
+++ b/scripts/add_license.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Checks if the source code contains required license and adds it if necessary.
+# Returns 1 if there was a missing license, 0 otherwise.
+COPYRIGHT_TXT=$(dirname $0)/copyright.txt
+
+# Any year is fine. We can update the year as a single PR in all files that have it up to last year.
+PAT_PL=".*// Copyright 2021-202\d Protocol Labs.*"
+# Files that were taken from ChainSafe and not modified can be left as-is.
+PAT_CS=".*// Copyright 2019-2022 ChainSafe Systems.*"
+PAT_SPDX="/*// SPDX-License-Identifier: Apache-2.0, MIT.*"
+
+# Look at enough lines so that we can include multiple copyright holders.
+LINES=4
+
+ret=0
+
+# Look for files without headers.
+for file in $(git grep --cached -Il '' -- '*.rs'); do
+  header=$(head -$LINES "$file")
+	if ! echo "$header" | grep -q -P "$PAT_SPDX"; then
+		echo "$file was missing header"
+		cat $COPYRIGHT_TXT "$file" > temp
+		mv temp "$file"
+		ret=1
+	fi
+done
+
+# Look for changes that don't have the new copyright holder.
+for file in $(git diff --name-only master -- '*.rs'); do
+  header=$(head -$LINES "$file")
+	if ! echo "$header" | grep -q -P "$PAT_PL"; then
+		echo "$file was missing Protocol Labs"
+		head -1 $COPYRIGHT_TXT > temp
+		cat "$file" >> temp
+		mv temp "$file"
+		ret=1
+	fi
+done
+
+exit $ret

--- a/scripts/copyright.txt
+++ b/scripts/copyright.txt
@@ -1,0 +1,2 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT

--- a/sdk/src/actor.rs
+++ b/sdk/src/actor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use core::option::Option;
 use std::ptr; // no_std
 

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
 use fvm_ipld_encoding::{to_vec, Cbor};
 use fvm_shared::address::Address;

--- a/sdk/src/debug.rs
+++ b/sdk/src/debug.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 pub use inner::*;
 
 #[cfg(not(feature = "debug"))]

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use thiserror::Error;
 
 #[derive(Copy, Clone, Debug, Error)]

--- a/sdk/src/event.rs
+++ b/sdk/src/event.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_shared::event::ActorEvent;
 
 use crate::{sys, SyscallResult};

--- a/sdk/src/gas.rs
+++ b/sdk/src/gas.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use crate::sys;
 
 /// Charge gas for the operation identified by name.

--- a/sdk/src/ipld.rs
+++ b/sdk/src/ipld.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
 use fvm_shared::MAX_CID_LEN;
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 pub mod actor;
 pub mod crypto;
 pub mod debug;

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::convert::TryInto;
 
 use fvm_ipld_encoding::DAG_CBOR;

--- a/sdk/src/network.rs
+++ b/sdk/src/network.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::convert::TryInto;
 
 use cid::Cid;

--- a/sdk/src/rand.rs
+++ b/sdk/src/rand.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
 

--- a/sdk/src/send.rs
+++ b/sdk/src/send.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::convert::TryInto;
 
 use fvm_ipld_encoding::{RawBytes, DAG_CBOR};

--- a/sdk/src/sself.rs
+++ b/sdk/src/sself.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;

--- a/sdk/src/sys/actor.rs
+++ b/sdk/src/sys/actor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for creating and resolving actors.
 
 // for documentation links

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for cryptographic operations.
 
 use fvm_shared::crypto::signature::SECP_PUB_LEN;

--- a/sdk/src/sys/debug.rs
+++ b/sdk/src/sys/debug.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for debugging.
 
 super::fvm_syscalls! {

--- a/sdk/src/sys/event.rs
+++ b/sdk/src/sys/event.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls related to eventing.
 
 // for documentation links

--- a/sdk/src/sys/gas.rs
+++ b/sdk/src/sys/gas.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for working with gas.
 
 // for documentation links

--- a/sdk/src/sys/ipld.rs
+++ b/sdk/src/sys/ipld.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for manipulating IPLD state.
 
 /// The ID of the "unit" block (or void for C programmers).

--- a/sdk/src/sys/mod.rs
+++ b/sdk/src/sys/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! This module defines the low-level syscall API.
 //!
 //! # Wasm Syscall ABI

--- a/sdk/src/sys/network.rs
+++ b/sdk/src/sys/network.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for network metadata.
 
 // for documentation links

--- a/sdk/src/sys/rand.rs
+++ b/sdk/src/sys/rand.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for getting randomness.
 
 use fvm_shared::randomness::RANDOMNESS_LENGTH;

--- a/sdk/src/sys/send.rs
+++ b/sdk/src/sys/send.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for sending messages to other actors.
 
 #[doc(inline)]

--- a/sdk/src/sys/sself.rs
+++ b/sdk/src/sys/sself.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for querying and modifying the current actor.
 
 // for documentation links

--- a/sdk/src/sys/vm.rs
+++ b/sdk/src/sys/vm.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for interacting with the VM.
 
 #[doc(inline)]

--- a/sdk/src/vm.rs
+++ b/sdk/src/vm.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::ptr;
 
 use fvm_ipld_encoding::{RawBytes, DAG_CBOR};

--- a/shared/src/address/errors.rs
+++ b/shared/src/address/errors.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/address/network.rs
+++ b/shared/src/address/network.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/address/payload.rs
+++ b/shared/src/address/payload.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/address/protocol.rs
+++ b/shared/src/address/protocol.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/bigint/bigint_ser.rs
+++ b/shared/src/bigint/bigint_ser.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/bigint/biguint_ser.rs
+++ b/shared/src/bigint/biguint_ser.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/bigint/mod.rs
+++ b/shared/src/bigint/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/clock/mod.rs
+++ b/shared/src/clock/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/clock/quantize.rs
+++ b/shared/src/clock/quantize.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/commcid/mod.rs
+++ b/shared/src/commcid/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/consensus/mod.rs
+++ b/shared/src/consensus/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use num_derive::FromPrimitive;
 
 use super::{Address, ChainEpoch};

--- a/shared/src/crypto/hash.rs
+++ b/shared/src/crypto/hash.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u64)]
 pub enum SupportedHashes {

--- a/shared/src/crypto/mod.rs
+++ b/shared/src/crypto/mod.rs
@@ -1,2 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 pub mod hash;
 pub mod signature;

--- a/shared/src/crypto/signature.rs
+++ b/shared/src/crypto/signature.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/deal/mod.rs
+++ b/shared/src/deal/mod.rs
@@ -1,1 +1,3 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 pub type DealID = u64;

--- a/shared/src/econ/mod.rs
+++ b/shared/src/econ/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::cmp::Ordering;
 use std::fmt;
 use std::iter::Sum;

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::fmt::Formatter;
 
 use num_derive::FromPrimitive;

--- a/shared/src/event/mod.rs
+++ b/shared/src/event/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use bitflags::bitflags;
 use fvm_ipld_encoding::{Cbor, RawBytes};
 use serde::{Deserialize, Serialize};

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/math.rs
+++ b/shared/src/math.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/message.rs
+++ b/shared/src/message.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/piece/mod.rs
+++ b/shared/src/piece/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/piece/zero.rs
+++ b/shared/src/piece/zero.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/randomness/mod.rs
+++ b/shared/src/randomness/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/receipt.rs
+++ b/shared/src/receipt.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/reward.rs
+++ b/shared/src/reward.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use serde_tuple::*;
 
 use crate::bigint::bigint_ser;

--- a/shared/src/sector/mod.rs
+++ b/shared/src/sector/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/sector/post.rs
+++ b/shared/src/sector/post.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/sector/registered_proof.rs
+++ b/shared/src/sector/registered_proof.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/sector/seal.rs
+++ b/shared/src/sector/seal.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/smooth/alpha_beta_filter.rs
+++ b/shared/src/smooth/alpha_beta_filter.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/smooth/mod.rs
+++ b/shared/src/smooth/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/smooth/smooth_func.rs
+++ b/shared/src/smooth/smooth_func.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/state/mod.rs
+++ b/shared/src/state/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/src/sys/mod.rs
+++ b/shared/src/sys/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! This module contains types exchanged at the syscall layer between actors
 //! (usually through the SDK) and the FVM.
 

--- a/shared/src/sys/out.rs
+++ b/shared/src/sys/out.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! This module contains syscall output data carrier structs, shared between
 //! the FVM SDK and the FVM itself, wrapping multi-value returns.
 //!

--- a/shared/src/version/mod.rs
+++ b/shared/src/version/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/tests/address_test.rs
+++ b/shared/tests/address_test.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/shared/tests/commcid_tests.rs
+++ b/shared/tests/commcid_tests.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/testing/common_fuzz/fuzz/examples/cbor_decode_gen.rs
+++ b/testing/common_fuzz/fuzz/examples/cbor_decode_gen.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::error::Error;
 use std::fs::File;
 use std::path::Path;

--- a/testing/common_fuzz/fuzz/fuzz_targets/cbor_decode.rs
+++ b/testing/common_fuzz/fuzz/fuzz_targets/cbor_decode.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #![no_main]
 
 use common_fuzz::cbor::Payload;

--- a/testing/common_fuzz/fuzz/fuzz_targets/cbor_encode.rs
+++ b/testing/common_fuzz/fuzz/fuzz_targets/cbor_encode.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #![no_main]
 
 use common_fuzz::cbor::Payload;

--- a/testing/common_fuzz/fuzz/fuzz_targets/rle_decode.rs
+++ b/testing/common_fuzz/fuzz/fuzz_targets/rle_decode.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #![no_main]
 use fvm_ipld_bitfield::BitField;
 use libfuzzer_sys::fuzz_target;

--- a/testing/common_fuzz/fuzz/fuzz_targets/rle_encode.rs
+++ b/testing/common_fuzz/fuzz/fuzz_targets/rle_encode.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #![no_main]
 use arbitrary::Arbitrary;
 use fvm_ipld_bitfield::BitField;

--- a/testing/common_fuzz/fuzz/fuzz_targets/rle_ops.rs
+++ b/testing/common_fuzz/fuzz/fuzz_targets/rle_ops.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/testing/common_fuzz/fuzz/src/cbor.rs
+++ b/testing/common_fuzz/fuzz/src/cbor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use arbitrary::Arbitrary;
 use cid::Cid;
 use fvm_ipld_bitfield::{BitField, UnvalidatedBitField};

--- a/testing/common_fuzz/fuzz/src/lib.rs
+++ b/testing/common_fuzz/fuzz/src/lib.rs
@@ -1,1 +1,3 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 pub mod cbor;

--- a/testing/common_fuzz/src/main.rs
+++ b/testing/common_fuzz/src/main.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 fn main() {
     println!("Hello, world!");
 }

--- a/testing/conformance/benches/bench_conformance.rs
+++ b/testing/conformance/benches/bench_conformance.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //#[macro_use]
 extern crate criterion;
 

--- a/testing/conformance/benches/bench_conformance_overhead.rs
+++ b/testing/conformance/benches/bench_conformance_overhead.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 extern crate criterion;
 use std::env::var;
 use std::path::Path;

--- a/testing/conformance/benches/bench_drivers.rs
+++ b/testing/conformance/benches/bench_drivers.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 extern crate criterion;
 
 use criterion::*;

--- a/testing/conformance/src/bin/perf-conformance.rs
+++ b/testing/conformance/src/bin/perf-conformance.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/testing/conformance/src/cidjson.rs
+++ b/testing/conformance/src/cidjson.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/testing/conformance/src/driver.rs
+++ b/testing/conformance/src/driver.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::fmt;
 
 use anyhow::{anyhow, Result};

--- a/testing/conformance/src/externs.rs
+++ b/testing/conformance/src/externs.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm::externs::{Chain, Consensus, Externs, Rand};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;

--- a/testing/conformance/src/lib.rs
+++ b/testing/conformance/src/lib.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/testing/conformance/src/rand.rs
+++ b/testing/conformance/src/rand.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/testing/conformance/src/vector.rs
+++ b/testing/conformance/src/vector.rs
@@ -1,3 +1,4 @@
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::sync::{Arc, Mutex};

--- a/testing/conformance/tests/runner.rs
+++ b/testing/conformance/tests/runner.rs
@@ -1,6 +1,7 @@
-#![cfg(ignore)]
+// Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
+#![cfg(ignore)]
 
 use std::collections::HashMap;
 use std::env::var;

--- a/testing/integration/examples/integration.rs
+++ b/testing/integration/examples/integration.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm::executor::{ApplyKind, Executor};
 use fvm_integration_tests::bundle;
 use fvm_integration_tests::dummy::DummyExterns;

--- a/testing/integration/src/builtin.rs
+++ b/testing/integration/src/builtin.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::{Context, Result};
 use cid::Cid;
 use fvm::machine::Manifest;

--- a/testing/integration/src/bundle.rs
+++ b/testing/integration/src/bundle.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::anyhow;
 use cid::Cid;
 use futures::executor::block_on;

--- a/testing/integration/src/dummy.rs
+++ b/testing/integration/src/dummy.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
 use fvm::externs::{Chain, Consensus, Externs, Rand};
 use fvm_ipld_encoding::DAG_CBOR;

--- a/testing/integration/src/error.rs
+++ b/testing/integration/src/error.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
 
 #[derive(thiserror::Error, Debug)]

--- a/testing/integration/src/lib.rs
+++ b/testing/integration/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 mod builtin;
 pub mod bundle;
 pub mod dummy;

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::{anyhow, Context, Result};
 use cid::Cid;
 use fvm::call_manager::DefaultCallManager;

--- a/testing/integration/tests/address_test.rs
+++ b/testing/integration/tests/address_test.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 mod bundles;
 use bundles::*;
 use fil_address_actor::WASM_BINARY as ADDRESS_BINARY;

--- a/testing/integration/tests/bundles/mod.rs
+++ b/testing/integration/tests/bundles/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::collections::BTreeMap;
 
 use anyhow::Context;

--- a/testing/integration/tests/embryo_sender_test.rs
+++ b/testing/integration/tests/embryo_sender_test.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 mod bundles;
 
 #[cfg(feature = "f4-as-account")]

--- a/testing/integration/tests/events_test.rs
+++ b/testing/integration/tests/events_test.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 mod bundles;
 use bundles::*;
 use fil_events_actor::WASM_BINARY as EVENTS_BINARY;

--- a/testing/integration/tests/fil-address-actor/build.rs
+++ b/testing/integration/tests/fil-address-actor/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 fn main() {
     use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()

--- a/testing/integration/tests/fil-address-actor/src/actor.rs
+++ b/testing/integration/tests/fil-address-actor/src/actor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_ipld_encoding::RawBytes;
 use fvm_sdk as sdk;
 use fvm_shared::address::{Address, SECP_PUB_LEN};

--- a/testing/integration/tests/fil-address-actor/src/lib.rs
+++ b/testing/integration/tests/fil-address-actor/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #[cfg(not(target_arch = "wasm32"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 

--- a/testing/integration/tests/fil-events-actor/build.rs
+++ b/testing/integration/tests/fil-events-actor/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 fn main() {
     use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()

--- a/testing/integration/tests/fil-events-actor/src/actor.rs
+++ b/testing/integration/tests/fil-events-actor/src/actor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_ipld_encoding::Cbor;
 use fvm_sdk as sdk;
 use fvm_shared::address::Address;

--- a/testing/integration/tests/fil-events-actor/src/lib.rs
+++ b/testing/integration/tests/fil-events-actor/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #[cfg(not(target_arch = "wasm32"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 

--- a/testing/integration/tests/fil-exit-data-actor/build.rs
+++ b/testing/integration/tests/fil-exit-data-actor/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 fn main() {
     use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()

--- a/testing/integration/tests/fil-exit-data-actor/src/lib.rs
+++ b/testing/integration/tests/fil-exit-data-actor/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #[cfg(not(target_arch = "wasm32"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 

--- a/testing/integration/tests/fil-gaslimit-actor/build.rs
+++ b/testing/integration/tests/fil-gaslimit-actor/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 fn main() {
     use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()

--- a/testing/integration/tests/fil-gaslimit-actor/src/actor.rs
+++ b/testing/integration/tests/fil-gaslimit-actor/src/actor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_sdk as sdk;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;

--- a/testing/integration/tests/fil-gaslimit-actor/src/lib.rs
+++ b/testing/integration/tests/fil-gaslimit-actor/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #[cfg(not(target_arch = "wasm32"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 

--- a/testing/integration/tests/fil-hello-world-actor/build.rs
+++ b/testing/integration/tests/fil-hello-world-actor/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 fn main() {
     use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()

--- a/testing/integration/tests/fil-hello-world-actor/src/lib.rs
+++ b/testing/integration/tests/fil-hello-world-actor/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #[cfg(not(target_arch = "wasm32"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 

--- a/testing/integration/tests/fil-integer-overflow-actor/build.rs
+++ b/testing/integration/tests/fil-integer-overflow-actor/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 fn main() {
     use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()

--- a/testing/integration/tests/fil-integer-overflow-actor/src/actor/blockstore.rs
+++ b/testing/integration/tests/fil-integer-overflow-actor/src/actor/blockstore.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::convert::TryFrom;
 
 use anyhow::{anyhow, Result};

--- a/testing/integration/tests/fil-integer-overflow-actor/src/actor/mod.rs
+++ b/testing/integration/tests/fil-integer-overflow-actor/src/actor/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_encoding::tuple::*;

--- a/testing/integration/tests/fil-integer-overflow-actor/src/lib.rs
+++ b/testing/integration/tests/fil-integer-overflow-actor/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #[cfg(not(target_arch = "wasm32"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 

--- a/testing/integration/tests/fil-ipld-actor/build.rs
+++ b/testing/integration/tests/fil-ipld-actor/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 fn main() {
     use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()

--- a/testing/integration/tests/fil-ipld-actor/src/actor.rs
+++ b/testing/integration/tests/fil-ipld-actor/src/actor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_ipld_encoding::{to_vec, BytesSer, DAG_CBOR};
 use fvm_sdk as sdk;
 use fvm_shared::error::ExitCode;

--- a/testing/integration/tests/fil-ipld-actor/src/lib.rs
+++ b/testing/integration/tests/fil-ipld-actor/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #[cfg(not(target_arch = "wasm32"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 

--- a/testing/integration/tests/fil-malformed-syscall-actor/build.rs
+++ b/testing/integration/tests/fil-malformed-syscall-actor/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 fn main() {
     use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()

--- a/testing/integration/tests/fil-malformed-syscall-actor/src/lib.rs
+++ b/testing/integration/tests/fil-malformed-syscall-actor/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #[cfg(not(target_arch = "wasm32"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 

--- a/testing/integration/tests/fil-readonly-actor/build.rs
+++ b/testing/integration/tests/fil-readonly-actor/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 fn main() {
     use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()

--- a/testing/integration/tests/fil-readonly-actor/src/lib.rs
+++ b/testing/integration/tests/fil-readonly-actor/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #[cfg(not(target_arch = "wasm32"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 

--- a/testing/integration/tests/fil-stack-overflow-actor/build.rs
+++ b/testing/integration/tests/fil-stack-overflow-actor/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 fn main() {
     use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()

--- a/testing/integration/tests/fil-stack-overflow-actor/src/actor.rs
+++ b/testing/integration/tests/fil-stack-overflow-actor/src/actor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_sdk as sdk;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;

--- a/testing/integration/tests/fil-stack-overflow-actor/src/lib.rs
+++ b/testing/integration/tests/fil-stack-overflow-actor/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #[cfg(not(target_arch = "wasm32"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 

--- a/testing/integration/tests/fil-syscall-actor/build.rs
+++ b/testing/integration/tests/fil-syscall-actor/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 fn main() {
     use substrate_wasm_builder::WasmBuilder;
     WasmBuilder::new()

--- a/testing/integration/tests/fil-syscall-actor/src/actor.rs
+++ b/testing/integration/tests/fil-syscall-actor/src/actor.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use actors_v10_runtime::runtime::builtins::Type;
 use fvm_sdk as sdk;
 use fvm_shared::address::{Address, SECP_PUB_LEN};

--- a/testing/integration/tests/fil-syscall-actor/src/lib.rs
+++ b/testing/integration/tests/fil-syscall-actor/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 #[cfg(not(target_arch = "wasm32"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 

--- a/testing/integration/tests/fil_integer_overflow.rs
+++ b/testing/integration/tests/fil_integer_overflow.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fil_integer_overflow_actor::WASM_BINARY as OVERFLOW_BINARY;
 use fvm::executor::{ApplyKind, Executor};
 use fvm_integration_tests::dummy::DummyExterns;

--- a/testing/integration/tests/fil_syscall.rs
+++ b/testing/integration/tests/fil_syscall.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fil_malformed_syscall_actor::WASM_BINARY as MALFORMED_ACTOR_BINARY;
 use fvm::call_manager::backtrace::Cause;
 use fvm::executor::{ApplyFailure, ApplyKind, Executor};

--- a/testing/integration/tests/gaslimit_test.rs
+++ b/testing/integration/tests/gaslimit_test.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use bundles::*;
 use fil_gaslimit_actor::WASM_BINARY as BINARY;
 use fvm::executor::{ApplyKind, Executor};

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;

--- a/testing/integration/tests/readonly_test.rs
+++ b/testing/integration/tests/readonly_test.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 mod bundles;
 use bundles::*;
 use fil_readonly_actor::WASM_BINARY;


### PR DESCRIPTION
Closes https://github.com/filecoin-project/ref-fvm/issues/1170

The PR adds a `add_license.sh` file similar to [Forest](https://github.com/ChainSafe/forest/tree/main/scripts) that can be invoked with `make license`, which is also called from CI. The script formats files where necessary and returns an error if it did so, which will stop CI, so we have to go back and commit these changes.

The script does two things:
1. It checks that each Rust code file has a license header. If not, it adds the copyright with _Protocol Labs_. 
2. It checks that every Rust file that changed compared to `master` has _Protocol Labs_ in the header, and adds it if not. At this point the common SPDX part should have already been added by 1), or present from when the file was originally copied from _ChainSafe Systems_. 

The effect should be that any file we modify will force us to add _Protocol Labs_. The ones we don't touch are kept as _ChainSafe_. 

I added _Protocol Labs_ to any file that changed since it has been taken in 5c13b82879c31c8a1e37e320b8a55fc736486e1a as a one-off step.