### PR TITLE
feat: charge 0.4gas/byte for memory copy and initialization

### DIFF
--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -263,8 +263,8 @@ lazy_static! {
             memory_access_cost: Gas::zero(),
 
             // Don't yet charge anything for copying.
-            memory_copy_per_byte_cost: Gas::zero(),
-            memory_fill_per_byte_cost: Gas::zero(),
+            memory_copy_per_byte_cost: Gas::from_milligas(400),
+            memory_fill_per_byte_cost: Gas::from_milligas(400),
         },
 
         // NOTE: we currently "flush" events, but we need to stop doing that except when asked.


### PR DESCRIPTION
Ideally we'd have a constant somewhere for this, but we'll need to think a bit more about the structure here.