### PR TITLE
fix: avoid default features and disable in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
           - name: build
             key: v3
             push: true
+            # we disable default features because rust will otherwise unify them and turn on opencl in CI.
             command: build
+            args: --no-default-features
           - name: check-clippy
             key: v3
             command: clippy

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -15,12 +15,11 @@ cid = { version = "0.8.5", default-features = false }
 fvm_shared = { version = "3.0.0-alpha.14", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
-lazy_static = { version = "1.4.0", optional = true }
+lazy_static = { version = "1.4.0" }
 log = "0.4.14"
 thiserror = "1.0.30"
 fvm_ipld_encoding = { version = "0.3", path = "../ipld/encoding" }
 
 [features]
-default = ["debug"]
-debug = ["lazy_static"]
+default = []
 m2-native = []

--- a/sdk/src/debug.rs
+++ b/sdk/src/debug.rs
@@ -1,84 +1,66 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-pub use inner::*;
+use lazy_static::lazy_static;
+use log::LevelFilter;
 
-#[cfg(not(feature = "debug"))]
-mod inner {
-    #[inline(always)]
-    pub fn init_logging() {}
+use crate::sys;
 
-    #[inline(always)]
-    pub fn enabled() {
-        false
-    }
-    #[inline(always)]
-    pub fn log(_: String) {}
+lazy_static! {
+    /// Lazily memoizes if debug mode is enabled.
+    static ref DEBUG_ENABLED: bool = unsafe { sys::debug::enabled().unwrap() >= 0 };
 }
 
-#[cfg(feature = "debug")]
-mod inner {
-    use lazy_static::lazy_static;
-    use log::LevelFilter;
+/// Logs a message on the node.
+#[inline]
+pub fn log(msg: String) {
+    unsafe {
+        sys::debug::log(msg.as_ptr(), msg.len() as u32).unwrap();
+    }
+}
+/// Initialize logging if debugging is enabled.
+#[inline(always)]
+pub fn init_logging() {
+    if enabled() {
+        log::set_logger(&Logger).expect("failed to enable logging");
+        log::set_max_level(LevelFilter::Trace);
+    }
+}
 
-    use crate::sys;
+/// Saves an artifact to the host env. New artifacts with the same name will overwrite old ones
+pub fn store_artifact(name: impl AsRef<str>, data: impl AsRef<[u8]>) {
+    let name = name.as_ref();
+    let data = data.as_ref();
+    unsafe {
+        sys::debug::store_artifact(
+            name.as_ptr(),
+            name.len() as u32,
+            data.as_ptr(),
+            data.len() as u32,
+        )
+        .unwrap();
+    }
+}
 
-    lazy_static! {
-        /// Lazily memoizes if debug mode is enabled.
-        static ref DEBUG_ENABLED: bool = unsafe { sys::debug::enabled().unwrap() >= 0 };
+/// Returns whether debug mode is enabled.
+#[inline(always)]
+pub fn enabled() -> bool {
+    *DEBUG_ENABLED
+}
+
+/// Logger is a debug-only logger that uses the FVM syscalls.
+struct Logger;
+
+impl log::Log for Logger {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        // TODO: per-level?
+        enabled()
     }
 
-    /// Logs a message on the node.
-    #[inline]
-    pub fn log(msg: String) {
-        unsafe {
-            sys::debug::log(msg.as_ptr(), msg.len() as u32).unwrap();
-        }
-    }
-    /// Initialize logging if debugging is enabled.
-    #[inline(always)]
-    pub fn init_logging() {
+    fn log(&self, record: &log::Record) {
         if enabled() {
-            log::set_logger(&Logger).expect("failed to enable logging");
-            log::set_max_level(LevelFilter::Trace);
+            log(format!("[{}] {}", record.level(), record.args()));
         }
     }
 
-    /// Saves an artifact to the host env. New artifacts with the same name will overwrite old ones
-    pub fn store_artifact(name: impl AsRef<str>, data: impl AsRef<[u8]>) {
-        let name = name.as_ref();
-        let data = data.as_ref();
-        unsafe {
-            sys::debug::store_artifact(
-                name.as_ptr(),
-                name.len() as u32,
-                data.as_ptr(),
-                data.len() as u32,
-            )
-            .unwrap();
-        }
-    }
-
-    /// Returns whether debug mode is enabled.
-    #[inline(always)]
-    pub fn enabled() -> bool {
-        *DEBUG_ENABLED
-    }
-
-    /// Logger is a debug-only logger that uses the FVM syscalls.
-    struct Logger;
-
-    impl log::Log for Logger {
-        fn enabled(&self, _: &log::Metadata) -> bool {
-            // TODO: per-level?
-            enabled()
-        }
-
-        fn log(&self, record: &log::Record) {
-            if enabled() {
-                log(format!("[{}] {}", record.level(), record.args()));
-            }
-        }
-
-        fn flush(&self) {}
-    }
+    fn flush(&self) {}
 }

--- a/sdk/src/sys/mod.rs
+++ b/sdk/src/sys/mod.rs
@@ -58,7 +58,6 @@ pub use fvm_shared::sys::TokenAmount;
 
 pub mod actor;
 pub mod crypto;
-#[cfg(feature = "debug")]
 pub mod debug;
 pub mod event;
 pub mod gas;

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Protocol Labs", "Filecoin Core Devs", "Polyphene"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "3.0.0-alpha.14", path = "../../fvm", default-features = false }
-fvm_shared = { version = "3.0.0-alpha.14", path = "../../shared" }
+fvm = { version = "3.0.0-alpha.14", path = "../../fvm", default-features = false, features = ["testing"] }
+fvm_shared = { version = "3.0.0-alpha.14", path = "../../shared", features = ["testing"] }
 fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.0", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
@@ -53,6 +53,6 @@ fil_readonly_actor = { path = "tests/fil-readonly-actor" }
 actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 
 [features]
-default = ["fvm/testing", "fvm_shared/testing"]
+default = []
 m2-native = []
 f4-as-account = ["fvm/f4-as-account"]


### PR DESCRIPTION
1. Avoid cases where we need to specify default features (except opencl in the fvm crate).
2. Disable default features in CI.

This lets us _reliably_ disable OpenCL. Otherwise, we need OpenCL to build, which isn't usually present in CI.

This also removes the "debug" feature from the SDK, because we always enable that anyways.