### PR TITLE
refactor: extract the engine from the machine and make it a pool

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -1,6 +1,7 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use std::mem;
+use std::rc::Rc;
 
 use anyhow::{anyhow, Context};
 use cid::Cid;
@@ -17,10 +18,11 @@ use num_traits::Zero;
 use super::{Backtrace, CallManager, InvocationResult, NO_DATA_BLOCK_ID};
 use crate::call_manager::backtrace::Frame;
 use crate::call_manager::FinishRet;
+use crate::engine::Engine;
 use crate::gas::{Gas, GasTracker};
 use crate::kernel::{Block, BlockRegistry, ExecutionError, Kernel, Result, SyscallError};
 use crate::machine::limiter::ExecMemory;
-use crate::machine::{Engine, Machine};
+use crate::machine::Machine;
 use crate::state_tree::ActorState;
 use crate::syscalls::error::Abort;
 use crate::syscalls::{charge_for_exec, update_gas_available};
@@ -38,6 +40,8 @@ pub struct InnerDefaultCallManager<M: Machine> {
     #[deref]
     #[deref_mut]
     machine: M,
+    /// The engine with which to execute the message.
+    engine: Rc<Engine>,
     /// The gas tracker.
     gas_tracker: GasTracker,
     /// The gas premium paid by this message.
@@ -89,6 +93,7 @@ where
 
     fn new(
         machine: M,
+        engine: Engine,
         gas_limit: i64,
         origin: ActorID,
         origin_address: Address,
@@ -100,6 +105,7 @@ where
             GasTracker::new(Gas::new(gas_limit), Gas::zero(), machine.context().tracing);
 
         DefaultCallManager(Some(Box::new(InnerDefaultCallManager {
+            engine: Rc::new(engine),
             machine,
             gas_tracker,
             gas_premium,
@@ -499,15 +505,11 @@ where
         // Increment invocation count
         self.invocation_count += 1;
 
-        // This is a cheap operation as it doesn't actually clone the struct,
-        // it returns a referenced copy.
-        let engine: Engine = self.engine().clone();
-
         // Ensure that actor's code is loaded and cached in the engine.
         // NOTE: this does not cover the EVM smart contract actor, which is a built-in actor, is
         // listed the manifest, and therefore preloaded during system initialization.
         #[cfg(feature = "m2-native")]
-        self.engine()
+        self.engine
             .prepare_actor_code(&state.code, self.blockstore())
             .map_err(
                 |_| syscall_error!(NotFound; "actor code cid does not exist {}", &state.code),
@@ -515,6 +517,8 @@ where
 
         log::trace!("calling {} -> {}::{}", from, to, method);
         self.map_mut(|cm| {
+            let engine = cm.engine.clone(); // reference the RC.
+
             // Make the kernel.
             let kernel = K::new(cm, block_registry, from, to, method, value.clone());
 

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -6,6 +6,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::{ActorID, MethodNum};
 
+use crate::engine::Engine;
 use crate::gas::{Gas, GasCharge, GasTracker, PriceList};
 use crate::kernel::{self, Result};
 use crate::machine::{Machine, MachineContext};
@@ -47,6 +48,7 @@ pub trait CallManager: 'static {
     /// Construct a new call manager.
     fn new(
         machine: Self::Machine,
+        engine: Engine,
         gas_limit: i64,
         origin: ActorID,
         origin_address: Address,

--- a/fvm/src/engine.rs
+++ b/fvm/src/engine.rs
@@ -4,7 +4,7 @@ use std::any::{Any, TypeId};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
 use std::ops::Deref;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 
 use anyhow::{anyhow, Context};
 use cid::Cid;
@@ -17,20 +17,17 @@ use wasmtime::{
     Module, Mutability, PoolingAllocationStrategy, Val, ValType,
 };
 
-use super::limiter::ExecMemory;
-use super::Machine;
 use crate::gas::WasmGasPrices;
-use crate::machine::NetworkConfig;
+use crate::machine::limiter::ExecMemory;
+use crate::machine::{Machine, NetworkConfig};
 use crate::syscalls::{bind_syscalls, charge_for_init, InvocationData};
 use crate::Kernel;
 
-/// A caching wasmtime engine.
-#[derive(Clone)]
-pub struct Engine(Arc<EngineInner>);
-
 /// Container managing engines with different consensus-affecting configurations.
-#[derive(Clone)]
-pub struct MultiEngine(Arc<Mutex<HashMap<EngineConfig, Engine>>>);
+pub struct MultiEngine {
+    engines: Mutex<HashMap<EngineConfig, EnginePool>>,
+    concurrency: u32,
+}
 
 /// The proper way of getting this struct is to convert from `NetworkConfig`
 #[derive(Clone, Eq, PartialEq, Hash)]
@@ -38,6 +35,7 @@ pub struct EngineConfig {
     pub max_call_depth: u32,
     pub max_wasm_stack: u32,
     pub max_inst_memory_bytes: u64,
+    pub concurrency: u32,
     pub wasm_prices: &'static WasmGasPrices,
     pub actor_redirect: Vec<(Cid, Cid)>,
 }
@@ -50,40 +48,48 @@ impl From<&NetworkConfig> for EngineConfig {
             max_inst_memory_bytes: nc.max_inst_memory_bytes,
             wasm_prices: &nc.price_list.wasm_rules,
             actor_redirect: nc.actor_redirect.clone(),
+            concurrency: 1,
         }
     }
 }
 
 impl MultiEngine {
-    pub fn new() -> MultiEngine {
-        MultiEngine(Arc::new(Mutex::new(HashMap::new())))
+    pub fn new(concurrency: u32) -> MultiEngine {
+        if concurrency == 0 {
+            panic!("concurrency must be positive");
+        }
+        MultiEngine {
+            engines: Mutex::new(HashMap::new()),
+            concurrency,
+        }
     }
 
-    pub fn get(&self, nc: &NetworkConfig) -> anyhow::Result<Engine> {
+    pub fn get(&self, nc: &NetworkConfig) -> anyhow::Result<EnginePool> {
         let mut engines = self
-            .0
+            .engines
             .lock()
             .map_err(|_| anyhow::Error::msg("multiengine lock is poisoned"))?;
 
-        let ec: EngineConfig = nc.into();
+        let mut ec: EngineConfig = nc.into();
+        ec.concurrency = self.concurrency;
 
-        let engine = match engines.entry(ec.clone()) {
+        let pool = match engines.entry(ec.clone()) {
             Occupied(entry) => entry.into_mut(),
-            Vacant(entry) => entry.insert(Engine::new_default(ec)?),
+            Vacant(entry) => entry.insert(EnginePool::new_default(ec)?),
         };
 
-        Ok(engine.clone())
+        Ok(pool.clone())
     }
 }
 
 impl Default for MultiEngine {
     fn default() -> Self {
-        Self::new()
+        Self::new(1)
     }
 }
 
 fn wasmtime_config(ec: &EngineConfig) -> anyhow::Result<wasmtime::Config> {
-    let instance_count = 1 + ec.max_call_depth;
+    let instance_count = (1 + ec.max_call_depth) * ec.concurrency;
     let instance_memory_maximum_size = ec.max_inst_memory_bytes;
     if instance_memory_maximum_size % wasmtime_environ::WASM_PAGE_SIZE as u64 != 0 {
         return Err(anyhow!(
@@ -191,6 +197,9 @@ struct ModuleRecord {
 }
 
 struct EngineInner {
+    limit: Mutex<u32>,
+    condv: Condvar,
+
     engine: wasmtime::Engine,
 
     /// These two fields are used used in the store constructor to avoid resolve a chicken & egg
@@ -208,17 +217,40 @@ struct EngineInner {
     actor_redirect: HashMap<Cid, Cid>,
 }
 
-impl Deref for Engine {
-    type Target = wasmtime::Engine;
+/// EnginePool represents a limited pool of engines.
+#[derive(Clone)]
+pub struct EnginePool(Arc<EngineInner>);
 
-    fn deref(&self) -> &Self::Target {
-        &self.0.engine
+impl EnginePool {
+    /// Acquire an [`Engine`]. This method will block until an [`Engine`] is available, and will
+    /// release the engine on drop.
+    pub fn acquire(&self) -> Engine {
+        *self
+            .0
+            .condv
+            .wait_while(self.0.limit.lock().unwrap(), |limit| *limit == 0)
+            .unwrap() -= 1;
+        Engine(self.0.clone())
     }
-}
 
-impl Engine {
+    /// Try to acquire an [`Engine`]. Returns `None` if the call would block, or if the lock is
+    /// poisoned.
+    ///
+    /// The [`Engine`] is released on drop.
+    pub fn try_acquire(&self) -> Option<Engine> {
+        self.0
+            .limit
+            .try_lock()
+            .ok()
+            .filter(|limit| **limit > 0)
+            .map(|mut limit| {
+                *limit -= 1;
+                Engine(self.0.clone())
+            })
+    }
+
     pub fn new_default(ec: EngineConfig) -> anyhow::Result<Self> {
-        Engine::new(&wasmtime_config(&ec)?, ec)
+        EnginePool::new(&wasmtime_config(&ec)?, ec)
     }
 
     /// Create a new Engine from a wasmtime config.
@@ -235,7 +267,9 @@ impl Engine {
 
         let actor_redirect = ec.actor_redirect.iter().cloned().collect();
 
-        Ok(Engine(Arc::new(EngineInner {
+        Ok(EnginePool(Arc::new(EngineInner {
+            limit: Mutex::new(ec.concurrency),
+            condv: Condvar::new(),
             engine,
             dummy_memory,
             dummy_gas_global: dummy_gg,
@@ -249,6 +283,28 @@ impl Engine {
 
 struct Cache<K> {
     linker: wasmtime::Linker<InvocationData<K>>,
+}
+
+/// An `Engine` represents a single, caching wasm engine. It should not be shared between concurrent
+/// call stacks.
+///
+/// The `Engine` will be returned to the [`EnginePool`] on drop.
+pub struct Engine(Arc<EngineInner>);
+
+impl Deref for Engine {
+    type Target = wasmtime::Engine;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0.engine
+    }
+}
+
+impl Drop for Engine {
+    fn drop(&mut self) {
+        let mut limit = self.0.limit.lock().unwrap();
+        *limit += 1;
+        self.0.condv.notify_one();
+    }
 }
 
 impl Engine {

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -12,6 +12,7 @@ pub use kernel::default::DefaultKernel;
 pub use kernel::Kernel;
 
 pub mod call_manager;
+pub mod engine;
 pub mod executor;
 pub mod externs;
 pub mod kernel;
@@ -61,8 +62,9 @@ mod test {
     use multihash::{Code, Multihash};
 
     use crate::call_manager::DefaultCallManager;
+    use crate::engine::EnginePool;
     use crate::externs::{Chain, Consensus, Externs, Rand};
-    use crate::machine::{DefaultMachine, Engine, Manifest, NetworkConfig};
+    use crate::machine::{DefaultMachine, Manifest, NetworkConfig};
     use crate::state_tree::StateTree;
     use crate::{executor, DefaultKernel};
 
@@ -133,15 +135,11 @@ mod test {
             .override_actors(actors_cid)
             .for_epoch(0, 0, root);
 
-        let machine = DefaultMachine::new(
-            &Engine::new_default((&mc.network).into()).unwrap(),
-            &mc,
-            bs,
-            DummyExterns,
-        )
-        .unwrap();
-        let _ = executor::DefaultExecutor::<DefaultKernel<DefaultCallManager<_>>>::new(Box::new(
-            machine,
-        ));
+        let machine = DefaultMachine::new(&mc, bs, DummyExterns).unwrap();
+        let engine = EnginePool::new_default((&mc.network).into()).unwrap();
+        let _ = executor::DefaultExecutor::<DefaultKernel<DefaultCallManager<_>>>::new(
+            engine,
+            Box::new(machine),
+        );
     }
 }

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -6,7 +6,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::event::StampedEvent;
 use fvm_shared::ActorID;
 
-use super::{Engine, Machine, MachineContext, Manifest};
+use super::{Machine, MachineContext, Manifest};
 use crate::kernel::Result;
 use crate::state_tree::{ActorState, StateTree};
 
@@ -16,11 +16,6 @@ impl<M: Machine> Machine for Box<M> {
     type Blockstore = M::Blockstore;
     type Externs = M::Externs;
     type Limiter = M::Limiter;
-
-    #[inline(always)]
-    fn engine(&self) -> &Engine {
-        (**self).engine()
-    }
 
     #[inline(always)]
     fn blockstore(&self) -> &Self::Blockstore {

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -23,12 +23,8 @@ pub use default::DefaultMachine;
 pub mod limiter;
 mod manifest;
 
-pub use manifest::Manifest;
-
-mod engine;
-
-pub use engine::{Engine, EngineConfig, MultiEngine};
 use fvm_shared::event::StampedEvent;
+pub use manifest::Manifest;
 
 use self::limiter::ExecMemory;
 
@@ -76,10 +72,6 @@ pub trait Machine: 'static {
     type Blockstore: Blockstore;
     type Externs: Externs;
     type Limiter: ResourceLimiter + ExecMemory;
-
-    /// Returns the underlying WASM engine. Cloning it will simply create a new handle with a
-    /// static lifetime.
-    fn engine(&self) -> &Engine;
 
     /// Returns a reference to the machine's blockstore.
     fn blockstore(&self) -> &Self::Blockstore;

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -7,10 +7,11 @@ use std::rc::Rc;
 use anyhow::Context;
 use cid::Cid;
 use fvm::call_manager::{Backtrace, CallManager, FinishRet, InvocationResult};
+use fvm::engine::Engine;
 use fvm::externs::{Chain, Consensus, Externs, Rand};
 use fvm::gas::{Gas, GasCharge, GasTracker};
 use fvm::machine::limiter::ExecMemory;
-use fvm::machine::{Engine, Machine, MachineContext, Manifest, NetworkConfig};
+use fvm::machine::{Machine, MachineContext, Manifest, NetworkConfig};
 use fvm::state_tree::{ActorState, StateTree};
 use fvm::{kernel, Kernel};
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
@@ -108,7 +109,6 @@ impl ExecMemory for DummyLimiter {
 
 /// Minimal *pseudo-functional* implementation of `Machine` for tests
 pub struct DummyMachine {
-    pub engine: Engine,
     pub state_tree: StateTree<MemoryBlockstore>,
     pub ctx: MachineContext,
     pub builtin_actors: Manifest,
@@ -146,7 +146,6 @@ impl DummyMachine {
 
         Ok(Self {
             ctx,
-            engine: Engine::new_default((&config).into())?,
             state_tree,
             builtin_actors: manifest,
         })
@@ -157,10 +156,6 @@ impl Machine for DummyMachine {
     type Blockstore = MemoryBlockstore;
     type Externs = DummyExterns;
     type Limiter = DummyLimiter;
-
-    fn engine(&self) -> &Engine {
-        &self.engine
-    }
 
     fn blockstore(&self) -> &Self::Blockstore {
         self.state_tree.store()
@@ -284,6 +279,7 @@ impl CallManager for DummyCallManager {
 
     fn new(
         machine: Self::Machine,
+        _engine: Engine,
         _gas_limit: i64,
         origin: ActorID,
         origin_address: Address,

--- a/testing/conformance/benches/bench_conformance.rs
+++ b/testing/conformance/benches/bench_conformance.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use colored::Colorize;
 use criterion::*;
-use fvm::machine::MultiEngine;
+use fvm::engine::MultiEngine;
 use fvm_conformance_tests::driver::*;
 use fvm_conformance_tests::report;
 use fvm_conformance_tests::vector::MessageVector;

--- a/testing/conformance/benches/bench_conformance_overhead.rs
+++ b/testing/conformance/benches/bench_conformance_overhead.rs
@@ -6,7 +6,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use criterion::*;
-use fvm::machine::{MultiEngine, BURNT_FUNDS_ACTOR_ID};
+use fvm::engine::MultiEngine;
+use fvm::machine::BURNT_FUNDS_ACTOR_ID;
 use fvm_conformance_tests::driver::*;
 use fvm_conformance_tests::vector::{ApplyMessage, MessageVector};
 use fvm_ipld_encoding::{Cbor, RawBytes};


### PR DESCRIPTION
Now that we're using the pooling allocator in wasmtime, we have to be careful about sharing a single engine between multiple concurrent message executions. Otherwise, we could run out of wasm "instances" and fail execution (e.g., if the user is validating two blocks in parallel).

To handle this, I've:

1. Turned the engine into an "engine pool" where we allocate `concurrency * call_depth` instances.
2. Put the EnginePool inside the Executor.
3. Put the Engine itself inside the CallManager.

That way, we "acquire" an Engine every time we handle a new message, and release the engine when we're done.

Unfortunately, putting the engine on the _machine_ didn't really make sense anymore, because the engine's lifetime is tied to a specific call and returned to the pool afterwards.

We could have acquired the engine for the lifetime of the _Machine_, but I was concerned about deadlocks.