### PR TITLE
Release SDK 2.1.0, ipld_encoding 0.2.3

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -23,7 +23,7 @@ fvm_shared = { version = "2.0.0", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.5.1", path = "../ipld/hamt"}
 fvm_ipld_amt = { version = "0.4.2", path = "../ipld/amt"}
 fvm_ipld_blockstore = { version = "0.1.1", path = "../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.2.2", path = "../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.2.3", path = "../ipld/encoding" }
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = "0.5"
 serde_repr = "0.1"

--- a/ipld/encoding/CHANGELOG.md
+++ b/ipld/encoding/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 Changes to the FVM's shared encoding utilities.
 
-## [Unreleased]
+## 0.2.3 [2022-12-12]
 
 Publicly use `serde` to expose it when developing actors.
+Add new `IpldBlock` type that supports both `DAG_CBOR` and `IPLD_RAW` codecs
 
 ## 0.2.2 [2022-06-13]
 

--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_encoding"
 description = "Sharded IPLD encoding."
-version = "0.2.2"
+version = "0.2.3"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0 [2022-12-12]
+
+Refactor: `send` and `message` use `Option<IpldBlock>` for params
+
 ## 2.0.0 [2022-10-12]
 
 No change.

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "2.0.0"
+version = "2.1.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -14,7 +14,7 @@ fvm_ipld_hamt = { version = "0.5.1", path = "../../ipld/hamt"}
 fvm_ipld_amt = { version = "0.4.2", path = "../../ipld/amt"}
 fvm_ipld_car = { version = "0.5.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.2.2", path = "../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.2.3", path = "../../ipld/encoding" }
 
 anyhow = "1.0.47"
 thiserror = "1.0.30"

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -14,7 +14,7 @@ fvm_ipld_hamt = { version = "0.5.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.4.2", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.5.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.2.2", path = "../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.2.3", path = "../../ipld/encoding" }
 
 anyhow = "1.0.47"
 cid = { version = "0.8.5", default-features = false }

--- a/testing/integration/tests/fil-hello-world-actor/Cargo.toml
+++ b/testing/integration/tests/fil-hello-world-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-fvm_sdk = { version = "2.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "2.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "2.0.0", path = "../../../../shared" }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-fvm_sdk = { version = "2.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "2.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "2.0.0", path = "../../../../shared" }
-fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.2.3", path = "../../../../ipld/encoding" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../../../ipld/blockstore" }
 
 anyhow = "1.0.57"

--- a/testing/integration/tests/fil-ipld-actor/Cargo.toml
+++ b/testing/integration/tests/fil-ipld-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "2.0.0", path = "../../../../sdk" }
+fvm_ipld_encoding = { version = "0.2.3", path = "../../../../ipld/encoding" }
+fvm_sdk = { version = "2.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "2.0.0", path = "../../../../shared" }
 
 [target.'cfg(coverage)'.dependencies]

--- a/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-fvm_sdk = { version = "2.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "2.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "2.0.0", path = "../../../../shared" }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-fvm_sdk = { version = "2.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "2.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "2.0.0", path = "../../../../shared" }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-syscall-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-fvm_ipld_encoding = { version = "0.2.2", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "2.0.0", path = "../../../../sdk" }
+fvm_ipld_encoding = { version = "0.2.3", path = "../../../../ipld/encoding" }
+fvm_sdk = { version = "2.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "2.0.0", path = "../../../../shared" }
 minicov = {version = "0.2", optional = true}
 multihash = "0.16.3"


### PR DESCRIPTION
@Stebalien / reviewer: please confirm that ipld_encoding can be a patch release (only _adding_ a type), while SDK is a minor release.