### PR TITLE
feat: change the recursive call limit to 1024

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -712,20 +712,7 @@ where
     where
         F: FnOnce(&mut Self) -> Result<V>,
     {
-        // We check _then_ set because we don't count the top call. This effectively allows a
-        // call-stack depth of `max_call_depth + 1` (or `max_call_depth` sub-calls). While this is
-        // likely a bug, this is how NV15 behaves so we mimic that behavior here.
-        //
-        // By example:
-        //
-        // 1. If the max depth is 0, call_stack_depth will be 1 and the top-level message won't be
-        //    able to make sub-calls (1 > 0).
-        // 2. If the max depth is 1, the call_stack_depth will be 1 in the top-level message, 2 in
-        //    sub-calls, and said sub-calls will not be able to make further subcalls (2 > 1).
-        //
-        // NOTE: Unlike the FVM, Lotus adds _then_ checks. It does this because the
-        // `call_stack_depth` in lotus is 0 for the top-level call, unlike in the FVM where it's 1.
-        if self.call_stack_depth > self.machine.context().max_call_depth {
+        if self.call_stack_depth >= self.machine.context().max_call_depth {
             let sys_err = syscall_error!(LimitExceeded, "message execution exceeds call depth");
             if self.machine.context().tracing {
                 self.trace(ExecutionEvent::CallError(sys_err.clone()));

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -15,7 +15,7 @@ pub enum Never {}
 
 unsafe impl SyscallSafe for Never {}
 
-/// The maximum message length included in the backtrace. Given 1025 levels, this gives us a total
+/// The maximum message length included in the backtrace. Given 1024 levels, this gives us a total
 /// maximum of around 1MiB for debugging.
 const MAX_MESSAGE_LEN: usize = 1024;
 

--- a/testing/integration/tests/fil-stack-overflow-actor/src/actor.rs
+++ b/testing/integration/tests/fil-stack-overflow-actor/src/actor.rs
@@ -11,7 +11,7 @@ pub fn invoke(_: u32) -> u32 {
     let m = sdk::message::method_number();
     // If we start with method 1, we'll be over recursive send limit, starting
     // with method 2 should be fine
-    if m > 1026 {
+    if m > 1025 {
         sdk::vm::abort(0x42, None);
     }
 


### PR DESCRIPTION
This was always supposed to be 1024, but became 1025 due to a bug in the implementation (before network launch). We're taking this opportunity to fix this long-standing bug as we change other system limits to bring them in-line with other VMs like the EVM.

(i.e., this will require a one-line comment in the FIP, so we might as well do it right now).