### PR TITLE
OPT-892: Hamt max array width made configurable.

### DIFF
--- a/ipld/hamt/fuzz/fuzz_targets/extensions.rs
+++ b/ipld/hamt/fuzz/fuzz_targets/extensions.rs
@@ -12,7 +12,7 @@ fuzz_target!(|data: (u8, u32, u32, u32, Vec<common::Operation>)| {
     let conf = Config {
         bit_width: 1 + bit_width % 8,
         min_data_depth: min_data_depth % 3,
-        max_array_width: max_array_width % 4, // Starting from 0 just to make sure it doesn't cause an issue.
+        max_array_width: (max_array_width % 4) as usize, // Starting from 0 just to make sure it doesn't cause an issue.
     };
     common::run(flush_rate, operations, conf);
 });

--- a/ipld/hamt/fuzz/fuzz_targets/extensions.rs
+++ b/ipld/hamt/fuzz/fuzz_targets/extensions.rs
@@ -7,11 +7,12 @@ use libfuzzer_sys::fuzz_target;
 
 mod common;
 
-fuzz_target!(|data: (u8, u32, u32, Vec<common::Operation>)| {
-    let (flush_rate, bit_width, min_data_depth, operations) = data;
+fuzz_target!(|data: (u8, u32, u32, u32, Vec<common::Operation>)| {
+    let (flush_rate, bit_width, min_data_depth, max_array_width, operations) = data;
     let conf = Config {
         bit_width: 1 + bit_width % 8,
-        min_data_depth: 0 + min_data_depth % 3,
+        min_data_depth: min_data_depth % 3,
+        max_array_width: max_array_width % 4, // Starting from 0 just to make sure it doesn't cause an issue.
     };
     common::run(flush_rate, operations, conf);
 });

--- a/ipld/hamt/src/lib.rs
+++ b/ipld/hamt/src/lib.rs
@@ -27,8 +27,6 @@ pub use self::hamt::Hamt;
 pub use self::hash::*;
 pub use self::hash_algorithm::*;
 
-const MAX_ARRAY_WIDTH: usize = 3;
-
 /// Default bit width for indexing a hash at each depth level
 const DEFAULT_BIT_WIDTH: u32 = 8;
 
@@ -57,6 +55,9 @@ pub struct Config {
     /// The setting makes most sense when the size of values outweigh the size of the link
     /// pointing at them. When storing small, hash-sized values, it might not matter.
     pub min_data_depth: u32,
+
+    /// Maximum number of key-value pairs in a bucket before it's pushed down.
+    pub max_array_width: usize,
 }
 
 impl Default for Config {
@@ -64,6 +65,7 @@ impl Default for Config {
         Self {
             bit_width: DEFAULT_BIT_WIDTH,
             min_data_depth: 0,
+            max_array_width: 3,
         }
     }
 }

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use super::bitfield::Bitfield;
 use super::hash_bits::HashBits;
 use super::pointer::Pointer;
-use super::{Error, Hash, HashAlgorithm, KeyValuePair, MAX_ARRAY_WIDTH};
+use super::{Error, Hash, HashAlgorithm, KeyValuePair};
 use crate::Config;
 
 /// Node in Hamt tree which contains bitfield of set indexes and pointers to nodes
@@ -322,7 +322,7 @@ where
                 }
 
                 // If the array is full, create a subshard and insert everything
-                if vals.len() >= MAX_ARRAY_WIDTH {
+                if vals.len() >= conf.max_array_width {
                     let kvs = std::mem::take(vals);
                     let hashed_kvs = kvs.into_iter().map(|KeyValuePair(k, v)| {
                         let hash = H::hash(&k);

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -12,7 +12,7 @@ use serde::de::{self, DeserializeOwned};
 use serde::{ser, Deserialize, Deserializer, Serialize, Serializer};
 
 use super::node::Node;
-use super::{Error, Hash, HashAlgorithm, KeyValuePair, MAX_ARRAY_WIDTH};
+use super::{Error, Hash, HashAlgorithm, KeyValuePair};
 use crate::Config;
 
 /// Pointer to index values or a link to another child node.
@@ -133,7 +133,7 @@ where
                     }
                     Ok(())
                 }
-                2..=MAX_ARRAY_WIDTH => {
+                i if 2 <= i && i <= conf.max_array_width => {
                     // If more child values than max width, nothing to change.
                     let mut children_len = 0;
                     for c in n.pointers.iter() {
@@ -143,7 +143,7 @@ where
                             return Ok(());
                         }
                     }
-                    if children_len > MAX_ARRAY_WIDTH {
+                    if children_len > conf.max_array_width {
                         return Ok(());
                     }
 

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -542,18 +542,9 @@ fn clean_child_ordering(factory: HamtFactory, stats: Option<BSStats>, mut cids: 
     }
 }
 
-#[test]
-fn min_data_depth_reduces_root_size() {
-    let mk_factory = |min_data_depth| HamtFactory {
-        conf: Config {
-            min_data_depth,
-            ..Default::default()
-        },
-    };
-
-    let factory1 = mk_factory(0);
-    let factory2 = mk_factory(1);
-
+/// Test that a HAMT produced by `factory1` has a larger root size than one produced by `factory2`
+/// after inserting the same data into both versions.
+fn test_reduced_root_size(factory1: HamtFactory, factory2: HamtFactory) {
     let mem = MemoryBlockstore::default();
     let mut hamt1 = factory1.new(&mem);
     let mut hamt2 = factory2.new(&mem);
@@ -578,6 +569,36 @@ fn min_data_depth_reduces_root_size() {
     let br2 = bytes_read_during_load(&c2, &factory2);
 
     assert!(br2 < br1);
+}
+
+#[test]
+fn min_data_depth_reduces_root_size() {
+    let mk_factory = |min_data_depth| HamtFactory {
+        conf: Config {
+            min_data_depth,
+            ..Default::default()
+        },
+    };
+
+    let factory1 = mk_factory(0);
+    let factory2 = mk_factory(1);
+
+    test_reduced_root_size(factory1, factory2);
+}
+
+#[test]
+fn max_array_width_reduces_root_size() {
+    let mk_factory = |max_array_width| HamtFactory {
+        conf: Config {
+            max_array_width,
+            ..Default::default()
+        },
+    };
+
+    let factory1 = mk_factory(3);
+    let factory2 = mk_factory(1);
+
+    test_reduced_root_size(factory1, factory2);
 }
 
 /// List of key value pairs with unique keys.

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -919,6 +919,7 @@ test_hamt_mod!(
         conf: Config {
             bit_width: 1,
             min_data_depth: 0,
+            max_array_width: 3
         },
     }
 );
@@ -929,6 +930,7 @@ test_hamt_mod!(
         conf: Config {
             bit_width: 4,
             min_data_depth: 2,
+            max_array_width: 1
         },
     }
 );


### PR DESCRIPTION
Related to https://github.com/filecoin-project/ref-fvm/issues/892 

The PR moves the currently constant `MAX_ARRAY_WIDTH` into the `hamt::Config`. 

We realized in https://github.com/filecoin-project/builtin-actors/pull/926 that the `min_data_depth` option added in https://github.com/filecoin-project/ref-fvm/pull/1088 is only really useful if the size of the `KeyValuePair`s are much larger than the pointers they are replaced with, or when we know for sure that there will be enough items inserted that they will result in a deep HAMT, and when we only need to access a few entries at a time. In these cases we can skip having to read/write an overweight root node every time.

For the EVM this wasn't the case, because the keys are the values are both 32 bytes, which is comparable to a CID. In this case a pointer to a node containing a single value is an overhead. We realized that we can have the best of both worlds by restricting the maximum number of entries in a bucket to one: then it doesn't matter if it's a KV pair or a pointer, but as soon as there would be two KV pairs, they get pushed down. 

The array width was made configurable in the `Kamt`, but probably I don't see why it couldn't be useful in the `Hamt` as well.