### PR TITLE
feat: fix block read charges

### DIFF
--- a/fvm/src/gas/charge.rs
+++ b/fvm/src/gas/charge.rs
@@ -20,6 +20,7 @@ pub struct GasCharge {
     /// 1. Storage gas.
     /// 2. Memory retention.
     /// 3. Deferred computation (e.g., flushing blocks.)
+    /// 4. Extern costs.
     ///
     /// This is split into a separate field to facilitate benchmarking.
     pub other_gas: Gas,


### PR DESCRIPTION
This change makes the block "read" charge more accurate.

It also moves all the "extern" charges to the "other" gas field so we can keep benchmarking locally. In the future, we'll likely want four fields to split this into multiple fields, but not now.

part of #1264