### PR TITLE
feat: rewrite the state snapshot system to have O(1) lookups

### DIFF
--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -47,7 +47,10 @@ pub struct StateTree<S> {
     read_only_layers: u32,
 }
 
-/// A map with an "undo" history. All inserts into this map
+/// A map with an "undo" history. All changes to this map are recorded in the history and can be "reverted" by calling `rollback`. Specifically:
+///
+/// 1. The user can call `history_len` to record the current history length.
+/// 2. The user can _later_ call `rollback(previous_length)` to rollback to the state in step 1.
 struct HistoryMap<K, V> {
     map: HashMap<K, V>,
     history: Vec<(K, Option<V>)>,


### PR DESCRIPTION
Instead of keeping true state "layers", we now keep an undo history.

1. When opening a new transaction, we record the current undo history height for both the resolve and state cache.
2. On abort, we walk the undo history backwards, undoing any changes.

This is `O(changes)` on revert, but that's fine. The cost of a potential revert can be charged when the change is made in the first place.

This is strictly better than the current situation where we spend `O(changes)` on every commit, which turns into `O(changes * call_depth)`.

Specifically:

1. Commits are O(1).
2. Actor Insertions/Deletions are O(1).
3. Actor address/state are O(1).
4. Reverts are O(N) in the amount of history being reverted.

I've also removed the `StateSnapshots` abstraction as it was just getting in the way.

fixes #1343