### PR TITLE
refactor: make send take all arguments

### DIFF
--- a/sdk/src/send.rs
+++ b/sdk/src/send.rs
@@ -9,7 +9,6 @@ use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::receipt::Receipt;
 use fvm_shared::sys::SendFlags;
 use fvm_shared::MethodNum;
-use num_traits::Zero;
 
 use crate::{sys, SyscallResult, NO_DATA_BLOCK_ID};
 
@@ -17,33 +16,6 @@ use crate::{sys, SyscallResult, NO_DATA_BLOCK_ID};
 // TODO: Drop the use of receipts here as we don't return the gas used. Alternatively, we _could_
 // return gas used?
 pub fn send(
-    to: &Address,
-    method: MethodNum,
-    params: RawBytes,
-    value: TokenAmount,
-    gas_limit: Option<u64>,
-) -> SyscallResult<Receipt> {
-    send_raw(to, method, params, value, gas_limit, SendFlags::default())
-}
-
-/// Sends a message to another actor in "read-only" mode. Value transfers, state mutations (`sself::set_root`, `sself::self_destruct`), and actor creation (explicit or implicit) will result in `IllegalOpreation` errors. Any events logged will be silently discarded.
-pub fn send_read_only(
-    to: &Address,
-    method: MethodNum,
-    params: RawBytes,
-    gas_limit: Option<u64>,
-) -> SyscallResult<Receipt> {
-    send_raw(
-        to,
-        method,
-        params,
-        TokenAmount::zero(),
-        gas_limit,
-        SendFlags::READ_ONLY,
-    )
-}
-
-fn send_raw(
     to: &Address,
     method: MethodNum,
     params: RawBytes,

--- a/testing/integration/tests/fil-address-actor/src/actor.rs
+++ b/testing/integration/tests/fil-address-actor/src/actor.rs
@@ -26,12 +26,17 @@ pub fn invoke(params: u32) -> u32 {
         2 => {
             // Create an account.
             let addr = Address::new_secp256k1(&[0; SECP_PUB_LEN]).unwrap();
-            assert!(
-                sdk::send::send(&addr, 0, RawBytes::default(), Zero::zero(), None)
-                    .unwrap()
-                    .exit_code
-                    .is_success()
-            );
+            assert!(sdk::send::send(
+                &addr,
+                0,
+                RawBytes::default(),
+                Zero::zero(),
+                None,
+                Default::default()
+            )
+            .unwrap()
+            .exit_code
+            .is_success());
 
             // Resolve the ID address of the account.
             let id = sdk::actor::resolve_address(&addr).expect("failed to find new account");
@@ -46,12 +51,17 @@ pub fn invoke(params: u32) -> u32 {
             // Create an embryo.
             let addr =
                 Address::new_delegated(0, b"foobar").expect("failed to construct f4 address");
-            assert!(
-                sdk::send::send(&addr, 0, RawBytes::default(), Zero::zero(), None)
-                    .unwrap()
-                    .exit_code
-                    .is_success()
-            );
+            assert!(sdk::send::send(
+                &addr,
+                0,
+                RawBytes::default(),
+                Zero::zero(),
+                None,
+                Default::default()
+            )
+            .unwrap()
+            .exit_code
+            .is_success());
 
             // Resolve the ID address of the embryo.
             let id = sdk::actor::resolve_address(&addr).expect("failed to find new embryo");
@@ -68,7 +78,14 @@ pub fn invoke(params: u32) -> u32 {
                 Address::new_delegated(999, b"foobar").expect("failed to construct f4 address");
             assert_eq!(
                 Err(ErrorNumber::NotFound),
-                sdk::send::send(&addr, 0, RawBytes::default(), Zero::zero(), None),
+                sdk::send::send(
+                    &addr,
+                    0,
+                    RawBytes::default(),
+                    Zero::zero(),
+                    None,
+                    Default::default()
+                ),
                 "expected send to unassignable f4 address to fail"
             );
         }

--- a/testing/integration/tests/fil-events-actor/src/actor.rs
+++ b/testing/integration/tests/fil-events-actor/src/actor.rs
@@ -99,8 +99,15 @@ pub fn invoke(params: u32) -> u32 {
 
             if counter > 0 {
                 let params = fvm_ipld_encoding::to_vec(&counter).expect("failed to serialize");
-                sdk::send::send(&our_addr, EMIT_SUBCALLS, params.into(), Zero::zero(), None)
-                    .unwrap();
+                sdk::send::send(
+                    &our_addr,
+                    EMIT_SUBCALLS,
+                    params.into(),
+                    Zero::zero(),
+                    None,
+                    Default::default(),
+                )
+                .unwrap();
             }
         }
         EMIT_SUBCALLS_REVERT => {
@@ -129,6 +136,7 @@ pub fn invoke(params: u32) -> u32 {
                     params.into(),
                     Zero::zero(),
                     None,
+                    Default::default(),
                 )
                 .ok();
             }

--- a/testing/integration/tests/fil-gaslimit-actor/src/actor.rs
+++ b/testing/integration/tests/fil-gaslimit-actor/src/actor.rs
@@ -39,7 +39,15 @@ pub fn invoke(params_id: u32) -> u32 {
         }
 
         // This send will never be committed if we exhaust gas.
-        sdk::send::send(&params.dest, 0, Default::default(), ten.clone(), None).unwrap();
+        sdk::send::send(
+            &params.dest,
+            0,
+            Default::default(),
+            ten.clone(),
+            None,
+            Default::default(),
+        )
+        .unwrap();
 
         // This event is also discarded if we exhaust gas.
         let single_entry_evt = {
@@ -64,7 +72,15 @@ pub fn invoke(params_id: u32) -> u32 {
     }
 
     // Send 10 to origin. This send is always persisted.
-    sdk::send::send(&params.dest, 0, Default::default(), fifty.clone(), None).unwrap();
+    sdk::send::send(
+        &params.dest,
+        0,
+        Default::default(),
+        fifty.clone(),
+        None,
+        Default::default(),
+    )
+    .unwrap();
 
     let gas_limit = if params.inner_gas_limit == 0 {
         None
@@ -74,7 +90,14 @@ pub fn invoke(params_id: u32) -> u32 {
 
     // send to self with the supplied gas_limit, propagating params.
     let (_, data) = sdk::message::params_raw(params_id).unwrap();
-    let ret = sdk::send::send(&self_addr, 2, data.into(), Zero::zero(), gas_limit);
+    let ret = sdk::send::send(
+        &self_addr,
+        2,
+        data.into(),
+        Zero::zero(),
+        gas_limit,
+        Default::default(),
+    );
 
     match ret {
         Ok(res) => {

--- a/testing/integration/tests/fil-readonly-actor/src/lib.rs
+++ b/testing/integration/tests/fil-readonly-actor/src/lib.rs
@@ -10,6 +10,7 @@ use fvm_sdk as sdk;
 use fvm_shared::address::{Address, SECP_PUB_LEN};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::event::{Entry, Flags};
+use fvm_shared::sys::SendFlags;
 use fvm_shared::METHOD_SEND;
 use sdk::error::{ActorDeleteError, StateUpdateError};
 use sdk::sys::ErrorNumber;
@@ -28,7 +29,14 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
         2 => {
             assert!(!sdk::vm::read_only());
             // Can't create actors when read-only.
-            let resp = sdk::send::send_read_only(&account, METHOD_SEND, RawBytes::default(), None);
+            let resp = sdk::send::send(
+                &account,
+                METHOD_SEND,
+                RawBytes::default(),
+                TokenAmount::default(),
+                None,
+                SendFlags::READ_ONLY,
+            );
             assert_eq!(resp, Err(ErrorNumber::ReadOnly));
 
             // But can still create them when not read-only.
@@ -38,17 +46,20 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
                 Default::default(),
                 Default::default(),
                 None,
+                Default::default(),
             )
             .unwrap()
             .exit_code
             .is_success());
 
             // Now recurse.
-            assert!(sdk::send::send_read_only(
+            assert!(sdk::send::send(
                 &Address::new_id(sdk::message::receiver()),
                 3,
                 Default::default(),
+                Default::default(),
                 None,
+                SendFlags::READ_ONLY,
             )
             .unwrap()
             .exit_code
@@ -65,16 +76,22 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
                 Default::default(),
                 TokenAmount::from_atto(1),
                 None,
+                Default::default(),
             );
             assert_eq!(resp, Err(ErrorNumber::ReadOnly));
 
             // Sending nothing succeeds.
-            assert!(
-                sdk::send::send(&account, 0, Default::default(), Default::default(), None)
-                    .unwrap()
-                    .exit_code
-                    .is_success()
-            );
+            assert!(sdk::send::send(
+                &account,
+                0,
+                Default::default(),
+                Default::default(),
+                None,
+                Default::default()
+            )
+            .unwrap()
+            .exit_code
+            .is_success());
 
             // Writing should succeed.
             let cid = sdk::ipld::put(0xb220, 32, 0x55, b"foo").unwrap();
@@ -96,6 +113,7 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
                 RawBytes::new("input".into()),
                 Default::default(),
                 None,
+                Default::default(),
             )
             .unwrap();
             assert!(output.exit_code.is_success());
@@ -108,16 +126,19 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
                 RawBytes::default(),
                 Default::default(),
                 None,
+                Default::default(),
             )
             .unwrap();
             assert_eq!(output.exit_code.value(), 42);
 
             // Should be able to recursivly send in read-only mode.
-            let output = sdk::send::send_read_only(
+            let output = sdk::send::send(
                 &Address::new_id(sdk::message::receiver()),
                 4,
                 RawBytes::new("input".into()),
+                Default::default(),
                 None,
+                SendFlags::READ_ONLY,
             )
             .unwrap();
             assert!(output.exit_code.is_success());

--- a/testing/integration/tests/fil-stack-overflow-actor/src/actor.rs
+++ b/testing/integration/tests/fil-stack-overflow-actor/src/actor.rs
@@ -63,6 +63,7 @@ pub fn do_send(m: u64) -> u32 {
         Vec::new().into(),
         TokenAmount::zero(),
         None,
+        Default::default(),
     );
     match r {
         Ok(rec) => match rec.exit_code {


### PR DESCRIPTION
Remove send_read_only. The goal was to avoid breaking changes, but we needed to break things anyways to thread the gas through.