### PR TITLE
feat: remove into in install_actor

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -861,7 +861,7 @@ where
             .machine()
             .engine()
             .preload(self.call_manager.blockstore(), &[code_id])
-            .map_err(|_| syscall_error!(IllegalArgument; "failed to load actor code").into())?;
+            .map_err(|_| syscall_error!(IllegalArgument; "failed to load actor code"))?;
 
         self.call_manager
             .charge_gas(self.call_manager.price_list().on_install_actor(size))?;


### PR DESCRIPTION
i dont known why, but in sdk,got error when build fvm dependency, but build   ref-fvm successfully
```
error[E0282]: type annotations needed
   --> /Users/lijunlong/.cargo/git/checkouts/ref-fvm-618db269bf84f1ac/8b4f157/fvm/src/kernel/default.rs:864:87
    |
864 |             .map_err(|_| syscall_error!(IllegalArgument; "failed to load actor code").into())?;
    |                                                                                       ^^^^
    |

error[E0283]: type annotations needed
   --> /Users/lijunlong/.cargo/git/checkouts/ref-fvm-618db269bf84f1ac/8b4f157/fvm/src/kernel/default.rs:864:87
    |
864 |             .map_err(|_| syscall_error!(IllegalArgument; "failed to load actor code").into())?;
    |                                                                                       ^^^^
    |
note: multiple `impl`s satisfying `kernel::error::ExecutionError: ~const From<_>` found
   --> /Users/lijunlong/.cargo/git/checkouts/ref-fvm-618db269bf84f1ac/8b4f157/fvm/src/kernel/blocks.rs:95:1
    |
95  | impl From<BlockPutError> for ExecutionError {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
111 | impl From<InvalidHandleError> for ExecutionError {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: /Users/lijunlong/.cargo/git/checkouts/ref-fvm-618db269bf84f1ac/8b4f157/fvm/src/kernel/error.rs:71:1
    |
71  | impl From<SyscallError> for ExecutionError {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: and another `impl` found in the `core` crate: `impl<T> From<T> for T;`
    = note: required because of the requirements on the impl of `FromResidual<std::result::Result<Infallible, _>>` for `std::result::Result<(), kernel::error::ExecutionError>`


```

and when i remove `into`, both ref-fvm and sdk build happy, could someone tell me why into fail when build my sdk?
