### PR TITLE
feat: refactor memory limits and apply to tables

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -22,7 +22,7 @@ use crate::eam_actor::EAM_ACTOR_ID;
 use crate::engine::Engine;
 use crate::gas::{Gas, GasTimer, GasTracker};
 use crate::kernel::{Block, BlockRegistry, ExecutionError, Kernel, Result, SyscallError};
-use crate::machine::limiter::ExecMemory;
+use crate::machine::limiter::MemoryLimiter;
 use crate::machine::Machine;
 use crate::state_tree::ActorState;
 use crate::syscalls::error::Abort;

--- a/fvm/src/engine.rs
+++ b/fvm/src/engine.rs
@@ -17,7 +17,7 @@ use wasmtime::{
 };
 
 use crate::gas::{GasTimer, WasmGasPrices};
-use crate::machine::limiter::ExecMemory;
+use crate::machine::limiter::MemoryLimiter;
 use crate::machine::{Machine, NetworkConfig};
 use crate::syscalls::{bind_syscalls, charge_for_init, record_init_time, InvocationData};
 use crate::Kernel;
@@ -539,7 +539,7 @@ impl Engine {
 
     /// Construct a new wasmtime "store" from the given kernel.
     pub fn new_store<K: Kernel>(&self, mut kernel: K) -> wasmtime::Store<InvocationData<K>> {
-        let memory_bytes = kernel.limiter_mut().curr_exec_memory_bytes();
+        let memory_bytes = kernel.limiter_mut().memory_used();
 
         let id = InvocationData {
             kernel,
@@ -557,8 +557,97 @@ impl Engine {
             .expect("failed to create available_gas global");
         store.data_mut().avail_gas_global = gg;
 
-        store.limiter(|id| id.kernel.limiter_mut());
+        fn as_wasmtime_limiter<K: Kernel>(
+            data: &mut InvocationData<K>,
+        ) -> &mut dyn wasmtime::ResourceLimiter {
+            unsafe {
+                &mut *(data.kernel.limiter_mut() as *mut _ as *mut WasmtimeLimiter<K::Limiter>)
+            }
+        }
+
+        store.limiter(as_wasmtime_limiter);
 
         store
+    }
+}
+
+#[repr(transparent)]
+struct WasmtimeLimiter<L>(L);
+
+impl<L: MemoryLimiter> wasmtime::ResourceLimiter for WasmtimeLimiter<L> {
+    fn memory_growing(&mut self, current: usize, desired: usize, maximum: Option<usize>) -> bool {
+        if maximum.map_or(false, |m| desired > m) {
+            return false;
+        }
+
+        self.0.grow_instance_memory(current, desired)
+    }
+
+    fn table_growing(&mut self, current: u32, desired: u32, maximum: Option<u32>) -> bool {
+        if maximum.map_or(false, |m| desired > m) {
+            return false;
+        }
+        self.0.grow_instance_table(current, desired)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wasmtime::ResourceLimiter;
+
+    use crate::engine::WasmtimeLimiter;
+    use crate::machine::limiter::MemoryLimiter;
+
+    #[derive(Default)]
+    struct Limiter {
+        memory: usize,
+    }
+    impl MemoryLimiter for Limiter {
+        fn memory_used(&self) -> usize {
+            unimplemented!()
+        }
+
+        fn grow_memory(&mut self, bytes: usize) -> bool {
+            self.memory += bytes;
+            true
+        }
+
+        fn with_stack_frame<T, G, F, R>(_: &mut T, _: G, _: F) -> R
+        where
+            G: Fn(&mut T) -> &mut Self,
+            F: FnOnce(&mut T) -> R,
+        {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn memory() {
+        let mut limits = WasmtimeLimiter(Limiter::default());
+        assert!(limits.memory_growing(0, 3, None));
+        assert_eq!(limits.0.memory, 3);
+
+        // The maximum in the args takes precedence.
+        assert!(!limits.memory_growing(3, 4, Some(2)));
+        assert_eq!(limits.0.memory, 3);
+
+        // Increase by 2.
+        assert!(limits.memory_growing(2, 4, None));
+        assert_eq!(limits.0.memory, 5);
+    }
+
+    #[test]
+    fn table() {
+        let mut limits = WasmtimeLimiter(Limiter::default());
+        assert!(limits.table_growing(0, 3, None));
+        assert_eq!(limits.0.memory, 3 * 8);
+
+        // The maximum in the args takes precedence.
+        assert!(!limits.table_growing(3, 4, Some(2)));
+        assert_eq!(limits.0.memory, 3 * 8);
+
+        // Increase by 2.
+        assert!(limits.table_growing(2, 4, None));
+        assert_eq!(limits.0.memory, 5 * 8);
     }
 }

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -32,11 +32,10 @@ pub use error::{ClassifyResult, Context, ExecutionError, Result, SyscallError};
 use fvm_shared::event::{ActorEvent, StampedEvent};
 pub use hash::SupportedHashes;
 use multihash::MultihashGeneric;
-use wasmtime::ResourceLimiter;
 
 use crate::call_manager::CallManager;
 use crate::gas::{Gas, GasTimer, PriceList};
-use crate::machine::limiter::ExecMemory;
+use crate::machine::limiter::MemoryLimiter;
 use crate::machine::Machine;
 
 pub struct SendResult {
@@ -362,7 +361,7 @@ pub trait DebugOps {
 /// It's only part of the kernel out of necessity to pass it through to the
 /// call manager which tracks the limits across the whole execution stack.
 pub trait LimiterOps {
-    type Limiter: ResourceLimiter + ExecMemory;
+    type Limiter: MemoryLimiter;
     /// Give access to the limiter of the underlying call manager.
     fn limiter_mut(&mut self) -> &mut Self::Limiter;
 }

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -21,7 +21,7 @@ use crate::externs::Externs;
 #[cfg(feature = "m2-native")]
 use crate::init_actor::State as InitActorState;
 use crate::kernel::{ClassifyResult, Result};
-use crate::machine::limiter::ExecResourceLimiter;
+use crate::machine::limiter::DefaultMemoryLimiter;
 use crate::machine::Manifest;
 use crate::state_tree::{ActorState, StateTree};
 use crate::syscall_error;
@@ -134,7 +134,7 @@ where
 {
     type Blockstore = BufferedBlockstore<B>;
     type Externs = E;
-    type Limiter = ExecResourceLimiter;
+    type Limiter = DefaultMemoryLimiter;
 
     fn blockstore(&self) -> &Self::Blockstore {
         self.state_tree.store()
@@ -258,6 +258,6 @@ where
     }
 
     fn new_limiter(&self) -> Self::Limiter {
-        ExecResourceLimiter::for_network(&self.context().network)
+        DefaultMemoryLimiter::for_network(&self.context().network)
     }
 }

--- a/fvm/src/machine/limiter.rs
+++ b/fvm/src/machine/limiter.rs
@@ -10,7 +10,7 @@ pub trait MemoryLimiter: Sized {
 
     /// Returns `true` if growing by `bytes` is allowed. Implement this memory to track and limit
     /// memory usage.
-    fn grow_memory(&mut self, bytes: usize) -> bool;
+    fn grow_memory(&mut self, delta: usize) -> bool;
 
     /// Push a new frame onto the call stack, and keep tallying up the current execution memory,
     /// then restore it to the current value when the frame is finished.

--- a/fvm/src/machine/limiter.rs
+++ b/fvm/src/machine/limiter.rs
@@ -1,16 +1,16 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use wasmtime::ResourceLimiter;
 
 use crate::machine::NetworkConfig;
 
 /// Execution level memory tracking and adjustment.
-pub trait ExecMemory
-where
-    Self: Sized,
-{
+pub trait MemoryLimiter: Sized {
     /// Get a snapshot of the total memory required by the modules on the call stack so far.
-    fn curr_exec_memory_bytes(&self) -> usize;
+    fn memory_used(&self) -> usize;
+
+    /// Returns `true` if growing by `bytes` is allowed. Implement this memory to track and limit
+    /// memory usage.
+    fn grow_memory(&mut self, bytes: usize) -> bool;
 
     /// Push a new frame onto the call stack, and keep tallying up the current execution memory,
     /// then restore it to the current value when the frame is finished.
@@ -18,62 +18,55 @@ where
     where
         G: Fn(&mut T) -> &mut Self,
         F: FnOnce(&mut T) -> R;
+
+    /// Grows an instance's memory from `from` to `to`. There's no need to manually implement this
+    /// unless you need to track instance metrics.
+    fn grow_instance_memory(&mut self, from: usize, to: usize) -> bool {
+        self.grow_memory(to.saturating_sub(from))
+    }
+
+    /// Grows an instance's table from `from` to `to` elements. There's no need to manually
+    /// implement this unless you need to track table metrics.
+    fn grow_instance_table(&mut self, from: u32, to: u32) -> bool {
+        // we charge 8 bytes per table element
+        self.grow_memory(to.saturating_sub(from).saturating_mul(8) as usize)
+    }
 }
 
 /// Limit resources throughout the whole message execution,
 /// across all Wasm instances.
-pub struct ExecResourceLimiter {
-    /// Maximum bytes that a single Wasm instance can use.
-    max_inst_memory_bytes: usize,
-    /// Maximum bytes that can be used at any point in time during an execution.
-    max_exec_memory_bytes: usize,
-    /// Total bytes desired so far by all the instances including the currently executing instance on the call stack.
-    curr_exec_memory_bytes: usize,
+pub struct DefaultMemoryLimiter {
+    max_memory_bytes: usize,
+    curr_memory_bytes: usize,
 }
 
-impl ExecResourceLimiter {
-    pub fn new(max_inst_memory_bytes: usize, max_exec_memory_bytes: usize) -> Self {
+impl DefaultMemoryLimiter {
+    pub fn new(max_memory_bytes: usize) -> Self {
         Self {
-            max_inst_memory_bytes,
-            max_exec_memory_bytes,
-            curr_exec_memory_bytes: 0,
+            max_memory_bytes,
+            curr_memory_bytes: 0,
         }
     }
 
     pub fn for_network(config: &NetworkConfig) -> Self {
-        Self::new(
-            config.max_inst_memory_bytes as usize,
-            config.max_exec_memory_bytes as usize,
-        )
+        Self::new(config.max_memory_bytes as usize)
     }
 }
 
-impl ResourceLimiter for ExecResourceLimiter {
-    fn memory_growing(&mut self, current: usize, desired: usize, maximum: Option<usize>) -> bool {
-        if desired > min(self.max_inst_memory_bytes, maximum) {
+impl MemoryLimiter for DefaultMemoryLimiter {
+    fn memory_used(&self) -> usize {
+        self.curr_memory_bytes
+    }
+
+    fn grow_memory(&mut self, bytes: usize) -> bool {
+        let total_desired = self.curr_memory_bytes.saturating_add(bytes);
+
+        if total_desired > self.max_memory_bytes {
             return false;
         }
 
-        let delta_desired = desired.saturating_sub(current);
-        let total_desired = self.curr_exec_memory_bytes.saturating_add(delta_desired);
-
-        if total_desired > self.max_exec_memory_bytes {
-            return false;
-        }
-
-        self.curr_exec_memory_bytes = total_desired;
+        self.curr_memory_bytes = total_desired;
         true
-    }
-
-    /// No limit on table elements.
-    fn table_growing(&mut self, _current: u32, desired: u32, maximum: Option<u32>) -> bool {
-        maximum.map_or(true, |m| desired <= m)
-    }
-}
-
-impl ExecMemory for ExecResourceLimiter {
-    fn curr_exec_memory_bytes(&self) -> usize {
-        self.curr_exec_memory_bytes
     }
 
     fn with_stack_frame<T, G, F, R>(t: &mut T, g: G, f: F) -> R
@@ -81,57 +74,54 @@ impl ExecMemory for ExecResourceLimiter {
         G: Fn(&mut T) -> &mut Self,
         F: FnOnce(&mut T) -> R,
     {
-        let memory_bytes = g(t).curr_exec_memory_bytes;
+        let memory_bytes = g(t).curr_memory_bytes;
         let ret = f(t);
         // This method is part of the trait so that a setter like this
         // doesn't have to be made public.
-        g(t).curr_exec_memory_bytes = memory_bytes;
+        g(t).curr_memory_bytes = memory_bytes;
         ret
     }
 }
 
-fn min(a: usize, b: Option<usize>) -> usize {
-    b.map_or(a, |b| std::cmp::min(a, b))
-}
-
 #[cfg(test)]
 mod tests {
-    use wasmtime::ResourceLimiter;
-
-    use super::ExecResourceLimiter;
-    use crate::machine::limiter::ExecMemory;
+    use super::DefaultMemoryLimiter;
+    use crate::machine::limiter::MemoryLimiter;
 
     #[test]
     fn basics() {
-        let mut limits = ExecResourceLimiter::new(4, 10);
-        assert!(limits.memory_growing(0, 3, None));
-        assert!(!limits.memory_growing(3, 4, Some(2))); // The maximum in the args takes precedence.
-        assert!(limits.memory_growing(3, 4, None)); // Ok, just at instance limit.
-        assert!(!limits.memory_growing(4, 5, None)); // Fail, over instance limit.
-        ExecResourceLimiter::with_stack_frame(
+        let mut limits = DefaultMemoryLimiter::new(4);
+        assert!(limits.grow_memory(3));
+        assert!(limits.grow_memory(1)); // Ok, just at memory limit.
+        assert!(!limits.grow_memory(1)); // Fail, over memory limit.
+
+        let mut limits = DefaultMemoryLimiter::new(6);
+        assert!(limits.grow_memory(1));
+        DefaultMemoryLimiter::with_stack_frame(
             &mut limits,
             |x| x,
             |limits| {
-                assert!(limits.memory_growing(0, 4, None)); // Ok, within instance limit.
-                ExecResourceLimiter::with_stack_frame(
+                assert!(limits.grow_memory(3)); // Ok, within memory limit.
+                DefaultMemoryLimiter::with_stack_frame(
                     limits,
                     |x| x,
                     |limits| {
-                        assert!(!limits.memory_growing(0, 3, None)); // Fail, 4+4+3 would be over the call stack limit of 10.
-                        assert!(limits.memory_growing(0, 2, None)); // Ok, just at the call stack limit (although we should used a seen a push as well.)
-                        assert_eq!(limits.curr_exec_memory_bytes(), 4 + 4 + 2);
+                        assert!(!limits.grow_memory(3)); // Fail, 1+3+3 would be over the limit of 6.
+                        assert!(limits.grow_memory(2)); // Ok, just at the call stack limit (although we should used a seen a push as well.)
+                        assert_eq!(limits.memory_used(), 1 + 3 + 2);
                     },
                 );
-                assert_eq!(limits.curr_exec_memory_bytes(), 4 + 4);
+                assert_eq!(limits.memory_used(), 4);
             },
         );
-        assert_eq!(limits.curr_exec_memory_bytes(), 4);
+        assert_eq!(limits.memory_used(), 1);
     }
 
     #[test]
     fn table() {
-        let mut limits = ExecResourceLimiter::new(1, 1);
-        assert!(limits.table_growing(0, 100, None));
-        assert!(!limits.table_growing(0, 100, Some(10)));
+        let mut limits = DefaultMemoryLimiter::new(10);
+        assert!(limits.grow_instance_table(0, 1)); // 8 bytes
+        assert!(limits.grow_memory(2)); // 2 bytes
+        assert!(!limits.grow_memory(1));
     }
 }

--- a/fvm/src/machine/limiter.rs
+++ b/fvm/src/machine/limiter.rs
@@ -5,11 +5,17 @@ use crate::machine::NetworkConfig;
 
 /// Execution level memory tracking and adjustment.
 pub trait MemoryLimiter: Sized {
-    /// Get a snapshot of the total memory required by the modules on the call stack so far.
+    /// Get a snapshot of the total memory required by the callstack (in bytes). This currently
+    /// includes:
+    ///
+    /// - Memory used by tables (8 bytes per element).
+    /// - Memory used by wasmtime instances.
+    ///
+    /// In the future, this will likely be extended to include IPLD blocks, actor code, etc.
     fn memory_used(&self) -> usize;
 
-    /// Returns `true` if growing by `bytes` is allowed. Implement this memory to track and limit
-    /// memory usage.
+    /// Returns `true` if growing by `delta` bytes is allowed. Implement this memory to track and
+    /// limit memory usage.
     fn grow_memory(&mut self, delta: usize) -> bool;
 
     /// Push a new frame onto the call stack, and keep tallying up the current execution memory,

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -9,7 +9,6 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::ActorID;
 use num_traits::Zero;
-use wasmtime::ResourceLimiter;
 
 use crate::externs::Externs;
 use crate::gas::{price_list_by_network_version, PriceList};
@@ -27,7 +26,7 @@ mod manifest;
 use fvm_shared::event::StampedEvent;
 pub use manifest::Manifest;
 
-use self::limiter::ExecMemory;
+use self::limiter::MemoryLimiter;
 
 mod boxed;
 
@@ -50,7 +49,7 @@ pub const BURNT_FUNDS_ACTOR_ID: ActorID = 99;
 pub trait Machine: 'static {
     type Blockstore: Blockstore;
     type Externs: Externs;
-    type Limiter: ResourceLimiter + ExecMemory;
+    type Limiter: MemoryLimiter;
 
     /// Returns a reference to the machine's blockstore.
     fn blockstore(&self) -> &Self::Blockstore;
@@ -125,10 +124,11 @@ pub struct NetworkConfig {
     /// DEFAULT: 512MiB
     pub max_inst_memory_bytes: u64,
 
-    /// Maximum size of memory used during the entire (recursive) message execution.
+    /// Maximum size of memory used during the entire (recursive) message execution. Includes blocks
+    /// and
     ///
     /// DEFAULT: 2GiB
-    pub max_exec_memory_bytes: u64,
+    pub max_memory_bytes: u64,
 
     /// An override for builtin-actors. If specified, this should be the CID of a builtin-actors
     /// "manifest".
@@ -159,7 +159,7 @@ impl NetworkConfig {
             max_call_depth: 1024,
             max_wasm_stack: 2048,
             max_inst_memory_bytes: 512 * (1 << 20),
-            max_exec_memory_bytes: 2 * (1 << 30),
+            max_memory_bytes: 2 * (1 << 30),
             actor_debugging: false,
             builtin_actors_override: None,
             price_list: price_list_by_network_version(network_version),

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -124,8 +124,9 @@ pub struct NetworkConfig {
     /// DEFAULT: 512MiB
     pub max_inst_memory_bytes: u64,
 
-    /// Maximum size of memory used during the entire (recursive) message execution. Includes blocks
-    /// and
+    /// Maximum size of memory used during the entire (recursive) message execution. This currently
+    /// includes Wasm memories and table elements and will eventually be extended to include IPLD
+    /// blocks and actor code.
     ///
     /// DEFAULT: 2GiB
     pub max_memory_bytes: u64,

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -9,7 +9,7 @@ use wasmtime::{AsContextMut, ExternType, Global, Linker, Memory, Module, Val};
 use crate::call_manager::backtrace;
 use crate::gas::{Gas, GasInstant, GasTimer};
 use crate::kernel::ExecutionError;
-use crate::machine::limiter::ExecMemory;
+use crate::machine::limiter::MemoryLimiter;
 use crate::Kernel;
 
 pub(crate) mod error;
@@ -104,7 +104,7 @@ pub fn charge_for_exec<K: Kernel>(
     let data = ctx.data_mut();
 
     // Separate the amount of gas charged for memory; this is only makes a difference in tracing.
-    let memory_bytes = data.kernel.limiter_mut().curr_exec_memory_bytes();
+    let memory_bytes = data.kernel.limiter_mut().memory_used();
     let memory_delta_bytes = memory_bytes.saturating_sub(data.last_memory_bytes);
     let memory_gas = data.kernel.price_list().grow_memory_gas(memory_delta_bytes);
 

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -329,7 +329,7 @@ fn native_stack_overflow() {
             DummyExterns,
             |nc| {
                 // The stack overflow test consumed the default 512MiB before it hit the recursion limit.
-                nc.max_exec_memory_bytes = 4 * (1 << 30);
+                nc.max_memory_bytes = 4 * (1 << 30);
                 nc.max_inst_memory_bytes = 4 * (1 << 30);
             },
             |_| (),


### PR DESCRIPTION
Motivation:

1. Explicitly limit table memory. We shouldn't be growing tables, but it's nice to have this check in place.
2. Pave the way for explicitly limiting block memory. We still need to _benchmark_ maximum blockstore memory before we can actually enable a limit, but I'd like to get _a_ limit into M2.1 if possible (instead of relying on gas).

Changes:

First, this refactors memory limits to remove the per-instance limits from the limiter itself (this is enforced by wasmtime) and instead track a global/shared "memory" limit. It then applies this to tables.

Second, this patch removes wasmtime interfaces from the limiter, instead implementing a wrapper to adapt to wasmtime's expected interface. I generally try to avoid exposing wasmtime types.

Finally, this fixes a small bug in the test limiter's minimum memory tracking (to correctly track the minimum non-zero amount allocated by any instance). This patch also tracks the minimum/maximum _table_ sizes.