### PR TITLE
Release ipld_encoding 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,7 +1850,7 @@ dependencies = [
 name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_sdk 3.0.0-alpha.19",
  "fvm_shared 3.0.0-alpha.15",
  "serde",
@@ -1888,7 +1888,7 @@ dependencies = [
 name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_sdk 3.0.0-alpha.19",
  "fvm_shared 3.0.0-alpha.15",
  "serde",
@@ -1900,7 +1900,7 @@ dependencies = [
 name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_sdk 3.0.0-alpha.19",
  "fvm_shared 3.0.0-alpha.15",
  "substrate-wasm-builder",
@@ -1912,7 +1912,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_sdk 3.0.0-alpha.19",
  "fvm_shared 3.0.0-alpha.15",
  "num-derive",
@@ -1925,7 +1925,7 @@ dependencies = [
 name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_sdk 3.0.0-alpha.19",
  "fvm_shared 3.0.0-alpha.15",
  "log",
@@ -1950,7 +1950,7 @@ dependencies = [
  "anyhow",
  "cid 0.8.6",
  "fvm_ipld_blockstore 0.1.1",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_sdk 3.0.0-alpha.19",
  "fvm_shared 3.0.0-alpha.15",
  "serde",
@@ -1962,7 +1962,7 @@ dependencies = [
 name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_sdk 3.0.0-alpha.19",
  "fvm_shared 3.0.0-alpha.15",
  "minicov",
@@ -1983,7 +1983,7 @@ name = "fil_readonly_actor"
 version = "0.1.0"
 dependencies = [
  "cid 0.8.6",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_sdk 3.0.0-alpha.19",
  "fvm_shared 3.0.0-alpha.15",
  "substrate-wasm-builder",
@@ -2003,7 +2003,7 @@ name = "fil_syscall_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_sdk 3.0.0-alpha.19",
  "fvm_shared 3.0.0-alpha.15",
  "minicov",
@@ -2347,7 +2347,7 @@ dependencies = [
  "fvm-wasm-instrument",
  "fvm_ipld_amt 0.5.0",
  "fvm_ipld_blockstore 0.1.1",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_hamt 0.6.1",
  "fvm_shared 3.0.0-alpha.15",
  "lazy_static",
@@ -2425,7 +2425,7 @@ dependencies = [
  "fvm_ipld_amt 0.5.0",
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_car 0.6.0",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_hamt 0.6.1",
  "fvm_shared 3.0.0-alpha.15",
  "itertools 0.10.5",
@@ -2464,7 +2464,7 @@ dependencies = [
  "fvm_integration_tests",
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_car 0.6.0",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_shared 3.0.0-alpha.15",
  "lazy_static",
  "libsecp256k1",
@@ -2503,7 +2503,7 @@ dependencies = [
  "fvm_ipld_amt 0.5.0",
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_car 0.6.0",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_hamt 0.6.1",
  "fvm_shared 3.0.0-alpha.15",
  "lazy_static",
@@ -2546,7 +2546,7 @@ dependencies = [
  "cid 0.8.6",
  "criterion",
  "fvm_ipld_blockstore 0.1.1",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "itertools 0.10.5",
  "once_cell",
  "serde",
@@ -2575,7 +2575,7 @@ version = "0.5.4"
 dependencies = [
  "arbitrary",
  "criterion",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "gperftools",
  "rand",
  "rand_xorshift",
@@ -2625,7 +2625,7 @@ dependencies = [
  "cid 0.8.6",
  "futures",
  "fvm_ipld_blockstore 0.1.1",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "integer-encoding",
  "serde",
  "thiserror",
@@ -2683,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_encoding"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -2728,7 +2728,7 @@ dependencies = [
  "criterion",
  "forest_hash_utils",
  "fvm_ipld_blockstore 0.1.1",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "hex",
  "libipld-core 0.14.0",
  "multihash 0.16.3",
@@ -2772,7 +2772,7 @@ dependencies = [
  "criterion",
  "forest_hash_utils",
  "fvm_ipld_blockstore 0.1.1",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "hex",
  "libipld-core 0.15.0",
  "multihash 0.16.3",
@@ -2841,7 +2841,7 @@ name = "fvm_sdk"
 version = "3.0.0-alpha.19"
 dependencies = [
  "cid 0.8.6",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_shared 3.0.0-alpha.15",
  "lazy_static",
  "log",
@@ -2893,7 +2893,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_blockstore 0.1.1",
- "fvm_ipld_encoding 0.3.1",
+ "fvm_ipld_encoding 0.3.2",
  "lazy_static",
  "libsecp256k1",
  "log",

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -23,7 +23,7 @@ fvm_shared = { version = "3.0.0-alpha.15", path = "../shared", features = ["cryp
 fvm_ipld_hamt = { version = "0.6.1", path = "../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.0", path = "../ipld/amt" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.3.1", path = "../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../ipld/encoding" }
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = "0.5"
 serde_repr = "0.1"

--- a/ipld/encoding/CHANGELOG.md
+++ b/ipld/encoding/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changes to the FVM's shared encoding utilities.
 
+## 0.3.2 [2022-12-17]
+
+- IpldBlock::serialize_cbor returns Option<IpldBlock> instead of IpldBlock
+
 ## 0.3.1 [2022-12-17]
 
 - Add new `IpldBlock` type that supports both `DAG_CBOR` and `IPLD_RAW` codecs

--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_encoding"
 description = "Sharded IPLD encoding."
-version = "0.3.1"
+version = "0.3.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/testing/calibration/Cargo.toml
+++ b/testing/calibration/Cargo.toml
@@ -12,7 +12,7 @@ fvm = { version = "3.0.0-alpha.16", path = "../../fvm", default-features = false
 fvm_shared = { version = "3.0.0-alpha.15", path = "../../shared", features = ["testing"] }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.3.1", path = "../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../ipld/encoding" }
 fvm_integration_tests = { path = "../integration" }
 
 actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }

--- a/testing/calibration/contract/fil-gas-calibration-actor/Cargo.toml
+++ b/testing/calibration/contract/fil-gas-calibration-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 fvm_sdk = { version = "3.0.0-alpha.19", path = "../../../../sdk" }
 fvm_shared = { version = "3.0.0-alpha.15", path = "../../../../shared" }
-fvm_ipld_encoding = { version = "0.3.1", path = "../../../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../../../ipld/encoding" }
 cid = { version = "0.8.2", default-features = false }
 num-derive = "0.3"
 num-traits = "0.2"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -14,7 +14,7 @@ fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.0", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.3.1", path = "../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../ipld/encoding" }
 
 anyhow = "1.0.47"
 thiserror = "1.0.30"

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -14,7 +14,7 @@ fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.0", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
-fvm_ipld_encoding = { version = "0.3.1", path = "../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../ipld/encoding" }
 
 anyhow = "1.0.47"
 cid = { version = "0.8.5", default-features = false }

--- a/testing/integration/tests/fil-address-actor/Cargo.toml
+++ b/testing/integration/tests/fil-address-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_ipld_encoding = { version = "0.3.1", path = "../../../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0-alpha.19", path = "../../../../sdk" }
 fvm_shared = { version = "3.0.0-alpha.15", path = "../../../../shared" }
 serde = "1.0.145"

--- a/testing/integration/tests/fil-events-actor/Cargo.toml
+++ b/testing/integration/tests/fil-events-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_ipld_encoding = { version = "0.3.1", path = "../../../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0-alpha.19", path = "../../../../sdk" }
 fvm_shared = { version = "3.0.0-alpha.15", path = "../../../../shared" }
 serde = {version = "1.0.145", features = ["derive"] }

--- a/testing/integration/tests/fil-exit-data-actor/Cargo.toml
+++ b/testing/integration/tests/fil-exit-data-actor/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 [dependencies]
 fvm_sdk = { version = "3.0.0-alpha.19", path = "../../../../sdk" }
 fvm_shared = { version = "3.0.0-alpha.15", path = "../../../../shared" }
-fvm_ipld_encoding = { version = "0.3.1", path = "../../../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../../../ipld/encoding" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.0.0-alpha.19", path = "../../../../sdk" }
 fvm_shared = { version = "3.0.0-alpha.15", path = "../../../../shared" }
-fvm_ipld_encoding = { version = "0.3.1", path = "../../../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../../../ipld/encoding" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-gaslimit-actor/Cargo.toml
+++ b/testing/integration/tests/fil-gaslimit-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_ipld_encoding = { version = "0.3.1", path = "../../../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0-alpha.19", path = "../../../../sdk" }
 fvm_shared = { version = "3.0.0-alpha.15", path = "../../../../shared" }
 serde = {version = "1.0.145", features = ["derive"] }

--- a/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.0.0-alpha.19", path = "../../../../sdk" }
 fvm_shared = { version = "3.0.0-alpha.15", path = "../../../../shared" }
-fvm_ipld_encoding = { version = "0.3.1", path = "../../../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../../../ipld/encoding" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../../../ipld/blockstore" }
 
 anyhow = "1.0.57"

--- a/testing/integration/tests/fil-ipld-actor/Cargo.toml
+++ b/testing/integration/tests/fil-ipld-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_ipld_encoding = { version = "0.3.1", path = "../../../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0-alpha.19", path = "../../../../sdk" }
 fvm_shared = { version = "3.0.0-alpha.15", path = "../../../../shared" }
 

--- a/testing/integration/tests/fil-readonly-actor/Cargo.toml
+++ b/testing/integration/tests/fil-readonly-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 fvm_sdk = { version = "3.0.0-alpha.19", path = "../../../../sdk" }
 fvm_shared = { version = "3.0.0-alpha.15", path = "../../../../shared" }
-fvm_ipld_encoding = { version = "0.3.1", path = "../../../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../../../ipld/encoding" }
 cid = { version = "0.8.5", default-features = false }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-syscall-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_ipld_encoding = { version = "0.3.1", path = "../../../../ipld/encoding" }
+fvm_ipld_encoding = { version = "0.3.2", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0-alpha.19", path = "../../../../sdk" }
 fvm_shared = { version = "3.0.0-alpha.15", path = "../../../../shared" }
 minicov = {version = "0.2", optional = true}


### PR DESCRIPTION
The only change is a tweak of the behaviour of `IpldBlock::serialize_cbor` to return `Option<IpldBlock>` instead of `IpldBlock`