### PR TITLE
fix: return NotFound from balance_of

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -872,17 +872,14 @@ where
             .call_manager
             .charge_gas(self.call_manager.price_list().on_balance_of())?;
 
-        let balance = t
-            .record(
-                self.call_manager
-                    .state_tree()
-                    .get_actor(actor_id)
-                    .context("cannot find actor"),
-            )?
-            .map(|a| a.balance)
-            .unwrap_or_default();
-
-        Ok(balance)
+        t.record(
+            self.call_manager
+                .state_tree()
+                .get_actor(actor_id)?
+                .context("actor not found")
+                .or_error(ErrorNumber::NotFound)
+                .map(|a| a.balance),
+        )
     }
 
     fn lookup_delegated_address(&self, actor_id: ActorID) -> Result<Option<Address>> {

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -142,6 +142,6 @@ pub fn balance_of(context: Context<'_, impl Kernel>, actor_id: u64) -> Result<sy
     let balance = context.kernel.balance_of(actor_id)?;
     balance
         .try_into()
-        .context("base-fee exceeds u128 limit")
+        .context("balance exceeds u128 limit")
         .or_fatal()
 }

--- a/sdk/src/sys/actor.rs
+++ b/sdk/src/sys/actor.rs
@@ -133,6 +133,17 @@ super::fvm_syscalls! {
     #[cfg(feature = "m2-native")]
     pub fn install_actor(cid_off: *const u8) -> Result<()>;
 
+    /// Gets the balance of the specified actor.
+    ///
+    /// # Arguments
+    ///
+    /// - `actor_id` is the ID of the target actor.
+    ///
+    /// # Errors
+    ///
+    /// | Error                | Reason                                         |
+    /// |----------------------|------------------------------------------------|
+    /// | [`NotFound`]         | the target actor does not exist                |
     pub fn balance_of(
         actor_id: u64
     )  -> Result<super::TokenAmount>;

--- a/testing/integration/tests/fil-syscall-actor/src/actor.rs
+++ b/testing/integration/tests/fil-syscall-actor/src/actor.rs
@@ -39,6 +39,7 @@ pub fn invoke(_: u32) -> u32 {
     test_create_actor();
     test_network_context();
     test_message_context();
+    test_balance();
 
     #[cfg(coverage)]
     sdk::debug::store_artifact("syscall_actor.profraw", minicov::capture_coverage());
@@ -235,4 +236,15 @@ fn test_message_context() {
     assert_eq!(sdk::message::method_number(), 1);
     assert!(sdk::message::value_received().is_zero());
     assert!(sdk::message::gas_premium().is_zero());
+}
+
+fn test_balance() {
+    // Getting the balance of a non-existent actor should return None.
+    assert_eq!(sdk::actor::balance_of(9191919), None);
+
+    // Our balance should match.
+    assert_eq!(
+        sdk::actor::balance_of(sdk::message::receiver()),
+        Some(sdk::sself::current_balance())
+    );
 }


### PR DESCRIPTION
The second half of #949. Found by @ZenGround0 in #1378

fixes #1378