### PR TITLE
CallManager: Restrict embryo creation to the EAM's namespace

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -18,6 +18,7 @@ use num_traits::Zero;
 use super::{Backtrace, CallManager, InvocationResult, NO_DATA_BLOCK_ID};
 use crate::call_manager::backtrace::Frame;
 use crate::call_manager::FinishRet;
+use crate::eam_actor::EAM_ACTOR_ID;
 use crate::engine::Engine;
 use crate::gas::{Gas, GasTimer, GasTracker};
 use crate::kernel::{Block, BlockRegistry, ExecutionError, Kernel, Result, SyscallError};
@@ -451,12 +452,13 @@ where
                 }
                 // Validate that there's an actor at the target ID (we don't care what is there,
                 // just that something is there).
-                Payload::Delegated(da)
-                    if self.state_tree().get_actor(da.namespace())?.is_some() =>
-                {
+                Payload::Delegated(da) if da.namespace() == EAM_ACTOR_ID => {
                     self.create_embryo_actor::<K>(&to)?
                 }
-                _ => return Err(syscall_error!(NotFound; "actor does not exist: {}", to).into()),
+                _ => return Err(
+                    syscall_error!(NotFound; "actor does not exist or cannot be created: {}", to)
+                        .into(),
+                ),
             },
         };
 

--- a/testing/integration/tests/fil-address-actor/src/actor.rs
+++ b/testing/integration/tests/fil-address-actor/src/actor.rs
@@ -46,11 +46,11 @@ pub fn invoke(params: u32) -> u32 {
                 sdk::actor::lookup_address(id).expect("failed to lookup account address");
             assert_eq!(addr, new_addr, "addresses don't match");
         }
-        // send to an f4, then resolve.
+        // send to an f4 in the EAM's namespace, then resolve.
         3 => {
             // Create an embryo.
             let addr =
-                Address::new_delegated(0, b"foobar").expect("failed to construct f4 address");
+                Address::new_delegated(10, b"foobar").expect("failed to construct f4 address");
             assert!(sdk::send::send(
                 &addr,
                 0,


### PR DESCRIPTION
This isn't strictly necessary, since there _shouldn't_ be anything wrong with deploying embryos to other ID namespaces. However, only embryos in the EAM's namespace can be deployed at today, so we might as well restrict this for now and not have to think about it.