### PR TITLE
feat: add charging for all memory copy/init operations

### DIFF
--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -293,8 +293,8 @@ lazy_static! {
             exec_instruction_cost: Gas::new(4),
             memory_fill_per_byte_cost: Zero::zero(),
             memory_copy_per_byte_cost: Zero::zero(),
-            memory_fill_base_cost: Gas::new(4),
-            memory_copy_base_cost: Gas::new(4),
+            memory_fill_base_cost: Gas::zero(),
+            memory_copy_base_cost: Gas::zero(),
         },
 
         event_emit_base_cost: Zero::zero(),
@@ -439,9 +439,9 @@ lazy_static! {
             // TODO GAS_PARAM
             memory_copy_per_byte_cost: Zero::zero(),
             // TODO GAS_PARAM
-            memory_fill_base_cost: Gas::new(4), // matches one instruction for now
+            memory_fill_base_cost: Gas::zero(),
             // TODO GAS_PARAM
-            memory_copy_base_cost: Gas::new(4), // matches one instruction for now
+            memory_copy_base_cost: Gas::zero(),
         },
 
         // END (Copied from SKYR_PRICES)
@@ -1095,28 +1095,28 @@ impl Rules for WasmGasPrices {
             | Operator::End => Ok(InstructionCost::Fixed(0)),
             // Memory related instructions...
             Operator::TableInit { .. } | Operator::TableCopy { .. } => linear_cost(
-                self.memory_copy_base_cost,
+                self.exec_instruction_cost + self.memory_copy_base_cost,
                 self.memory_copy_per_byte_cost,
                 TABLE_ELEMENT_SIZE,
             ),
             Operator::TableFill { .. } | Operator::TableGrow { .. } => linear_cost(
-                self.memory_fill_base_cost,
+                self.exec_instruction_cost + self.memory_fill_base_cost,
                 self.memory_fill_per_byte_cost,
                 TABLE_ELEMENT_SIZE,
             ),
             Operator::MemoryGrow { .. } => linear_cost(
-                self.memory_fill_base_cost,
+                self.exec_instruction_cost + self.memory_fill_base_cost,
                 self.memory_fill_per_byte_cost,
                 // This is the odd-one out because it operates on entire pages.
                 wasmtime_environ::WASM_PAGE_SIZE,
             ),
             Operator::MemoryFill { .. } => linear_cost(
-                self.memory_fill_base_cost,
+                self.exec_instruction_cost + self.memory_fill_base_cost,
                 self.memory_fill_per_byte_cost,
                 1,
             ),
             Operator::MemoryInit { .. } | Operator::MemoryCopy { .. } => linear_cost(
-                self.memory_copy_base_cost,
+                self.exec_instruction_cost + self.memory_copy_base_cost,
                 self.memory_copy_per_byte_cost,
                 1,
             ),

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -22,6 +22,10 @@ use num_traits::Zero;
 use super::GasCharge;
 use crate::gas::Gas;
 
+// Each element reserves a `usize` in the table, so we charge 8 bytes per pointer.
+// https://docs.rs/wasmtime/2.0.2/wasmtime/struct.InstanceLimits.html#structfield.table_elements
+const TABLE_ELEMENT_SIZE: u32 = 8;
+
 lazy_static! {
     static ref OH_SNAP_PRICES: PriceList = PriceList {
         storage_gas_multiplier: 1300,
@@ -146,7 +150,10 @@ lazy_static! {
 
         wasm_rules: WasmGasPrices{
             exec_instruction_cost: Zero::zero(),
-            memory_expansion_per_byte_cost: Zero::zero(),
+            memory_fill_per_byte_cost: Zero::zero(),
+            memory_copy_per_byte_cost: Zero::zero(),
+            memory_fill_base_cost: Zero::zero(),
+            memory_copy_base_cost: Zero::zero(),
         },
 
         event_emit_base_cost: Zero::zero(),
@@ -284,7 +291,10 @@ lazy_static! {
 
         wasm_rules: WasmGasPrices{
             exec_instruction_cost: Gas::new(4),
-            memory_expansion_per_byte_cost: Zero::zero(),
+            memory_fill_per_byte_cost: Zero::zero(),
+            memory_copy_per_byte_cost: Zero::zero(),
+            memory_fill_base_cost: Gas::new(4),
+            memory_copy_base_cost: Gas::new(4),
         },
 
         event_emit_base_cost: Zero::zero(),
@@ -424,7 +434,14 @@ lazy_static! {
 
         wasm_rules: WasmGasPrices{
             exec_instruction_cost: Gas::new(4),
-            memory_expansion_per_byte_cost: Zero::zero(),
+            // TODO GAS_PARAM
+            memory_fill_per_byte_cost: Zero::zero(),
+            // TODO GAS_PARAM
+            memory_copy_per_byte_cost: Zero::zero(),
+            // TODO GAS_PARAM
+            memory_fill_base_cost: Gas::new(4), // matches one instruction for now
+            // TODO GAS_PARAM
+            memory_copy_base_cost: Gas::new(4), // matches one instruction for now
         },
 
         // END (Copied from SKYR_PRICES)
@@ -618,8 +635,14 @@ pub struct PriceList {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct WasmGasPrices {
     pub(crate) exec_instruction_cost: Gas,
-    /// Gas cost for every byte made writeable in Wasm memory.
-    pub(crate) memory_expansion_per_byte_cost: Gas,
+    /// Gas cost for any memory fill instruction (one time charge).
+    pub(crate) memory_fill_base_cost: Gas,
+    /// Gas cost for every byte "filled" in Wasm memory.
+    pub(crate) memory_fill_per_byte_cost: Gas,
+    /// Gas cost for any memory copy instruction (one time charge).
+    pub(crate) memory_copy_base_cost: Gas,
+    /// Gas cost for every byte copied in Wasm memory.
+    pub(crate) memory_copy_per_byte_cost: Gas,
 }
 
 impl PriceList {
@@ -981,19 +1004,20 @@ impl PriceList {
 
     /// Returns the gas required for initializing memory.
     pub fn init_memory_gas(&self, min_memory_bytes: usize) -> Gas {
-        self.wasm_rules.memory_expansion_per_byte_cost * min_memory_bytes
+        self.wasm_rules.memory_fill_base_cost
+            + self.wasm_rules.memory_fill_per_byte_cost * min_memory_bytes
     }
 
     /// Returns the gas required for growing memory.
     pub fn grow_memory_gas(&self, grow_memory_bytes: usize) -> Gas {
-        self.wasm_rules.memory_expansion_per_byte_cost * grow_memory_bytes
+        self.wasm_rules.memory_fill_base_cost
+            + self.wasm_rules.memory_fill_per_byte_cost * grow_memory_bytes
     }
 
     /// Returns the gas required for initializing tables.
     pub fn init_table_gas(&self, min_table_elements: u32) -> Gas {
-        // Each element reserves a `usize` in the table, so we charge 8 bytes per pointer.
-        // https://docs.rs/wasmtime/2.0.2/wasmtime/struct.InstanceLimits.html#structfield.table_elements
-        self.wasm_rules.memory_expansion_per_byte_cost * min_table_elements * 8
+        self.wasm_rules.memory_fill_base_cost
+            + self.wasm_rules.memory_fill_per_byte_cost * min_table_elements * TABLE_ELEMENT_SIZE
     }
 
     #[inline]
@@ -1033,6 +1057,28 @@ impl Rules for WasmGasPrices {
             return Ok(InstructionCost::Fixed(0));
         }
 
+        fn linear_cost(
+            base: Gas,
+            linear: Gas,
+            unit_multiplier: u32,
+        ) -> anyhow::Result<InstructionCost> {
+            let base = base
+                .as_milligas()
+                .try_into()
+                .context("base gas exceeds u32")?;
+            let gas_per_unit = linear * unit_multiplier;
+            let expansion_cost: u32 = gas_per_unit
+                .as_milligas()
+                .try_into()
+                .context("linear gas exceeds u32")?;
+            match expansion_cost
+                .try_into().ok() // zero or not zero.
+            {
+                Some(expansion_cost) => Ok(InstructionCost::Linear(base, expansion_cost)),
+                None => Ok(InstructionCost::Fixed(base)),
+            }
+        }
+
         // Rules valid for nv16. We will need to be generic over Rules (massive
         // generics tax), use &dyn Rules (which breaks other things), or pass
         // in the network version, or rules version, to vary these prices going
@@ -1047,22 +1093,34 @@ impl Rules for WasmGasPrices {
             | Operator::Return
             | Operator::Else
             | Operator::End => Ok(InstructionCost::Fixed(0)),
-            Operator::MemoryGrow { .. } => Ok({
-                // Saturating. If there's an overflow, we'll catch it later.
-                let gas_per_page =
-                    self.memory_expansion_per_byte_cost * wasmtime_environ::WASM_PAGE_SIZE;
-
-                let expansion_cost: u32 = gas_per_page
-                    .as_milligas()
-                    .try_into()
-                    .context("memory expansion cost exceeds u32")?;
-                match expansion_cost
-                    .try_into().ok() // zero or not zero.
-                {
-                    Some(cost) => InstructionCost::Linear(self.exec_instruction_cost.as_milligas() as u64, cost),
-                    None => InstructionCost::Fixed(self.exec_instruction_cost.as_milligas() as u64),
-                }
-            }),
+            // Memory related instructions...
+            Operator::TableInit { .. } | Operator::TableCopy { .. } => linear_cost(
+                self.memory_copy_base_cost,
+                self.memory_copy_per_byte_cost,
+                TABLE_ELEMENT_SIZE,
+            ),
+            Operator::TableFill { .. } | Operator::TableGrow { .. } => linear_cost(
+                self.memory_fill_base_cost,
+                self.memory_fill_per_byte_cost,
+                TABLE_ELEMENT_SIZE,
+            ),
+            Operator::MemoryGrow { .. } => linear_cost(
+                self.memory_fill_base_cost,
+                self.memory_fill_per_byte_cost,
+                // This is the odd-one out because it operates on entire pages.
+                wasmtime_environ::WASM_PAGE_SIZE,
+            ),
+            Operator::MemoryFill { .. } => linear_cost(
+                self.memory_fill_base_cost,
+                self.memory_fill_per_byte_cost,
+                1,
+            ),
+            Operator::MemoryInit { .. } | Operator::MemoryCopy { .. } => linear_cost(
+                self.memory_copy_base_cost,
+                self.memory_copy_per_byte_cost,
+                1,
+            ),
+            // Everything else...
             _ => Ok(InstructionCost::Fixed(
                 self.exec_instruction_cost.as_milligas() as u64,
             )),


### PR DESCRIPTION
I'm not actually charging anything right now, but this lets us charge for:

1. Memory copying.
2. Memory "filling" (where I'm treating all memory expansion as "filling").

fixes #1075