### PR TITLE
feat: explicit gas charges for different instruction types

### DIFF
--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -148,12 +148,18 @@ lazy_static! {
         syscall_cost: Zero::zero(),
         extern_cost: Zero::zero(),
 
-        wasm_rules: WasmGasPrices{
-            exec_instruction_cost: Zero::zero(),
-            memory_fill_per_byte_cost: Zero::zero(),
+        wasm_rules: WasmGasPrices {
+            instruction_default:  Zero::zero(),
+            math_default:  Zero::zero(),
+            math_sqrt:  Zero::zero(),
+            jump_unconditional:  Zero::zero(),
+            jump_conditional:  Zero::zero(),
+            jump_indirect:  Zero::zero(),
+            call:  Zero::zero(),
+            memory_fill_base_cost:  Zero::zero(),
+            memory_fill_per_byte_cost:  Zero::zero(),
+            memory_access_cost:  Zero::zero(),
             memory_copy_per_byte_cost: Zero::zero(),
-            memory_fill_base_cost: Zero::zero(),
-            memory_copy_base_cost: Zero::zero(),
         },
 
         event_emit_base_cost: Zero::zero(),
@@ -290,11 +296,17 @@ lazy_static! {
         extern_cost: Gas::new(21000),
 
         wasm_rules: WasmGasPrices{
-            exec_instruction_cost: Gas::new(4),
+            instruction_default: Gas::new(4),
+            math_default: Gas::new(4),
+            math_sqrt: Gas::new(4),
+            jump_unconditional: Gas::new(4),
+            jump_conditional: Gas::new(4),
+            jump_indirect: Gas::new(4),
+            call: Zero::zero(), // In skyr, we didn't charge for more than the jump.
+            memory_fill_base_cost: Zero::zero(),
             memory_fill_per_byte_cost: Zero::zero(),
+            memory_access_cost: Zero::zero(),
             memory_copy_per_byte_cost: Zero::zero(),
-            memory_fill_base_cost: Gas::zero(),
-            memory_copy_base_cost: Gas::zero(),
         },
 
         event_emit_base_cost: Zero::zero(),
@@ -433,18 +445,18 @@ lazy_static! {
         extern_cost: Gas::new(21000),
 
         wasm_rules: WasmGasPrices{
-            exec_instruction_cost: Gas::new(4),
-            // TODO GAS_PARAM
+            instruction_default: Gas::new(4),
+            math_default: Gas::new(4),
+            math_sqrt: Gas::new(4),
+            jump_unconditional: Gas::new(4),
+            jump_conditional: Gas::new(4),
+            jump_indirect: Gas::new(4),
+            call: Zero::zero(), // In skyr, we didn't charge for more than the jump.
+            memory_fill_base_cost: Zero::zero(),
             memory_fill_per_byte_cost: Zero::zero(),
-            // TODO GAS_PARAM
+            memory_access_cost: Zero::zero(),
             memory_copy_per_byte_cost: Zero::zero(),
-            // TODO GAS_PARAM
-            memory_fill_base_cost: Gas::zero(),
-            // TODO GAS_PARAM
-            memory_copy_base_cost: Gas::zero(),
         },
-
-        // END (Copied from SKYR_PRICES)
 
         // TODO GAS_PARAM
         event_emit_base_cost: Zero::zero(),
@@ -634,13 +646,27 @@ pub struct PriceList {
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct WasmGasPrices {
-    pub(crate) exec_instruction_cost: Gas,
+    /// The default gas cost for instructions.
+    pub(crate) instruction_default: Gas,
+    /// The default gas cost for math instructions.
+    pub(crate) math_default: Gas,
+    /// The gas cost for sqrt.
+    pub(crate) math_sqrt: Gas,
+    /// The gas cost for unconditional jumps.
+    pub(crate) jump_unconditional: Gas,
+    /// The gas cost for conditional jumps.
+    pub(crate) jump_conditional: Gas,
+    /// The gas cost for indirect jumps.
+    pub(crate) jump_indirect: Gas,
+    /// The gas cost for calls (not including the jump cost).
+    pub(crate) call: Gas,
+
     /// Gas cost for any memory fill instruction (one time charge).
     pub(crate) memory_fill_base_cost: Gas,
     /// Gas cost for every byte "filled" in Wasm memory.
     pub(crate) memory_fill_per_byte_cost: Gas,
     /// Gas cost for any memory copy instruction (one time charge).
-    pub(crate) memory_copy_base_cost: Gas,
+    pub(crate) memory_access_cost: Gas,
     /// Gas cost for every byte copied in Wasm memory.
     pub(crate) memory_copy_per_byte_cost: Gas,
 }
@@ -1053,9 +1079,7 @@ pub fn price_list_by_network_version(network_version: NetworkVersion) -> &'stati
 
 impl Rules for WasmGasPrices {
     fn instruction_cost(&self, instruction: &Operator) -> anyhow::Result<InstructionCost> {
-        if self.exec_instruction_cost.is_zero() {
-            return Ok(InstructionCost::Fixed(0));
-        }
+        use InstructionCost::*;
 
         fn linear_cost(
             base: Gas,
@@ -1074,8 +1098,35 @@ impl Rules for WasmGasPrices {
             match expansion_cost
                 .try_into().ok() // zero or not zero.
             {
-                Some(expansion_cost) => Ok(InstructionCost::Linear(base, expansion_cost)),
-                None => Ok(InstructionCost::Fixed(base)),
+                Some(expansion_cost) => Ok(Linear(base, expansion_cost)),
+                None => Ok(Fixed(base)),
+            }
+        }
+
+        macro_rules! charge_inst {
+            (unsupported($message:expr)) => {
+                Err(anyhow::anyhow!($message))
+            };
+            (free()) => {
+                Ok(Fixed(0))
+            };
+            (fixed($e:expr)) => {
+                Ok(Fixed(($e).as_milligas() as u64))
+            };
+            (linear($base:expr,$linear:expr, $multiplier:expr)) => {
+                linear_cost($base, $linear, $multiplier)
+            };
+        }
+
+        macro_rules! charge_table {
+            ($($($op:ident),+$(,)? => $kind:ident ($($args:expr),*$(,)?),)*) => {
+                match instruction {
+                    $(
+                        $(| Operator::$op { .. })+ => {
+                            charge_inst!($kind($($args),*))
+                        },
+                    )*
+                }
             }
         }
 
@@ -1083,47 +1134,241 @@ impl Rules for WasmGasPrices {
         // generics tax), use &dyn Rules (which breaks other things), or pass
         // in the network version, or rules version, to vary these prices going
         // forward.
-        match instruction {
-            // FIP-0032: nop, drop, block, loop, unreachable, return, else, end are priced 0.
-            Operator::Nop
-            | Operator::Drop
-            | Operator::Block { .. }
-            | Operator::Loop { .. }
-            | Operator::Unreachable
-            | Operator::Return
-            | Operator::Else
-            | Operator::End => Ok(InstructionCost::Fixed(0)),
-            // Memory related instructions...
-            Operator::TableInit { .. } | Operator::TableCopy { .. } => linear_cost(
-                self.exec_instruction_cost + self.memory_copy_base_cost,
+        charge_table! {
+            /******************/
+            /*  Control Flow  */
+            /******************/
+
+            // FIP-0032: nop, block, loop, unreachable, return, else, end are priced 0.
+            Nop, Block, Loop, Unreachable, Return, Else, End => free(),
+
+            Br       => fixed(self.jump_unconditional),
+            BrIf, If => fixed(self.jump_conditional),
+            BrTable  => fixed(self.jump_indirect + self.memory_access_cost),
+
+            // TODO M2.2: Charge to jump back, and charge for arguments.
+            Call          => fixed(self.jump_unconditional + self.call),
+            CallIndirect  => fixed(self.jump_indirect + self.memory_access_cost + self.call),
+
+            /**********************/
+            /*  Stack & Registers */
+            /**********************/
+
+            // Constants, stack ops, etc.
+            Drop,                                   // FIP-0032
+            I64ExtendI32U,                          // only unsigned is free.
+            I32WrapI64,                             // truncates
+            I32ReinterpretF32, I64ReinterpretF64,   // casts
+            F32ReinterpretI32, F64ReinterpretI64,   // casts other way
+            I32Const, I64Const, F32Const, F64Const, // inline constants
+            => free(),
+
+            // Locals (TODO M2.2). Free because these are register references.
+            LocalGet, LocalSet, LocalTee => free(),
+
+            // Globals (TODO M2.2). Free because these are register references.
+            GlobalGet, GlobalSet         => free(),
+
+            // Select.
+            Select, TypedSelect          => fixed(self.instruction_default),
+
+            /*********/
+            /*  Math */
+            /*********/
+
+            // Sign extension
+            I32Extend8S, I32Extend16S,
+            I64Extend8S, I64Extend16S, I64Extend32S, I64ExtendI32S,
+            => fixed(self.math_default),
+
+            // Bitwise
+            I32And, I32Or, I32Xor, I32Shl, I32ShrS, I32ShrU, I32Rotl, I32Rotr,
+            I64And, I64Or, I64Xor, I64Shl, I64ShrS, I64ShrU, I64Rotl, I64Rotr,
+            => fixed(self.math_default),
+
+            // Comparison
+            I32Eqz, I32Eq, I32Ne, I32LtS, I32LtU, I32GtS, I32GtU, I32LeS, I32LeU, I32GeS, I32GeU,
+            I64Eqz, I64Eq, I64Ne, I64LtS, I64LtU, I64GtS, I64GtU, I64LeS, I64LeU, I64GeS, I64GeU,
+            => fixed(self.math_default),
+
+            // Math
+            I32Clz, I32Ctz, I32Popcnt, I32Add, I32Sub, I32Mul, I32DivS, I32DivU, I32RemS, I32RemU,
+            I64Clz, I64Ctz, I64Popcnt, I64Add, I64Sub, I64Mul, I64DivS, I64DivU, I64RemS, I64RemU,
+            => fixed(self.math_default),
+
+            // Floating point.
+            I32TruncF32S, I32TruncF32U, I32TruncF64S, I32TruncF64U,
+            I64TruncF32S, I64TruncF32U, I64TruncF64S, I64TruncF64U,
+            I32TruncSatF32S, I32TruncSatF32U, I32TruncSatF64S, I32TruncSatF64U,
+            I64TruncSatF32S, I64TruncSatF32U, I64TruncSatF64S, I64TruncSatF64U,
+            F32Eq, F32Ne, F32Lt, F32Gt, F32Le, F32Ge,
+            F64Eq, F64Ne, F64Lt, F64Gt, F64Le, F64Ge,
+            F32Abs, F32Neg, F32Ceil, F32Floor, F32Trunc, F32Nearest, F32Add, F32Sub, F32Mul, F32Div, F32Min, F32Max,
+            F64Abs, F64Neg, F64Ceil, F64Floor, F64Trunc, F64Nearest, F64Add, F64Sub, F64Mul, F64Div, F64Min, F64Max,
+            F64Copysign, F32Copysign, F32DemoteF64, F64PromoteF32,
+            F32ConvertI32S, F32ConvertI32U, F32ConvertI64S, F32ConvertI64U,
+            F64ConvertI32S, F64ConvertI32U, F64ConvertI64S, F64ConvertI64U,
+            => fixed(self.math_default),
+
+            // Sqrt.
+            F32Sqrt, F64Sqrt => fixed(self.math_sqrt),
+
+            /************/
+            /*  Memory  */
+            /************/
+
+            // Loading just costs a random access. We don't charge a base instruction cost, because
+            // loads are just dependencies of future instructions.
+            F32Load, I32Load, I32Load8U, I32Load16U,
+            F64Load, I64Load, I64Load8U, I64Load16U, I64Load32U,
+            TableGet,
+            => fixed(self.memory_access_cost),
+
+            // However, sign extending loads _do_ cost an instruction.
+            I32Load16S,
+            I32Load8S,
+            I64Load8S,
+            I64Load16S,
+            I64Load32S,
+            => fixed(self.memory_access_cost + self.instruction_default),
+
+            // Stores cost an instruction and a base fill fee.
+            F32Store, I32Store, I32Store8, I32Store16,
+            F64Store, I64Store, I64Store8, I64Store16, I64Store32,
+            TableSet,
+            => fixed(self.memory_fill_base_cost + self.instruction_default),
+
+            // Bulk memory copies & fills
+            TableInit, TableCopy => linear(
+                self.instruction_default + self.memory_access_cost,
                 self.memory_copy_per_byte_cost,
                 TABLE_ELEMENT_SIZE,
             ),
-            Operator::TableFill { .. } | Operator::TableGrow { .. } => linear_cost(
-                self.exec_instruction_cost + self.memory_fill_base_cost,
+            TableFill, TableGrow => linear(
+                self.instruction_default + self.memory_fill_base_cost,
                 self.memory_fill_per_byte_cost,
                 TABLE_ELEMENT_SIZE,
             ),
-            Operator::MemoryGrow { .. } => linear_cost(
-                self.exec_instruction_cost + self.memory_fill_base_cost,
+            MemoryGrow => linear(
+                self.instruction_default + self.memory_fill_base_cost,
                 self.memory_fill_per_byte_cost,
                 // This is the odd-one out because it operates on entire pages.
                 wasmtime_environ::WASM_PAGE_SIZE,
             ),
-            Operator::MemoryFill { .. } => linear_cost(
-                self.exec_instruction_cost + self.memory_fill_base_cost,
+            MemoryFill => linear(
+                self.instruction_default + self.memory_fill_base_cost,
                 self.memory_fill_per_byte_cost,
                 1,
             ),
-            Operator::MemoryInit { .. } | Operator::MemoryCopy { .. } => linear_cost(
-                self.exec_instruction_cost + self.memory_copy_base_cost,
+            MemoryInit, MemoryCopy => linear(
+                self.instruction_default + self.memory_access_cost,
                 self.memory_copy_per_byte_cost,
                 1,
             ),
-            // Everything else...
-            _ => Ok(InstructionCost::Fixed(
-                self.exec_instruction_cost.as_milligas() as u64,
-            )),
+
+            // Dropping is an optimization hint, and doesn't cost anything.
+            DataDrop, ElemDrop => free(),
+
+            // Charge one instruction for getting a table/memory size.
+            MemorySize, TableSize => fixed(self.instruction_default),
+
+            /******************/
+            /*  Unsupported   */
+            /******************/
+
+            // Exception handling.
+
+            Try, Catch, Throw, Rethrow, CatchAll, Delegate,
+
+            // Tail calls.
+            ReturnCall, ReturnCallIndirect,
+
+            // Reference ops
+
+            RefNull, RefIsNull, RefFunc,
+
+            // All atomic operations
+
+            MemoryAtomicNotify, MemoryAtomicWait32, MemoryAtomicWait64, AtomicFence,
+            I32AtomicLoad, I32AtomicLoad8U, I32AtomicLoad16U,
+            I64AtomicLoad, I64AtomicLoad8U, I64AtomicLoad16U, I64AtomicLoad32U,
+            I32AtomicStore, I32AtomicStore8, I32AtomicStore16,
+            I64AtomicStore, I64AtomicStore8, I64AtomicStore16, I64AtomicStore32,
+            I32AtomicRmwAdd, I32AtomicRmw8AddU, I32AtomicRmw16AddU,
+            I64AtomicRmwAdd, I64AtomicRmw8AddU, I64AtomicRmw16AddU, I64AtomicRmw32AddU,
+            I32AtomicRmwSub, I32AtomicRmw8SubU, I32AtomicRmw16SubU,
+            I64AtomicRmwSub, I64AtomicRmw8SubU, I64AtomicRmw16SubU, I64AtomicRmw32SubU,
+            I32AtomicRmwAnd, I32AtomicRmw8AndU, I32AtomicRmw16AndU,
+            I64AtomicRmwAnd, I64AtomicRmw8AndU, I64AtomicRmw16AndU, I64AtomicRmw32AndU,
+            I32AtomicRmwOr, I32AtomicRmw8OrU, I32AtomicRmw16OrU,
+            I64AtomicRmwOr, I64AtomicRmw8OrU, I64AtomicRmw16OrU, I64AtomicRmw32OrU,
+            I32AtomicRmwXor, I32AtomicRmw8XorU, I32AtomicRmw16XorU,
+            I64AtomicRmwXor, I64AtomicRmw8XorU, I64AtomicRmw16XorU, I64AtomicRmw32XorU,
+            I32AtomicRmwXchg, I32AtomicRmw8XchgU, I32AtomicRmw16XchgU,
+            I64AtomicRmwXchg, I64AtomicRmw8XchgU, I64AtomicRmw16XchgU, I64AtomicRmw32XchgU,
+            I32AtomicRmwCmpxchg, I32AtomicRmw8CmpxchgU, I32AtomicRmw16CmpxchgU,
+            I64AtomicRmwCmpxchg, I64AtomicRmw8CmpxchgU, I64AtomicRmw16CmpxchgU, I64AtomicRmw32CmpxchgU,
+
+            // All SIMD operations.
+
+            V128Load, V128Store, V128Const,
+            V128Load8x8S, V128Load16x4S, V128Load32x2S,
+            V128Load8x8U, V128Load16x4U, V128Load32x2U,
+            V128Load8Splat, V128Load16Splat, V128Load32Splat, V128Load64Splat,
+            V128Load32Zero, V128Load64Zero,
+            V128Load8Lane, V128Load16Lane, V128Load32Lane, V128Load64Lane,
+            V128Store8Lane, V128Store16Lane, V128Store32Lane, V128Store64Lane,
+            I8x16Shuffle,
+            I8x16ReplaceLane, I8x16ExtractLaneS, I16x8ExtractLaneS,
+            I16x8ReplaceLane, I8x16ExtractLaneU, I16x8ExtractLaneU,
+            I32x4ExtractLane, I64x2ExtractLane, F32x4ExtractLane, F64x2ExtractLane,
+            I32x4ReplaceLane, I64x2ReplaceLane, F32x4ReplaceLane, F64x2ReplaceLane,
+            I8x16Swizzle, I8x16RelaxedSwizzle,
+            I8x16Splat, I16x8Splat, I32x4Splat, I64x2Splat, F32x4Splat, F64x2Splat,
+            I8x16Eq, I8x16Ne, I8x16LtS, I8x16LtU, I8x16GtS, I8x16GtU, I8x16LeS, I8x16LeU, I8x16GeS, I8x16GeU,
+            I16x8Eq, I16x8Ne, I16x8LtS, I16x8LtU, I16x8GtS, I16x8GtU, I16x8LeS, I16x8LeU, I16x8GeS, I16x8GeU,
+            I32x4Eq, I32x4Ne, I32x4LtS, I32x4LtU, I32x4GtS, I32x4GtU, I32x4LeS, I32x4LeU, I32x4GeS, I32x4GeU,
+            I64x2Eq, I64x2Ne, I64x2LtS, I64x2GtS, I64x2LeS, I64x2GeS,
+            F32x4Eq, F32x4Ne, F32x4Lt, F32x4Gt,
+            F32x4Le, F32x4Ge, F64x2Eq, F64x2Ne, F64x2Lt, F64x2Gt, F64x2Le, F64x2Ge,
+            V128Not, V128And, V128AndNot, V128Or, V128Xor, V128Bitselect, V128AnyTrue,
+            I8x16Abs, I8x16Neg, I8x16Popcnt, I8x16AllTrue, I8x16Bitmask, I8x16NarrowI16x8S,
+            I8x16NarrowI16x8U, I8x16Shl, I8x16ShrS, I8x16ShrU, I8x16Add, I8x16AddSatS, I8x16AddSatU,
+            I8x16Sub, I8x16SubSatS, I8x16SubSatU, I8x16MinS, I8x16MinU, I8x16MaxS, I8x16MaxU, I8x16AvgrU,
+            I16x8ExtAddPairwiseI8x16S, I16x8ExtAddPairwiseI8x16U, I16x8Abs, I16x8Neg, I16x8Q15MulrSatS,
+            I16x8AllTrue, I16x8Bitmask, I16x8NarrowI32x4S, I16x8NarrowI32x4U, I16x8ExtendLowI8x16S,
+            I16x8ExtendHighI8x16S, I16x8ExtendLowI8x16U, I16x8ExtendHighI8x16U, I16x8Shl, I16x8ShrS,
+            I16x8ShrU, I16x8Add, I16x8AddSatS, I16x8AddSatU, I16x8Sub, I16x8SubSatS, I16x8SubSatU,
+            I16x8Mul, I16x8MinS, I16x8MinU, I16x8MaxS, I16x8MaxU, I16x8AvgrU, I16x8ExtMulLowI8x16S,
+            I16x8ExtMulHighI8x16S, I16x8ExtMulLowI8x16U, I16x8ExtMulHighI8x16U,
+            I32x4ExtAddPairwiseI16x8S, I32x4ExtAddPairwiseI16x8U, I32x4Abs, I32x4Neg, I32x4AllTrue,
+            I32x4Bitmask, I32x4ExtendLowI16x8S, I32x4ExtendHighI16x8S, I32x4ExtendLowI16x8U,
+            I32x4ExtendHighI16x8U, I32x4Shl, I32x4ShrS, I32x4ShrU, I32x4Add, I32x4Sub, I32x4Mul,
+            I32x4MinS, I32x4MinU, I32x4MaxS, I32x4MaxU, I32x4DotI16x8S, I32x4ExtMulLowI16x8S,
+            I32x4ExtMulHighI16x8S, I32x4ExtMulLowI16x8U, I32x4ExtMulHighI16x8U,
+            I64x2Abs, I64x2Neg, I64x2AllTrue, I64x2Bitmask, I64x2ExtendLowI32x4S,
+            I64x2ExtendHighI32x4S, I64x2ExtendLowI32x4U, I64x2ExtendHighI32x4U, I64x2Shl,
+            I64x2ShrS, I64x2ShrU, I64x2Add, I64x2Sub, I64x2Mul, I64x2ExtMulLowI32x4S,
+            I64x2ExtMulHighI32x4S, I64x2ExtMulLowI32x4U, I64x2ExtMulHighI32x4U,
+            F32x4Ceil, F32x4Floor, F32x4Trunc, F32x4Nearest, F32x4Abs, F32x4Neg, F32x4Sqrt,
+            F32x4Add, F32x4Sub, F32x4Mul, F32x4Div, F32x4Min, F32x4Max, F32x4PMin, F32x4PMax,
+            F64x2Ceil, F64x2Floor, F64x2Trunc, F64x2Nearest, F64x2Abs, F64x2Neg, F64x2Sqrt,
+            F64x2Add, F64x2Sub, F64x2Mul, F64x2Div, F64x2Min, F64x2Max, F64x2PMin, F64x2PMax,
+            I32x4TruncSatF32x4S, I32x4TruncSatF32x4U,
+            F32x4ConvertI32x4S, F32x4ConvertI32x4U,
+            I32x4TruncSatF64x2SZero, I32x4TruncSatF64x2UZero,
+            F64x2ConvertLowI32x4S, F64x2ConvertLowI32x4U,
+            F32x4DemoteF64x2Zero, F64x2PromoteLowF32x4,
+            I32x4RelaxedTruncSatF32x4S, I32x4RelaxedTruncSatF64x2SZero,
+            I32x4RelaxedTruncSatF32x4U, I32x4RelaxedTruncSatF64x2UZero,
+            F32x4RelaxedFma, F64x2RelaxedFma,
+            F32x4RelaxedFnma, F64x2RelaxedFnma,
+            I8x16RelaxedLaneselect, I16x8RelaxedLaneselect, I32x4RelaxedLaneselect, I64x2RelaxedLaneselect,
+            F32x4RelaxedMin, F32x4RelaxedMax, F64x2RelaxedMin, F64x2RelaxedMax,
+            I16x8RelaxedQ15mulrS,
+            I16x8DotI8x16I7x16S, I32x4DotI8x16I7x16AddS,
+            F32x4RelaxedDotBf16x8AddF32x4,
+            => unsupported("unsupported operation"),
         }
     }
 


### PR DESCRIPTION
We now explicitly charge for individual instructions, and reject unsupported ones.

Unlike #1249, this patch leaves the actual _charges_ the same, it just puts the framework in place so we can get reduce the diff and decide on values later.