### PR TITLE
feat: adjust memory retention fee

### DIFF
--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -424,10 +424,11 @@ pub struct PriceList {
     /// Gas cost per byte allocated (computation cost).
     pub(crate) block_allocate: ScalingCost,
 
-    /// Gas cost for every block retained in memory (read and/or written) to ensure we can't retain
-    /// more than 1GiB of memory while executing a block.
+    /// Minimum gas cost for every block retained in memory (read and/or written) to ensure we can't
+    /// retain more than 1GiB of memory while executing a block.
     ///
-    /// This is applied along with `block_allocate` but kept separate so we can benchmark properly.
+    /// This is just a _minimum_. The final per-byte charge of retaining a block is:
+    /// `min(block_memory_retention.scale, compute_costs)`.
     pub(crate) block_memory_retention: ScalingCost,
 
     /// Gas cost for opening a block.

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -217,7 +217,7 @@ lazy_static! {
             scale: Gas::from_milligas(400),
         },
 
-        block_memory_retention: ScalingCost {
+        block_memory_retention_minimum: ScalingCost {
             flat: Gas::zero(),
             scale: Gas::new(10),
         },
@@ -429,7 +429,7 @@ pub struct PriceList {
     ///
     /// This is just a _minimum_. The final per-byte charge of retaining a block is:
     /// `min(block_memory_retention.scale, compute_costs)`.
-    pub(crate) block_memory_retention: ScalingCost,
+    pub(crate) block_memory_retention_minimum: ScalingCost,
 
     /// Gas cost for opening a block.
     pub(crate) block_open: ScalingCost,
@@ -720,7 +720,7 @@ impl PriceList {
         let block_open = self.block_open.scale * data_size;
 
         // But we need to make sure we charge at least the memory retention cost.
-        let retention_min = self.block_memory_retention.apply(data_size);
+        let retention_min = self.block_memory_retention_minimum.apply(data_size);
         let retention_surcharge = (retention_min - (compute + block_open)).max(Gas::zero());
         GasCharge::new(
             "OnBlockOpenPerByte",
@@ -747,7 +747,7 @@ impl PriceList {
         let compute = self.block_memcpy.apply(data_size) + self.block_allocate.apply(data_size);
 
         // But we need to make sure we charge at least the memory retention cost.
-        let retention_min = self.block_memory_retention.apply(data_size);
+        let retention_min = self.block_memory_retention_minimum.apply(data_size);
         let retention_surcharge = (retention_min - compute).max(Gas::zero());
 
         GasCharge::new("OnBlockCreate", compute, retention_surcharge)


### PR DESCRIPTION
TL;DR: This reduces read/write costs by 0.4.

The point of this fee is to charge at _least_ 10gas/byte. So that's what we now do. Instead of charging an additional fee, we:

1. Compute the actual per-byte "compute" fees.
2. Compute the minimum memory retention fee.
3. Apply a memory retention surcharge up to the minimum memory retention fee.

This seems complex, but the effect is simple: We're now charging 0.4 gas less per byte for reads and writes. I could have just reduced the memory retention cost by 0.4, but the new logic more accurately reflects our intentions with this fee.