### PR TITLE
Audit fixes

### DIFF
--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -142,6 +142,6 @@ pub fn balance_of(context: Context<'_, impl Kernel>, actor_id: u64) -> Result<sy
     let balance = context.kernel.balance_of(actor_id)?;
     balance
         .try_into()
-        .context("base-fee exceeds u128 limit")
+        .context("balance exceeds u128 limit")
         .or_fatal()
 }

--- a/sdk/src/actor.rs
+++ b/sdk/src/actor.rs
@@ -143,12 +143,11 @@ pub fn get_code_cid_for_type(typ: i32) -> Cid {
     }
 }
 
-/// Retrieves the balance of the specified actor, or None if the actor doesn't exist.
+/// Retrieves the balance of the specified actor, zero if the actor doesn't exist.
 pub fn balance_of(actor_id: ActorID) -> Option<TokenAmount> {
     unsafe {
         match sys::actor::balance_of(actor_id) {
             Ok(balance) => Some(balance.into()),
-            Err(ErrorNumber::NotFound) => None,
             Err(e) => panic!("unexpected error: {e}"),
         }
     }


### PR DESCRIPTION
From auditing syscalls found a typo and a mismatch between sdk and kernel semantics on a non existent actor when calling balance_of