### PR TITLE
FVM: Move ChainID to shared

### DIFF
--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -19,6 +19,7 @@ use crate::state_tree::{ActorState, StateTree};
 mod default;
 
 pub use default::DefaultMachine;
+use fvm_shared::chainid::ChainID;
 
 pub mod limiter;
 mod manifest;
@@ -34,28 +35,6 @@ pub const REWARD_ACTOR_ID: ActorID = 2;
 
 /// Distinguished Account actor that is the destination of all burnt funds.
 pub const BURNT_FUNDS_ACTOR_ID: ActorID = 99;
-
-#[derive(Clone, Copy, Debug)]
-pub struct ChainID(u64);
-
-impl ChainID {
-    pub const ZERO: Self = Self(0);
-    pub const WALLABY: Self = Self(31415);
-    pub const CALIBRATION: Self = Self(314159);
-    pub const CATERPILLER_BUTTERFLY: Self = Self(3141592);
-}
-
-impl From<u64> for ChainID {
-    fn from(src: u64) -> Self {
-        Self(src)
-    }
-}
-
-impl From<ChainID> for u64 {
-    fn from(src: ChainID) -> Self {
-        src.0
-    }
-}
 
 /// The Machine is the top-level object of the FVM.
 ///
@@ -175,7 +154,7 @@ impl NetworkConfig {
     /// Create a new network config for the given network version.
     pub fn new(network_version: NetworkVersion) -> Self {
         NetworkConfig {
-            chain_id: ChainID::ZERO,
+            chain_id: ChainID::from(0u64),
             network_version,
             max_call_depth: 1024,
             max_wasm_stack: 2048,

--- a/sdk/src/network.rs
+++ b/sdk/src/network.rs
@@ -3,6 +3,7 @@
 use std::convert::TryInto;
 
 use cid::Cid;
+use fvm_shared::chainid::ChainID;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
@@ -21,8 +22,8 @@ lazy_static::lazy_static! {
     };
 }
 
-pub fn chain_id() -> u64 {
-    NETWORK_CONTEXT.chain_id
+pub fn chain_id() -> ChainID {
+    NETWORK_CONTEXT.chain_id.into()
 }
 
 pub fn curr_epoch() -> ChainEpoch {

--- a/shared/src/chainid/mod.rs
+++ b/shared/src/chainid/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ChainID(u64);
+
+impl From<u64> for ChainID {
+    fn from(src: u64) -> Self {
+        Self(src)
+    }
+}
+
+impl From<ChainID> for u64 {
+    fn from(src: ChainID) -> Self {
+        src.0
+    }
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -10,6 +10,7 @@ use clock::ChainEpoch;
 
 pub mod address;
 pub mod bigint;
+pub mod chainid;
 pub mod clock;
 pub mod commcid;
 pub mod consensus;

--- a/testing/integration/tests/fil-syscall-actor/src/actor.rs
+++ b/testing/integration/tests/fil-syscall-actor/src/actor.rs
@@ -3,6 +3,7 @@
 use actors_v10_runtime::runtime::builtins::Type;
 use fvm_sdk as sdk;
 use fvm_shared::address::{Address, SECP_PUB_LEN};
+use fvm_shared::chainid::ChainID;
 use fvm_shared::crypto::hash::SupportedHashes as SharedSupportedHashes;
 use fvm_shared::error::ExitCode;
 use multihash::derive::Multihash;
@@ -219,7 +220,7 @@ fn test_hash_syscall() {
 fn test_network_context() {
     use fvm_shared::econ::TokenAmount;
     use fvm_shared::version::NetworkVersion;
-    assert_eq!(sdk::network::chain_id(), 1); // hehe we are ETH now
+    assert_eq!(sdk::network::chain_id(), ChainID::from(1)); // hehe we are ETH now
     assert_eq!(sdk::network::curr_epoch(), 0);
     assert_eq!(sdk::network::version(), NetworkVersion::V18);
     assert_eq!(sdk::network::tipset_timestamp(), 0);

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -12,7 +12,6 @@ use fil_ipld_actor::WASM_BINARY as IPLD_BINARY;
 use fil_stack_overflow_actor::WASM_BINARY as OVERFLOW_BINARY;
 use fil_syscall_actor::WASM_BINARY as SYSCALL_BINARY;
 use fvm::executor::{ApplyKind, Executor, ThreadedExecutor};
-use fvm::machine::ChainID;
 use fvm_integration_tests::dummy::DummyExterns;
 use fvm_integration_tests::tester::{Account, IntegrationExecutor};
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
@@ -28,6 +27,7 @@ use num_traits::Zero;
 
 mod bundles;
 use bundles::*;
+use fvm_shared::chainid::ChainID;
 
 /// The state object.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug, Default)]


### PR DESCRIPTION
#1230 
#1231 

This can't be in FVM if we want built-in actors to actually reference the type (which it doesn't _have_ to, but IMO it should).