### PR TITLE
Split the "read" cache from the "write" cache in the state-tree

### DIFF
--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::cell::RefCell;
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 use anyhow::{anyhow, Context as _};
@@ -31,8 +32,10 @@ pub struct StateTree<S> {
     version: StateTreeVersion,
     info: Option<Cid>,
 
-    /// State cache
+    /// State snapshots.
     snaps: StateSnapshots,
+    /// Read-cache (always check the snapshots first)
+    read_cache: RefCell<HashMap<ActorID, Option<ActorState>>>,
 }
 
 /// Collection of state snapshots
@@ -247,6 +250,7 @@ where
             version,
             info,
             snaps: StateSnapshots::new(),
+            read_cache: Default::default(),
         })
     }
 
@@ -294,6 +298,7 @@ where
                     version,
                     info,
                     snaps: StateSnapshots::new(),
+                    read_cache: Default::default(),
                 })
             }
         }
@@ -321,21 +326,22 @@ where
             StateCacheResult::Exists(state) => Some(state),
             StateCacheResult::Deleted => None,
             StateCacheResult::Uncached => {
-                // if state doesn't exist, find using hamt
-                let key = Address::new_id(id).to_bytes();
-                let act = self
-                    .hamt
-                    .get(&key)
-                    .with_context(|| format!("failed to lookup actor {}", id))
-                    .or_fatal()?
-                    .cloned();
-
-                // Update cache if state was found
-                if let Some(act_s) = &act {
-                    self.snaps.set_actor(id, act_s.clone())?;
+                let mut read_cache = self.read_cache.borrow_mut();
+                match read_cache.entry(id) {
+                    Entry::Occupied(e) => e.get().clone(),
+                    Entry::Vacant(e) => {
+                        e.insert({
+                            // It's not cached, so we look it up and cache it.
+                            let key = Address::new_id(id).to_bytes();
+                            self.hamt
+                                .get(&key)
+                                .with_context(|| format!("failed to lookup actor {}", id))
+                                .or_fatal()?
+                                .cloned()
+                        })
+                        .clone()
+                    }
                 }
-
-                act
             }
         })
     }
@@ -369,7 +375,7 @@ where
 
     /// Delete actor identified by the supplied ID. Returns no error if the actor doesn't exist.
     pub fn delete_actor(&mut self, id: ActorID) -> Result<()> {
-        // Remove value from cache
+        // Record that we've deleted the actor.
         self.snaps.delete_actor(id)?;
 
         Ok(())
@@ -448,6 +454,10 @@ where
                 self.snaps.layers.len()
             )));
         }
+
+        // Clear the read-cache as it only reflects the state of the current state-tree, not
+        // modifications contained in the snaps.
+        self.read_cache.borrow_mut().clear();
 
         for (&id, sto) in self.snaps.layers[0].actors.borrow().iter() {
             let addr = Address::new_id(id);

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -34,7 +34,10 @@ pub struct StateTree<S> {
 
     /// State snapshots.
     snaps: StateSnapshots,
-    /// Read-cache (always check the snapshots first)
+    /// Read-cache for the backing blockstore. This DOES NOT contain
+    /// mutations in progress (contained in the snapshots). Always check
+    /// snapshots first, then the read cache, then fall back to the backing
+    /// blockstore.
     read_cache: RefCell<HashMap<ActorID, Option<ActorState>>>,
 }
 


### PR DESCRIPTION
This will let us charge the right amount for updating state. Otherwise, we end up making changes to the state-tree even if we only _read_ some actor's state.

fixes #120