### PR TITLE
KAMT: fix serialization/deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,7 +2791,6 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_encoding 0.3.2",
  "hex",
- "libipld-core 0.15.0",
  "multihash 0.16.3",
  "once_cell",
  "quickcheck",

--- a/ipld/kamt/Cargo.toml
+++ b/ipld/kamt/Cargo.toml
@@ -17,7 +17,6 @@ sha2 = "0.10"
 once_cell = "1.5"
 forest_hash_utils = "0.1"
 anyhow = "1.0.51"
-libipld-core = { version = "0.15.0", features = ["serde-codec"] }
 fvm_ipld_encoding = { version = "0.3", path = "../encoding" }
 fvm_ipld_blockstore = { version = "0.1", path = "../blockstore" }
 

--- a/ipld/kamt/src/ext.rs
+++ b/ipld/kamt/src/ext.rs
@@ -4,8 +4,6 @@
 
 use std::cmp::min;
 
-use serde::{Deserialize, Serialize};
-
 use crate::hash_bits::{mkmask, HashBits};
 use crate::{Error, HashedKey};
 
@@ -14,7 +12,7 @@ use crate::{Error, HashedKey};
 /// the tree being very deep, with most but the deepest being empty. The
 /// extension allows a `Pointer::Link` to skip empty levels and point straight
 /// to the next non-empty `Node`.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub(crate) struct Extension {
     /// The length (in bits) of the extension between the `Node` containing the `Link`
     /// and the node the `Link` is pointing to. It might be less than the length of the
@@ -43,6 +41,10 @@ impl Extension {
 
     pub fn path_bits(&self) -> HashBits {
         HashBits::new_from_slice(&self.path, self.length)
+    }
+
+    pub fn path_bytes(&self) -> &[u8] {
+        &self.path
     }
 
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
We were using the "struct" (json-like) representation instead of the tuple representation, and we were encoding the extension as a list of bytes (numbers) instead of as a byte-string.

This version:

1. Simplifies the serialization/deserialization logic. We had all the IPLD stuff to because we didn't have a tag. Now that we have a tag, we can use CBOR's built-in support for it.
2. Encodes links as a single tuple of CID, length, and pointer.

Unfortunately, it I couldn't find a simple way to _entirely_ rely on the deriving logic, but I've made it do most of the work.

I'm inlining the extension into the link to save a byte in the encoding.

fixes #1356