### PR TITLE
refactor: update the gas schedule

### DIFF
--- a/fvm/src/gas/charge.rs
+++ b/fvm/src/gas/charge.rs
@@ -12,21 +12,29 @@ use super::Gas;
 #[derive(Clone, Debug)]
 pub struct GasCharge {
     pub name: Cow<'static, str>,
-    /// Compute costs
+    /// Gas charged for immediate computation.
     pub compute_gas: Gas,
-    /// Storage costs
-    pub storage_gas: Gas,
+
+    /// Other gas including:
+    ///
+    /// 1. Storage gas.
+    /// 2. Memory retention.
+    /// 3. Deferred computation (e.g., flushing blocks.)
+    ///
+    /// This is split into a separate field to facilitate benchmarking.
+    pub other_gas: Gas,
+
     /// Execution time related to this charge, if traced and successfully measured.
     pub elapsed: GasDuration,
 }
 
 impl GasCharge {
-    pub fn new(name: impl Into<Cow<'static, str>>, compute_gas: Gas, storage_gas: Gas) -> Self {
+    pub fn new(name: impl Into<Cow<'static, str>>, compute_gas: Gas, other_gas: Gas) -> Self {
         let name = name.into();
         Self {
             name,
             compute_gas,
-            storage_gas,
+            other_gas,
             elapsed: GasDuration::default(),
         }
     }
@@ -34,6 +42,6 @@ impl GasCharge {
     /// Calculates total gas charge (in milligas) by summing compute and
     /// storage gas associated with this charge.
     pub fn total(&self) -> Gas {
-        self.compute_gas + self.storage_gas
+        self.compute_gas + self.other_gas
     }
 }

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -262,13 +262,13 @@ where
         }
         let start = GasTimer::start();
         let block = self.blocks.get(id)?;
-        let code = multihash::Code::try_from(hash_fun)
+        let code = SupportedHashes::try_from(hash_fun)
             .map_err(|_| syscall_error!(IllegalCid; "invalid CID codec"))?;
 
         let t = self.call_manager.charge_gas(
             self.call_manager
                 .price_list()
-                .on_block_link(block.size() as usize),
+                .on_block_link(code, block.size() as usize),
         )?;
 
         let hash = code.digest(block.data());

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -5,7 +5,7 @@ use super::*;
 mod ipld {
 
     use cid::Cid;
-    use fvm::kernel::IpldBlockOps;
+    use fvm::kernel::{IpldBlockOps, SupportedHashes};
     use fvm::machine::Machine;
     use fvm_ipld_blockstore::Blockstore;
     use fvm_ipld_encoding::DAG_CBOR;
@@ -188,7 +188,10 @@ mod ipld {
                 .machine
                 .context()
                 .price_list
-                .on_block_link(expected_block.size() as usize)
+                .on_block_link(
+                    SupportedHashes::try_from(cid.hash().code()).unwrap(),
+                    expected_block.size() as usize,
+                )
                 .total();
 
             assert_eq!(

--- a/testing/conformance/src/tracing.rs
+++ b/testing/conformance/src/tracing.rs
@@ -39,7 +39,7 @@ pub struct TestMessageTombstone {
 pub struct TestGasCharge {
     pub name: String,
     pub compute_gas: i64,
-    pub storage_gas: i64,
+    pub other_gas: i64,
     pub elapsed_nanos: Option<u128>,
 }
 
@@ -102,7 +102,7 @@ impl TestTraceExporter {
                             Some(TestGasCharge {
                                 name: charge.name.into(),
                                 compute_gas: charge.compute_gas.as_milligas(),
-                                storage_gas: charge.storage_gas.as_milligas(),
+                                other_gas: charge.other_gas.as_milligas(),
                                 elapsed_nanos,
                             })
                         }


### PR DESCRIPTION
# Code Changes

1. Remove the old gas schedules. We don't support these releases and we don't need to try to maintain compatibility.
2. Use ScalingCost everywhere to make things simpler.
3. Add clear TODOs for gas prices that need to be figured out.
4. Try to clearly split up operations in a way that should be easier to measure.
5. Rename the "storage gas" field on gas charges to "other gas", and move all charges that aren't charging for _immediate_ computation. This makes benchmarking easier. Includes:
    - Deferred operations (e.g., flush).
    - Memory retention
    - Storage
    
# Syscall Gas Changes

The following changes have been made since M1. This includes reverting some of the changes that are currently on master.

## Signature Validation

- Secp256k1 signature verification has gained a new 10gas/byte cost to reflect the cost of hashing (blake2b).
- BLS signature verification has gained a new 26gas/byte cost to reflect the cost of hashing.

## Hashing

Hashing no longer has a flat cost (was 31355) but has the following costs (per algorithm):

- sha256: 7gas/byte
- blake2b: 10gas/byte
- keccak256: 33gas/byte
- ripemd160: 35gas/byte

For sha256, the "break-even" is ~4.5KiB, for blake2b the break-even is ~3.1KiB. Overall, these changes should result in a gas cost reduction as most things we hash on-chain are tiny.

TODO: sha256 likely assumes hardware support and will need more testing.

## Memory

- Memory copy costs have been reduced from 0.5gas/byte to 0.4gas/byte.
- The "memory retention" cost of 10gas/byte has been split into a 2gas/byte memory _allocation_ cost, and an 8gas/byte memory retention cost. This change does not affect actual gas costs, it just splits the cost into a "compute" cost (allocation) and a non-compute cost (memory retention).

## Storage

Block storage costs have increased by 13.8gas/byte (from 1300gas/byte to 1313.8gas/byte, or 1%):

- PLUS 2 * 2 = 4 gas for an expected 2 allocations (one on write, one on flush).
- PLUS 10gas/byte for hashing.
- MINUS 0.1 * 2 gas/byte for the reduction in memcpy costs.

## Randomness

Randomness now charges for hashing. Specifically, it charges:

1. 1400 for the "extern" call.
2. 10gas/byte of entropy plus 480 gas for hashing the randomness itself.

This is likely still a small under-charge (we're missing some hashing and copying costs), but it brings us closer.