### PR TITLE
[v2] Add a Log execution event, created with the log syscall

### DIFF
--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -17,7 +17,7 @@ mod default;
 
 pub use default::DefaultCallManager;
 
-use crate::trace::ExecutionTrace;
+use crate::trace::{ExecutionEvent, ExecutionTrace};
 
 /// BlockID representing nil parameters or return data.
 pub const NO_DATA_BLOCK_ID: u32 = 0;
@@ -121,6 +121,14 @@ pub trait CallManager: 'static {
         self.gas_tracker_mut().apply_charge(charge)?;
         Ok(())
     }
+
+    /// Whether tracing is requested.
+    fn tracing(&self) -> bool {
+        self.machine().context().tracing
+    }
+
+    /// Records an execution trace event.
+    fn trace(&mut self, event: ExecutionEvent);
 }
 
 /// The result of a method invocation.

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -31,6 +31,7 @@ use crate::call_manager::{CallManager, InvocationResult, NO_DATA_BLOCK_ID};
 use crate::externs::{Consensus, Rand};
 use crate::gas::GasCharge;
 use crate::state_tree::ActorState;
+use crate::trace::ExecutionEvent;
 use crate::{syscall_error, EMPTY_ARR_CID};
 
 lazy_static! {
@@ -799,8 +800,11 @@ impl<C> DebugOps for DefaultKernel<C>
 where
     C: CallManager,
 {
-    fn log(&self, msg: String) {
-        println!("{}", msg)
+    fn log(&mut self, msg: String) {
+        println!("{}", &msg);
+        if self.call_manager.tracing() {
+            self.call_manager.trace(ExecutionEvent::Log(msg));
+        }
     }
 
     fn debug_enabled(&self) -> bool {

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -329,7 +329,7 @@ pub trait RandomnessOps {
 /// Debugging APIs.
 pub trait DebugOps {
     /// Log a message.
-    fn log(&self, msg: String);
+    fn log(&mut self, msg: String);
 
     /// Returns whether debug mode is enabled.
     fn debug_enabled(&self) -> bool;

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -27,4 +27,5 @@ pub enum ExecutionEvent {
     CallReturn(RawBytes),
     CallAbort(ExitCode),
     CallError(SyscallError),
+    Log(String),
 }

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -8,6 +8,7 @@ use fvm::externs::{Consensus, Externs, Rand};
 use fvm::gas::{Gas, GasCharge, GasTracker};
 use fvm::machine::{Engine, Machine, MachineContext, Manifest, NetworkConfig};
 use fvm::state_tree::{ActorState, StateTree};
+use fvm::trace::ExecutionEvent;
 use fvm::{kernel, Kernel};
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::CborStore;
@@ -297,4 +298,10 @@ impl CallManager for DummyCallManager {
     fn invocation_count(&self) -> u64 {
         todo!()
     }
+
+    fn tracing(&self) -> bool {
+        false
+    }
+
+    fn trace(&mut self, _event: ExecutionEvent) {}
 }

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -10,6 +10,7 @@ use fvm::machine::{
     DefaultMachine, Engine, Machine, MachineContext, Manifest, MultiEngine, NetworkConfig,
 };
 use fvm::state_tree::{ActorState, StateTree};
+use fvm::trace::ExecutionEvent;
 use fvm::DefaultKernel;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_car::load_car_unchecked;
@@ -284,6 +285,8 @@ where
     fn invocation_count(&self) -> u64 {
         self.0.invocation_count()
     }
+
+    fn trace(&mut self, _event: ExecutionEvent) {}
 }
 
 /// A kernel for intercepting syscalls.
@@ -496,7 +499,7 @@ where
     C: CallManager<Machine = TestMachine<M>>,
     K: Kernel<CallManager = TestCallManager<C>>,
 {
-    fn log(&self, msg: String) {
+    fn log(&mut self, msg: String) {
         self.0.log(msg)
     }
 


### PR DESCRIPTION
I am attempting to improve instrumentation to support analysis of gas charges across spans of code. See #1397.

This PR adds a `Log` execution event to the trace format. A log event is recorded when the `log` syscall is invoked. The log event carries a single `String` message.

A string is the most basic payload to carry here, so I think the right place to start. Some structure may be encoded into strings (for subsequent offline analysis). We could consider adding some kind of key/value pair metadata, but I suggest we defer until observed usage justifies it.

Note that the GasCharge event's `name` is a `Cow<'static, str>`. I presume this is because the same literal name is expected to be used frequently and this type will lead to meaningful optimisation. I'm not sure that that's appropriate for the `Log` event, if it would rule out dynamically constructed messages.

This PR is against the `release/v2` branch, because I am analysing the built-in actors that are not yet using fvm v3. I intend to forward-port it when stable.