### PR TITLE
Remove the Cbor trait and its uses

### DIFF
--- a/fvm/src/account_actor.rs
+++ b/fvm/src/account_actor.rs
@@ -10,7 +10,6 @@
 //! details.
 
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
 
 /// State specifies the key address for the actor.
@@ -18,5 +17,3 @@ use fvm_shared::address::Address;
 pub struct State {
     pub address: Address,
 }
-
-impl Cbor for State {}

--- a/fvm/src/init_actor.rs
+++ b/fvm/src/init_actor.rs
@@ -19,7 +19,7 @@ use anyhow::Context;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::{Cbor, CborStore};
+use fvm_ipld_encoding::CborStore;
 use fvm_ipld_hamt::Hamt;
 use fvm_shared::address::{Address, Payload};
 use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
@@ -38,8 +38,6 @@ pub struct State {
     #[cfg(feature = "m2-native")]
     pub installed_actors: Cid,
 }
-
-impl Cbor for State {}
 
 impl State {
     // ideally we would just #[cfg(test)] this, but it is used by non test-gated code in

--- a/fvm/src/syscalls/context.rs
+++ b/fvm/src/syscalls/context.rs
@@ -5,10 +5,11 @@ use std::ops::{Deref, DerefMut};
 use std::panic;
 
 use cid::Cid;
-use fvm_ipld_encoding::{from_slice, Cbor};
+use fvm_ipld_encoding::from_slice;
 use fvm_shared::address::Address;
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::MAX_CID_LEN;
+use serde::de::DeserializeOwned;
 
 use crate::kernel::{ClassifyResult, Context as _, Result};
 use crate::syscall_error;
@@ -106,7 +107,7 @@ impl Memory {
         Address::from_bytes(bytes).or_error(ErrorNumber::IllegalArgument)
     }
 
-    pub fn read_cbor<T: Cbor>(&self, offset: u32, len: u32) -> Result<T> {
+    pub fn read_cbor<T: DeserializeOwned>(&self, offset: u32, len: u32) -> Result<T> {
         let bytes = self.try_slice(offset, len)?;
         // Catch panics when decoding cbor from actors, _just_ in case.
         match panic::catch_unwind(|| from_slice(bytes).or_error(ErrorNumber::IllegalArgument)) {

--- a/fvm/src/system_actor.rs
+++ b/fvm/src/system_actor.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
-use fvm_ipld_encoding::{Cbor, CborStore};
+use fvm_ipld_encoding::CborStore;
 use fvm_shared::ActorID;
 
 use crate::kernel::{ClassifyResult, Result};
@@ -17,7 +17,6 @@ pub struct State {
     // builtin actor registry: Vec<(String, Cid)>
     pub builtin_actors: Cid,
 }
-impl Cbor for State {}
 
 impl State {
     pub fn load<B>(state_tree: &StateTree<B>) -> Result<(Self, ActorState)>

--- a/ipld/encoding/src/cbor.rs
+++ b/ipld/encoding/src/cbor.rs
@@ -12,6 +12,7 @@ use super::errors::Error;
 use crate::{de, from_slice, ser, strict_bytes, to_vec};
 
 /// Cbor utility functions for serializable objects
+#[deprecated(note = "use to_vec or from_slice directly")]
 pub trait Cbor: ser::Serialize + de::DeserializeOwned {
     /// Marshalls cbor encodable object into cbor bytes
     fn marshal_cbor(&self) -> Result<Vec<u8>, Error> {
@@ -24,7 +25,9 @@ pub trait Cbor: ser::Serialize + de::DeserializeOwned {
     }
 }
 
+#[allow(deprecated)]
 impl<T> Cbor for Vec<T> where T: Cbor {}
+#[allow(deprecated)]
 impl<T> Cbor for Option<T> where T: Cbor {}
 
 /// Raw serialized cbor bytes.
@@ -54,6 +57,7 @@ impl From<RawBytes> for Rc<[u8]> {
     }
 }
 
+#[allow(deprecated)]
 impl Cbor for RawBytes {}
 
 impl Deref for RawBytes {

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
-use fvm_ipld_encoding::{to_vec, Cbor};
+use fvm_ipld_encoding::to_vec;
 use fvm_shared::address::Address;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::hash::SupportedHashes;
@@ -132,17 +132,13 @@ pub fn compute_unsealed_sector_cid(
 
 /// Verifies a sector seal proof.
 pub fn verify_seal(info: &SealVerifyInfo) -> SyscallResult<bool> {
-    let info = info
-        .marshal_cbor()
-        .expect("failed to marshal seal verification input");
+    let info = to_vec(info).expect("failed to marshal seal verification input");
     unsafe { sys::crypto::verify_seal(info.as_ptr(), info.len() as u32).map(status_code_to_bool) }
 }
 
 /// Verifies a window proof of spacetime.
 pub fn verify_post(info: &WindowPoStVerifyInfo) -> SyscallResult<bool> {
-    let info = info
-        .marshal_cbor()
-        .expect("failed to marshal PoSt verification input");
+    let info = to_vec(info).expect("failed to marshal PoSt verification input");
     unsafe { sys::crypto::verify_post(info.as_ptr(), info.len() as u32).map(status_code_to_bool) }
 }
 
@@ -188,9 +184,7 @@ pub fn verify_consensus_fault(
 }
 
 pub fn verify_aggregate_seals(info: &AggregateSealVerifyProofAndInfos) -> SyscallResult<bool> {
-    let info = info
-        .marshal_cbor()
-        .expect("failed to marshal aggregate seal verification input");
+    let info = to_vec(info).expect("failed to marshal aggregate seal verification input");
     unsafe {
         sys::crypto::verify_aggregate_seals(info.as_ptr(), info.len() as u32)
             .map(status_code_to_bool)
@@ -198,9 +192,7 @@ pub fn verify_aggregate_seals(info: &AggregateSealVerifyProofAndInfos) -> Syscal
 }
 
 pub fn verify_replica_update(info: &ReplicaUpdateInfo) -> SyscallResult<bool> {
-    let info = info
-        .marshal_cbor()
-        .expect("failed to marshal replica update verification input");
+    let info = to_vec(info).expect("failed to marshal replica update verification input");
     unsafe {
         sys::crypto::verify_replica_update(info.as_ptr(), info.len() as u32)
             .map(status_code_to_bool)

--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 
 use data_encoding::Encoding;
 use data_encoding_macro::new_encoding;
-use fvm_ipld_encoding::{strict_bytes, Cbor};
+use fvm_ipld_encoding::strict_bytes;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 pub use self::errors::Error;
@@ -73,8 +73,6 @@ const TESTNET_PREFIX: &str = "t";
 pub struct Address {
     payload: Payload,
 }
-
-impl Cbor for Address {}
 
 impl Address {
     /// Construct a new address with the specified network.

--- a/shared/src/crypto/signature.rs
+++ b/shared/src/crypto/signature.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use std::error;
 
 use fvm_ipld_encoding::repr::*;
-use fvm_ipld_encoding::{de, ser, strict_bytes, Cbor, Error as EncodingError};
+use fvm_ipld_encoding::{de, ser, strict_bytes, Error as EncodingError};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use thiserror::Error;
@@ -41,8 +41,6 @@ pub struct Signature {
     pub sig_type: SignatureType,
     pub bytes: Vec<u8>,
 }
-
-impl Cbor for Signature {}
 
 impl ser::Serialize for Signature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/shared/src/event/mod.rs
+++ b/shared/src/event/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use bitflags::bitflags;
-use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 use serde::{Deserialize, Serialize};
 use serde_tuple::*;
 
@@ -17,8 +17,6 @@ pub struct StampedEvent {
     event: ActorEvent,
 }
 
-impl Cbor for StampedEvent {}
-
 impl StampedEvent {
     pub fn new(emitter: ActorID, event: ActorEvent) -> Self {
         Self { emitter, event }
@@ -31,8 +29,6 @@ impl StampedEvent {
 pub struct ActorEvent {
     pub entries: Vec<Entry>,
 }
-
-impl Cbor for ActorEvent {}
 
 impl From<Vec<Entry>> for ActorEvent {
     fn from(entries: Vec<Entry>) -> Self {
@@ -61,8 +57,6 @@ pub struct Entry {
     /// Any DAG-CBOR encodeable type.
     pub value: RawBytes,
 }
-
-impl Cbor for Entry {}
 
 // TODO write macro
 // event!({

--- a/shared/src/message.rs
+++ b/shared/src/message.rs
@@ -5,7 +5,7 @@
 use anyhow::anyhow;
 use fvm_ipld_encoding::de::{Deserialize, Deserializer};
 use fvm_ipld_encoding::ser::{Serialize, Serializer};
-use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 
 use crate::address::Address;
 use crate::econ::TokenAmount;
@@ -26,8 +26,6 @@ pub struct Message {
     pub gas_fee_cap: TokenAmount,
     pub gas_premium: TokenAmount,
 }
-
-impl Cbor for Message {}
 
 impl Message {
     /// Does some basic checks on the Message to see if the fields are valid.

--- a/shared/src/piece/mod.rs
+++ b/shared/src/piece/mod.rs
@@ -2,8 +2,6 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_encoding::Cbor;
-
 #[cfg(feature = "proofs")]
 pub mod zero;
 
@@ -71,8 +69,6 @@ pub struct PieceInfo {
     /// Content identifier for piece.
     pub cid: Cid,
 }
-
-impl Cbor for PieceInfo {}
 
 #[cfg(feature = "proofs")]
 use std::convert::TryFrom;

--- a/shared/src/receipt.rs
+++ b/shared/src/receipt.rs
@@ -4,7 +4,7 @@
 
 use cid::Cid;
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
-use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 
 use crate::error::ExitCode;
 
@@ -19,5 +19,3 @@ pub struct Receipt {
     /// CBOR NULL value on the wire).
     pub events_root: Option<Cid>, // Amt<Event>
 }
-
-impl Cbor for Receipt {}

--- a/shared/src/sector/post.rs
+++ b/shared/src/sector/post.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-use fvm_ipld_encoding::{strict_bytes, Cbor};
+use fvm_ipld_encoding::strict_bytes;
 use serde_tuple::*;
 
 use super::*;
@@ -55,9 +55,3 @@ pub struct WindowPoStVerifyInfo {
 pub struct OnChainWindowPoStVerifyInfo {
     pub proofs: Vec<PoStProof>,
 }
-
-impl Cbor for WindowPoStVerifyInfo {}
-
-impl Cbor for PoStProof {}
-
-impl Cbor for SectorInfo {}

--- a/shared/src/sector/seal.rs
+++ b/shared/src/sector/seal.rs
@@ -4,8 +4,8 @@
 
 use cid::Cid;
 use clock::ChainEpoch;
+use fvm_ipld_encoding::strict_bytes;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::{strict_bytes, Cbor};
 
 use crate::randomness::Randomness;
 use crate::sector::{
@@ -32,9 +32,6 @@ pub struct SealVerifyInfo {
     pub sealed_cid: Cid,   // Commr
     pub unsealed_cid: Cid, // Commd
 }
-
-// For syscall marshalling.
-impl Cbor for SealVerifyInfo {}
 
 /// SealVerifyParams is the structure of information that must be sent with
 /// a message to commit a sector. Most of this information is not needed in the
@@ -73,9 +70,6 @@ pub struct AggregateSealVerifyProofAndInfos {
     pub infos: Vec<AggregateSealVerifyInfo>,
 }
 
-// For syscall marshalling.
-impl Cbor for AggregateSealVerifyProofAndInfos {}
-
 /// Information needed to verify a replica update
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ReplicaUpdateInfo {
@@ -85,6 +79,3 @@ pub struct ReplicaUpdateInfo {
     pub new_unsealed_cid: Cid,
     pub proof: Vec<u8>,
 }
-
-// For syscall marshalling.
-impl Cbor for ReplicaUpdateInfo {}

--- a/shared/src/smooth/alpha_beta_filter.rs
+++ b/shared/src/smooth/alpha_beta_filter.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::Cbor;
 
 use crate::bigint::{bigint_ser, BigInt, Integer};
 use crate::clock::ChainEpoch;
@@ -38,8 +37,6 @@ impl FilterEstimate {
         (&self.velocity * delta_t) + position
     }
 }
-
-impl Cbor for FilterEstimate {}
 
 pub struct AlphaBetaFilter<'a, 'b, 'f> {
     alpha: &'a BigInt,

--- a/shared/src/state/mod.rs
+++ b/shared/src/state/mod.rs
@@ -5,7 +5,6 @@
 use cid::Cid;
 use fvm_ipld_encoding::repr::*;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::Cbor;
 use serde::{Deserialize, Serialize};
 
 /// Specifies the version of the state tree
@@ -39,8 +38,6 @@ pub struct StateRoot {
     /// Info. The structure depends on the state root version.
     pub info: Cid,
 }
-
-impl Cbor for StateRoot {}
 
 /// Empty state tree information. This is serialized as an array for future proofing.
 #[derive(Default, Deserialize, Serialize)]

--- a/shared/tests/address_test.rs
+++ b/shared/tests/address_test.rs
@@ -6,7 +6,7 @@ use std::iter;
 use std::str::FromStr;
 
 use data_encoding::{DecodeError, DecodeKind};
-use fvm_ipld_encoding::{from_slice, Cbor};
+use fvm_ipld_encoding::{from_slice, to_vec};
 use fvm_shared::address::{
     Address, Error, Protocol, BLS_PUB_LEN, MAX_SUBADDRESS_LEN, PAYLOAD_HASH_LEN, SECP_PUB_LEN,
 };
@@ -559,7 +559,7 @@ fn cbor_encoding() {
 
     for t in test_vectors.iter() {
         let res = Address::from_str(t.input).unwrap();
-        let encoded = res.marshal_cbor().unwrap();
+        let encoded = to_vec(&res).unwrap();
         // assert intermediate value is correct
         assert_eq!(encoded.as_slice(), t.encoded);
         let rec: Address = from_slice(&encoded).unwrap();

--- a/testing/conformance/benches/bench_conformance_overhead.rs
+++ b/testing/conformance/benches/bench_conformance_overhead.rs
@@ -10,7 +10,7 @@ use fvm::engine::MultiEngine;
 use fvm::machine::BURNT_FUNDS_ACTOR_ID;
 use fvm_conformance_tests::driver::*;
 use fvm_conformance_tests::vector::{ApplyMessage, MessageVector};
-use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::message::Message;
@@ -52,7 +52,7 @@ fn bench_500_simple_state_access(
 ) -> anyhow::Result<()> {
     let five_hundred_state_accesses = (0..500)
         .map(|i| ApplyMessage {
-            bytes: Message {
+            bytes: fvm_ipld_encoding::to_vec(&Message {
                 version: 0,
                 from: Address::new_id(BURNT_FUNDS_ACTOR_ID),
                 to: Address::new_id(BURNT_FUNDS_ACTOR_ID),
@@ -63,8 +63,7 @@ fn bench_500_simple_state_access(
                 gas_limit: 5000000000,
                 gas_fee_cap: TokenAmount::zero(),
                 gas_premium: TokenAmount::zero(),
-            }
-            .marshal_cbor()
+            })
             .unwrap(),
             epoch_offset: None,
         })

--- a/testing/conformance/benches/bench_drivers.rs
+++ b/testing/conformance/benches/bench_drivers.rs
@@ -10,7 +10,7 @@ use fvm_conformance_tests::driver::*;
 use fvm_conformance_tests::vector::{MessageVector, Variant};
 use fvm_conformance_tests::vm::{TestKernel, TestMachine};
 use fvm_ipld_blockstore::MemoryBlockstore;
-use fvm_ipld_encoding::Cbor;
+use fvm_ipld_encoding::from_slice;
 use fvm_shared::address::Protocol;
 use fvm_shared::crypto::signature::SECP_SIG_LEN;
 use fvm_shared::message::Message;
@@ -126,7 +126,7 @@ pub fn bench_vector_file(
                 .apply_messages
                 .iter()
                 .map(|m| {
-                    let unmarshalled = Message::unmarshal_cbor(&m.bytes).unwrap();
+                    let unmarshalled: Message = from_slice(&m.bytes).unwrap();
                     let mut raw_length = m.bytes.len();
                     if unmarshalled.from.protocol() == Protocol::Secp256k1 {
                         // 65 bytes signature + 1 byte type + 3 bytes for field info.

--- a/testing/conformance/src/bin/perf-conformance.rs
+++ b/testing/conformance/src/bin/perf-conformance.rs
@@ -11,7 +11,7 @@ use conformance_tests::vm::{TestKernel, TestMachine};
 use fvm::executor::{ApplyKind, DefaultExecutor, Executor};
 use fvm::machine::{Engine, EngineConfig};
 use fvm_ipld_blockstore::MemoryBlockstore;
-use fvm_ipld_encoding::Cbor;
+use fvm_ipld_encoding::from_slice;
 use fvm_shared::address::Protocol;
 use fvm_shared::crypto::signature::SECP_SIG_LEN;
 use fvm_shared::message::Message;
@@ -68,7 +68,7 @@ pub fn run_variant_for_perf(
 
     // Apply all messages in the vector.
     for m in v.apply_messages.iter() {
-        let msg = Message::unmarshal_cbor(&m.bytes).unwrap();
+        let msg: Message = from_slice(&m.bytes).unwrap();
 
         // Execute the message.
         let mut raw_length = m.bytes.len();

--- a/testing/conformance/src/driver.rs
+++ b/testing/conformance/src/driver.rs
@@ -12,7 +12,7 @@ use fvm::kernel::Context;
 use fvm::machine::Machine;
 use fvm::state_tree::{ActorState, StateTree};
 use fvm_ipld_blockstore::MemoryBlockstore;
-use fvm_ipld_encoding::{Cbor, CborStore};
+use fvm_ipld_encoding::{from_slice, CborStore};
 use fvm_shared::address::Protocol;
 use fvm_shared::crypto::signature::SECP_SIG_LEN;
 use fvm_shared::message::Message;
@@ -159,7 +159,7 @@ fn compare_state_roots(bs: &MemoryBlockstore, root: &Cid, vector: &MessageVector
     // might exist in the state-tree (it's usually incomplete).
 
     for m in &vector.apply_messages {
-        let msg = Message::unmarshal_cbor(&m.bytes)?;
+        let msg: Message = from_slice(&m.bytes)?;
         let actual_actor = actual_st.get_actor_by_address(&msg.from)?;
         let expected_actor = expected_st.get_actor_by_address(&msg.from)?;
         compare_actors(bs, "sender", actual_actor, expected_actor)?;
@@ -245,7 +245,7 @@ pub fn run_variant(
 
     // Apply all messages in the vector.
     for (i, m) in v.apply_messages.iter().enumerate() {
-        let msg = Message::unmarshal_cbor(&m.bytes)?;
+        let msg: Message = from_slice(&m.bytes)?;
 
         // Execute the message.
         let mut raw_length = m.bytes.len();

--- a/testing/integration/tests/fil-events-actor/src/actor.rs
+++ b/testing/integration/tests/fil-events-actor/src/actor.rs
@@ -1,7 +1,6 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::Cbor;
 use fvm_sdk as sdk;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;

--- a/testing/integration/tests/fil-events-actor/src/actor.rs
+++ b/testing/integration/tests/fil-events-actor/src/actor.rs
@@ -15,15 +15,11 @@ struct EventPayload1 {
     b: String,
 }
 
-impl Cbor for EventPayload1 {}
-
 #[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
 struct EventPayload2 {
     c: i32,
     d: Vec<u64>,
 }
-
-impl Cbor for EventPayload2 {}
 
 #[no_mangle]
 pub fn invoke(params: u32) -> u32 {
@@ -43,7 +39,7 @@ pub fn invoke(params: u32) -> u32 {
     let single_entry_evt = vec![Entry {
         flags: Flags::all(),
         key: "foo".to_owned(),
-        value: payload.marshal_cbor().unwrap().into(),
+        value: fvm_ipld_encoding::to_vec(&payload).unwrap().into(),
     }];
 
     let payload1 = EventPayload1 {
@@ -59,12 +55,12 @@ pub fn invoke(params: u32) -> u32 {
         Entry {
             flags: Flags::all(),
             key: "bar".to_owned(),
-            value: payload1.marshal_cbor().unwrap().into(),
+            value: fvm_ipld_encoding::to_vec(&payload1).unwrap().into(),
         },
         Entry {
             flags: Flags::FLAG_INDEXED_KEY | Flags::FLAG_INDEXED_VALUE,
             key: "baz".to_string(),
-            value: payload2.marshal_cbor().unwrap().into(),
+            value: fvm_ipld_encoding::to_vec(&payload2).unwrap().into(),
         },
     ];
 
@@ -75,7 +71,7 @@ pub fn invoke(params: u32) -> u32 {
         }
         EMIT_MALFORMED => unsafe {
             // mangle an event.
-            let mut serialized = single_entry_evt.marshal_cbor().unwrap();
+            let mut serialized = fvm_ipld_encoding::to_vec(&single_entry_evt).unwrap();
             serialized[1] = 0xff;
 
             assert!(


### PR DESCRIPTION
This "convenience" trait in the shared libraries introduced additional coupling between actors and FVM libraries, e.g. where an actor object that didn't provide the empty `impl Cbor` block would be unusable in some places.

It's not that convenient, since removing it gives a nice net reduction in code.

The built-in actors no longer use this as of https://github.com/filecoin-project/builtin-actors/pull/960