### PR TITLE
fix: IpldBlock::serialize_cbor should return an Option

### DIFF
--- a/ipld/encoding/src/ipld_block.rs
+++ b/ipld/encoding/src/ipld_block.rs
@@ -44,8 +44,8 @@ impl IpldBlock {
         };
         Ok(IpldBlock { codec, data })
     }
-    pub fn serialize_cbor<T: serde::Serialize + ?Sized>(value: &T) -> Result<Self, Error> {
-        IpldBlock::serialize(DAG_CBOR, value)
+    pub fn serialize_cbor<T: serde::Serialize + ?Sized>(value: &T) -> Result<Option<Self>, Error> {
+        Ok(Some(IpldBlock::serialize(DAG_CBOR, value)?))
     }
 }
 

--- a/testing/integration/tests/fil-events-actor/src/actor.rs
+++ b/testing/integration/tests/fil-events-actor/src/actor.rs
@@ -102,7 +102,7 @@ pub fn invoke(params: u32) -> u32 {
                 sdk::send::send(
                     &our_addr,
                     EMIT_SUBCALLS,
-                    Some(IpldBlock::serialize_cbor(&counter).unwrap()),
+                    IpldBlock::serialize_cbor(&counter).unwrap(),
                     Zero::zero(),
                     None,
                     Default::default(),
@@ -133,7 +133,7 @@ pub fn invoke(params: u32) -> u32 {
                 let _ = sdk::send::send(
                     &our_addr,
                     EMIT_SUBCALLS_REVERT,
-                    Some(IpldBlock::serialize_cbor(&counter).unwrap()),
+                    IpldBlock::serialize_cbor(&counter).unwrap(),
                     Zero::zero(),
                     None,
                     Default::default(),


### PR DESCRIPTION
This matches the behaviour introduced on the v2 FVM in #1199 