### PR TITLE
deps: Update wasmtime to v4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -857,40 +857,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.88.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52056f6d0584484b57fa6c1a65c1fcb15f3780d8b6a758426d9e3084169b2ddd"
-dependencies = [
- "cranelift-entity 0.88.2",
-]
-
-[[package]]
-name = "cranelift-bforest"
 version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc952b310b24444fc14ab8b9cbe3fafd7e7329e3eec84c3a9b11d2b5cf6f3be1"
 dependencies = [
- "cranelift-entity 0.91.0",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.88.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fed94c8770dc25d01154c3ffa64ed0b3ba9d583736f305fed7beebe5d9cf74"
-dependencies = [
- "arrayvec 0.7.2",
- "bumpalo",
- "cranelift-bforest 0.88.2",
- "cranelift-codegen-meta 0.88.2",
- "cranelift-codegen-shared 0.88.2",
- "cranelift-entity 0.88.2",
- "cranelift-isle 0.88.2",
- "gimli 0.26.2",
- "log",
- "regalloc2 0.3.2",
- "smallvec",
- "target-lexicon",
+ "cranelift-entity",
 ]
 
 [[package]]
@@ -901,26 +872,17 @@ checksum = "e73470419b33011e50dbf0f6439cbccbaabe9381de172da4e1b6efcda4bb8fa7"
 dependencies = [
  "arrayvec 0.7.2",
  "bumpalo",
- "cranelift-bforest 0.91.0",
- "cranelift-codegen-meta 0.91.0",
- "cranelift-codegen-shared 0.91.0",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
  "cranelift-egraph",
- "cranelift-entity 0.91.0",
- "cranelift-isle 0.91.0",
+ "cranelift-entity",
+ "cranelift-isle",
  "gimli 0.26.2",
  "log",
- "regalloc2 0.5.1",
+ "regalloc2",
  "smallvec",
  "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.88.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c451b81faf237d11c7e4f3165eeb6bac61112762c5cfe7b4c0fb7241474358f"
-dependencies = [
- "cranelift-codegen-shared 0.88.2",
 ]
 
 [[package]]
@@ -929,14 +891,8 @@ version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911a1872464108a11ac9965c2b079e61bbdf1bc2e0b9001264264add2e12a38f"
 dependencies = [
- "cranelift-codegen-shared 0.91.0",
+ "cranelift-codegen-shared",
 ]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.88.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c940133198426d26128f08be2b40b0bd117b84771fd36798969c4d712d81fc"
 
 [[package]]
 name = "cranelift-codegen-shared"
@@ -950,21 +906,12 @@ version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6c623f4b5d2a6bad32c403f03765d4484a827eb93ee78f8cb6219ef118fd59"
 dependencies = [
- "cranelift-entity 0.91.0",
+ "cranelift-entity",
  "fxhash",
  "hashbrown",
  "indexmap",
  "log",
  "smallvec",
-]
-
-[[package]]
-name = "cranelift-entity"
-version = "0.88.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0f1b2fdc18776956370cf8d9b009ded3f855350c480c1c52142510961f352"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -978,33 +925,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.88.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34897538b36b216cc8dd324e73263596d51b8cf610da6498322838b2546baf8a"
-dependencies = [
- "cranelift-codegen 0.88.2",
- "log",
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-frontend"
 version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a4ac920422ee36bff2c66257fec861765e3d95a125cdf58d8c0f3bba7e40e61"
 dependencies = [
- "cranelift-codegen 0.91.0",
+ "cranelift-codegen",
  "log",
  "smallvec",
  "target-lexicon",
 ]
-
-[[package]]
-name = "cranelift-isle"
-version = "0.88.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2629a569fae540f16a76b70afcc87ad7decb38dc28fa6c648ac73b51e78470"
 
 [[package]]
 name = "cranelift-isle"
@@ -1014,40 +943,13 @@ checksum = "c541263fb37ad2baa53ec8c37218ee5d02fa0984670d9419dedd8002ea68ff08"
 
 [[package]]
 name = "cranelift-native"
-version = "0.88.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20937dab4e14d3e225c5adfc9c7106bafd4ac669bdb43027b911ff794c6fb318"
-dependencies = [
- "cranelift-codegen 0.88.2",
- "libc",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-native"
 version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de5d7a063e8563d670aaca38de16591a9b70dc66cbad4d49a7b4ae8395fd1ce"
 dependencies = [
- "cranelift-codegen 0.91.0",
+ "cranelift-codegen",
  "libc",
  "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-wasm"
-version = "0.88.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fc2288957a94fd342a015811479de1837850924166d1f1856d8406e6f3609b"
-dependencies = [
- "cranelift-codegen 0.88.2",
- "cranelift-entity 0.88.2",
- "cranelift-frontend 0.88.2",
- "itertools 0.10.5",
- "log",
- "smallvec",
- "wasmparser 0.89.1",
- "wasmtime-types 1.0.2",
 ]
 
 [[package]]
@@ -1056,14 +958,14 @@ version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc4dd03b713b5d71b582915b8c272f4813cdd8c99a3e03d9ba70c44468a6e0"
 dependencies = [
- "cranelift-codegen 0.91.0",
- "cranelift-entity 0.91.0",
- "cranelift-frontend 0.91.0",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
  "itertools 0.10.5",
  "log",
  "smallvec",
  "wasmparser 0.95.0",
- "wasmtime-types 4.0.0",
+ "wasmtime-types",
 ]
 
 [[package]]
@@ -1635,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_account"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "anyhow",
  "fil_actors_runtime",
@@ -1671,7 +1573,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_cron"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1686,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_datacap"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "cid 0.8.6",
  "fil_actors_runtime",
@@ -1707,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_ethaccount"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1721,7 +1623,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_evm"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.2",
@@ -1756,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_init"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1775,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_market"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1798,7 +1700,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_miner"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1823,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_multisig"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1844,7 +1746,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_paych"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1861,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_placeholder"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "fvm_sdk 3.0.0-alpha.19",
  "fvm_shared 3.0.0-alpha.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1870,7 +1772,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_power"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1892,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_reward"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1908,7 +1810,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_system"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1924,7 +1826,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_verifreg"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -1946,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1988,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "fil_builtin_actors_bundle"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#393d7daeb89fc54286daeb0cf5078fb01f4756d8"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c2182a9a73abd434e565ffb96bc9543dd3648fa7"
 dependencies = [
  "cid 0.8.6",
  "clap",
@@ -2495,9 +2397,9 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "thiserror",
- "wasmtime 4.0.0",
- "wasmtime-environ 1.0.2",
- "wasmtime-runtime 1.0.2",
+ "wasmtime",
+ "wasmtime-environ",
+ "wasmtime-runtime",
  "yastl",
 ]
 
@@ -2576,7 +2478,7 @@ dependencies = [
  "serde_tuple",
  "thiserror",
  "walkdir",
- "wasmtime 4.0.0",
+ "wasmtime",
 ]
 
 [[package]]
@@ -2607,7 +2509,7 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "thiserror",
- "wasmtime 1.0.2",
+ "wasmtime",
 ]
 
 [[package]]
@@ -2647,7 +2549,7 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "thiserror",
- "wasmtime 4.0.0",
+ "wasmtime",
  "wat",
 ]
 
@@ -3329,18 +3231,12 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
-
-[[package]]
-name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3536,12 +3432,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
@@ -3597,7 +3487,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
 dependencies = [
- "rustix 0.36.5",
+ "rustix",
 ]
 
 [[package]]
@@ -4097,7 +3987,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4317,18 +4207,6 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43a209257d978ef079f3d446331d0f1794f5e0fc19b306a199983857833a779"
-dependencies = [
- "fxhash",
- "log",
- "slice-group-by",
- "smallvec",
-]
-
-[[package]]
-name = "regalloc2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300d4fbfb40c1c66a78ba3ddd41c1110247cf52f97b87d0f2fc9209bd49b030c"
@@ -4464,30 +4342,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes 0.7.5",
- "libc",
- "linux-raw-sys 0.0.46",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 1.0.3",
+ "io-lifetimes",
  "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.42.0",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5302,15 +5166,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.89.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5d3e08b13876f96dd55608d03cd4883a0545884932d5adf11925876c96daef"
-dependencies = [
- "indexmap",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
@@ -5341,33 +5196,6 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad5af6ba38311282f2a21670d96e78266e8c8e2f38cbcd52c254df6ccbc7731"
-dependencies = [
- "anyhow",
- "bincode",
- "cfg-if 1.0.0",
- "indexmap",
- "libc",
- "log",
- "object 0.29.0",
- "once_cell",
- "paste",
- "psm",
- "rayon",
- "serde",
- "target-lexicon",
- "wasmparser 0.89.1",
- "wasmtime-cranelift 1.0.2",
- "wasmtime-environ 1.0.2",
- "wasmtime-jit 1.0.2",
- "wasmtime-runtime 1.0.2",
- "windows-sys 0.36.1",
-]
-
-[[package]]
-name = "wasmtime"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abddf11816dd8f5e7310f6ebe5a2503b43f20ab2bf050b7d63f5b1bb96a81d9"
@@ -5386,20 +5214,11 @@ dependencies = [
  "serde",
  "target-lexicon",
  "wasmparser 0.95.0",
- "wasmtime-cranelift 4.0.0",
- "wasmtime-environ 4.0.0",
- "wasmtime-jit 4.0.0",
- "wasmtime-runtime 4.0.0",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "wasmtime-asm-macros"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45de63ddfc8b9223d1adc8f7b2ee5f35d1f6d112833934ad7ea66e4f4339e597"
-dependencies = [
- "cfg-if 1.0.0",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-jit",
+ "wasmtime-runtime",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5413,63 +5232,23 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd91339b742ff20bfed4532a27b73c86b5bcbfedd6bea2dcdf2d64471e1b5c6"
-dependencies = [
- "anyhow",
- "cranelift-codegen 0.88.2",
- "cranelift-entity 0.88.2",
- "cranelift-frontend 0.88.2",
- "cranelift-native 0.88.2",
- "cranelift-wasm 0.88.2",
- "gimli 0.26.2",
- "log",
- "object 0.29.0",
- "target-lexicon",
- "thiserror",
- "wasmparser 0.89.1",
- "wasmtime-environ 1.0.2",
-]
-
-[[package]]
-name = "wasmtime-cranelift"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5bcb1d5ef211726b11e1286fe96cb40c69044c3632e1d6c67805d88a2e1a34"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.91.0",
- "cranelift-entity 0.91.0",
- "cranelift-frontend 0.91.0",
- "cranelift-native 0.91.0",
- "cranelift-wasm 0.91.0",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "cranelift-wasm",
  "gimli 0.26.2",
  "log",
  "object 0.29.0",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.95.0",
- "wasmtime-environ 4.0.0",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb881c61f4f627b5d45c54e629724974f8a8890d455bcbe634330cc27309644"
-dependencies = [
- "anyhow",
- "cranelift-entity 0.88.2",
- "gimli 0.26.2",
- "indexmap",
- "log",
- "object 0.29.0",
- "serde",
- "target-lexicon",
- "thiserror",
- "wasmparser 0.89.1",
- "wasmtime-types 1.0.2",
+ "wasmtime-environ",
 ]
 
 [[package]]
@@ -5479,7 +5258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcab3fac5a2ff68ce9857166a7d7c0e5251b554839b9dda7ed3b5528e191936e"
 dependencies = [
  "anyhow",
- "cranelift-entity 0.91.0",
+ "cranelift-entity",
  "gimli 0.26.2",
  "indexmap",
  "log",
@@ -5488,31 +5267,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmparser 0.95.0",
- "wasmtime-types 4.0.0",
-]
-
-[[package]]
-name = "wasmtime-jit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1985c628011fe26adf5e23a5301bdc79b245e0e338f14bb58b39e4e25e4d8681"
-dependencies = [
- "addr2line 0.17.0",
- "anyhow",
- "bincode",
- "cfg-if 1.0.0",
- "cpp_demangle",
- "gimli 0.26.2",
- "log",
- "object 0.29.0",
- "rustc-demangle",
- "rustix 0.35.13",
- "serde",
- "target-lexicon",
- "thiserror",
- "wasmtime-environ 1.0.2",
- "wasmtime-runtime 1.0.2",
- "windows-sys 0.36.1",
+ "wasmtime-types",
 ]
 
 [[package]]
@@ -5533,19 +5288,10 @@ dependencies = [
  "rustc-demangle",
  "serde",
  "target-lexicon",
- "wasmtime-environ 4.0.0",
+ "wasmtime-environ",
  "wasmtime-jit-icache-coherence",
- "wasmtime-runtime 4.0.0",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "wasmtime-jit-debug"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f671b588486f5ccec8c5a3dba6b4c07eac2e66ab8c60e6f4e53717c77f709731"
-dependencies = [
- "once_cell",
+ "wasmtime-runtime",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5565,31 +5311,7 @@ checksum = "22d9c2e92b0fc124d2cad6cb497a4c840580a7dd2414a37109e8c7cfe699c0ea"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "wasmtime-runtime"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8f92ad4b61736339c29361da85769ebc200f184361959d1792832e592a1afd"
-dependencies = [
- "anyhow",
- "cc",
- "cfg-if 1.0.0",
- "indexmap",
- "libc",
- "log",
- "mach",
- "memoffset 0.6.5",
- "paste",
- "rand",
- "rustix 0.35.13",
- "thiserror",
- "wasmtime-asm-macros 1.0.2",
- "wasmtime-environ 1.0.2",
- "wasmtime-jit-debug 1.0.2",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5609,23 +5331,11 @@ dependencies = [
  "memoffset 0.6.5",
  "paste",
  "rand",
- "rustix 0.36.5",
- "wasmtime-asm-macros 4.0.0",
- "wasmtime-environ 4.0.0",
- "wasmtime-jit-debug 4.0.0",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "wasmtime-types"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23d61cb4c46e837b431196dd06abb11731541021916d03476a178b54dc07aeb"
-dependencies = [
- "cranelift-entity 0.88.2",
- "serde",
- "thiserror",
- "wasmparser 0.89.1",
+ "rustix",
+ "wasmtime-asm-macros",
+ "wasmtime-environ",
+ "wasmtime-jit-debug",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5634,7 +5344,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f3d8ee409447cae51651fd812437a0047ed8d7f44e94171ee05ce7cb955c96"
 dependencies = [
- "cranelift-entity 0.91.0",
+ "cranelift-entity",
  "serde",
  "thiserror",
  "wasmparser 0.95.0",
@@ -5724,30 +5434,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -5758,21 +5455,9 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5782,21 +5467,9 @@ checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5809,12 +5482,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,16 @@ version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52056f6d0584484b57fa6c1a65c1fcb15f3780d8b6a758426d9e3084169b2ddd"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.88.2",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc952b310b24444fc14ab8b9cbe3fafd7e7329e3eec84c3a9b11d2b5cf6f3be1"
+dependencies = [
+ "cranelift-entity 0.91.0",
 ]
 
 [[package]]
@@ -872,14 +881,35 @@ checksum = "18fed94c8770dc25d01154c3ffa64ed0b3ba9d583736f305fed7beebe5d9cf74"
 dependencies = [
  "arrayvec 0.7.2",
  "bumpalo",
- "cranelift-bforest",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-entity",
- "cranelift-isle",
+ "cranelift-bforest 0.88.2",
+ "cranelift-codegen-meta 0.88.2",
+ "cranelift-codegen-shared 0.88.2",
+ "cranelift-entity 0.88.2",
+ "cranelift-isle 0.88.2",
  "gimli 0.26.2",
  "log",
- "regalloc2",
+ "regalloc2 0.3.2",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e73470419b33011e50dbf0f6439cbccbaabe9381de172da4e1b6efcda4bb8fa7"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bumpalo",
+ "cranelift-bforest 0.91.0",
+ "cranelift-codegen-meta 0.91.0",
+ "cranelift-codegen-shared 0.91.0",
+ "cranelift-egraph",
+ "cranelift-entity 0.91.0",
+ "cranelift-isle 0.91.0",
+ "gimli 0.26.2",
+ "log",
+ "regalloc2 0.5.1",
  "smallvec",
  "target-lexicon",
 ]
@@ -890,7 +920,16 @@ version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c451b81faf237d11c7e4f3165eeb6bac61112762c5cfe7b4c0fb7241474358f"
 dependencies = [
- "cranelift-codegen-shared",
+ "cranelift-codegen-shared 0.88.2",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911a1872464108a11ac9965c2b079e61bbdf1bc2e0b9001264264add2e12a38f"
+dependencies = [
+ "cranelift-codegen-shared 0.91.0",
 ]
 
 [[package]]
@@ -898,6 +937,26 @@ name = "cranelift-codegen-shared"
 version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c940133198426d26128f08be2b40b0bd117b84771fd36798969c4d712d81fc"
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e036f3f07adb24a86fb46e977e8fe03b18bb16b1eada949cf2c48283e5f8a862"
+
+[[package]]
+name = "cranelift-egraph"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6c623f4b5d2a6bad32c403f03765d4484a827eb93ee78f8cb6219ef118fd59"
+dependencies = [
+ "cranelift-entity 0.91.0",
+ "fxhash",
+ "hashbrown",
+ "indexmap",
+ "log",
+ "smallvec",
+]
 
 [[package]]
 name = "cranelift-entity"
@@ -909,12 +968,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-entity"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74385eb5e405b3562f0caa7bcc4ab9a93c7958dd5bcd0e910bffb7765eacd6fc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cranelift-frontend"
 version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34897538b36b216cc8dd324e73263596d51b8cf610da6498322838b2546baf8a"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.88.2",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a4ac920422ee36bff2c66257fec861765e3d95a125cdf58d8c0f3bba7e40e61"
+dependencies = [
+ "cranelift-codegen 0.91.0",
  "log",
  "smallvec",
  "target-lexicon",
@@ -927,12 +1007,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b2629a569fae540f16a76b70afcc87ad7decb38dc28fa6c648ac73b51e78470"
 
 [[package]]
+name = "cranelift-isle"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c541263fb37ad2baa53ec8c37218ee5d02fa0984670d9419dedd8002ea68ff08"
+
+[[package]]
 name = "cranelift-native"
 version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20937dab4e14d3e225c5adfc9c7106bafd4ac669bdb43027b911ff794c6fb318"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.88.2",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de5d7a063e8563d670aaca38de16591a9b70dc66cbad4d49a7b4ae8395fd1ce"
+dependencies = [
+ "cranelift-codegen 0.91.0",
  "libc",
  "target-lexicon",
 ]
@@ -943,14 +1040,30 @@ version = "0.88.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80fc2288957a94fd342a015811479de1837850924166d1f1856d8406e6f3609b"
 dependencies = [
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-frontend",
+ "cranelift-codegen 0.88.2",
+ "cranelift-entity 0.88.2",
+ "cranelift-frontend 0.88.2",
  "itertools 0.10.5",
  "log",
  "smallvec",
  "wasmparser 0.89.1",
- "wasmtime-types",
+ "wasmtime-types 1.0.2",
+]
+
+[[package]]
+name = "cranelift-wasm"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc4dd03b713b5d71b582915b8c272f4813cdd8c99a3e03d9ba70c44468a6e0"
+dependencies = [
+ "cranelift-codegen 0.91.0",
+ "cranelift-entity 0.91.0",
+ "cranelift-frontend 0.91.0",
+ "itertools 0.10.5",
+ "log",
+ "smallvec",
+ "wasmparser 0.95.0",
+ "wasmtime-types 4.0.0",
 ]
 
 [[package]]
@@ -2382,9 +2495,9 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "thiserror",
- "wasmtime",
- "wasmtime-environ",
- "wasmtime-runtime",
+ "wasmtime 4.0.0",
+ "wasmtime-environ 1.0.2",
+ "wasmtime-runtime 1.0.2",
  "yastl",
 ]
 
@@ -2463,7 +2576,7 @@ dependencies = [
  "serde_tuple",
  "thiserror",
  "walkdir",
- "wasmtime",
+ "wasmtime 4.0.0",
 ]
 
 [[package]]
@@ -2494,7 +2607,7 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "thiserror",
- "wasmtime",
+ "wasmtime 1.0.2",
 ]
 
 [[package]]
@@ -2534,7 +2647,7 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "thiserror",
- "wasmtime",
+ "wasmtime 4.0.0",
  "wat",
 ]
 
@@ -4215,6 +4328,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300d4fbfb40c1c66a78ba3ddd41c1110247cf52f97b87d0f2fc9209bd49b030c"
+dependencies = [
+ "fxhash",
+ "log",
+ "slice-group-by",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5234,11 +5359,38 @@ dependencies = [
  "serde",
  "target-lexicon",
  "wasmparser 0.89.1",
- "wasmtime-cranelift",
- "wasmtime-environ",
- "wasmtime-jit",
- "wasmtime-runtime",
+ "wasmtime-cranelift 1.0.2",
+ "wasmtime-environ 1.0.2",
+ "wasmtime-jit 1.0.2",
+ "wasmtime-runtime 1.0.2",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "wasmtime"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4abddf11816dd8f5e7310f6ebe5a2503b43f20ab2bf050b7d63f5b1bb96a81d9"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "cfg-if 1.0.0",
+ "indexmap",
+ "libc",
+ "log",
+ "object 0.29.0",
+ "once_cell",
+ "paste",
+ "psm",
+ "rayon",
+ "serde",
+ "target-lexicon",
+ "wasmparser 0.95.0",
+ "wasmtime-cranelift 4.0.0",
+ "wasmtime-environ 4.0.0",
+ "wasmtime-jit 4.0.0",
+ "wasmtime-runtime 4.0.0",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5251,24 +5403,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-asm-macros"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f5206486f0467ba86e84d35996c4048b077cec2c9e5b322e7b853bdbe79334"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "wasmtime-cranelift"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bd91339b742ff20bfed4532a27b73c86b5bcbfedd6bea2dcdf2d64471e1b5c6"
 dependencies = [
  "anyhow",
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "cranelift-wasm",
+ "cranelift-codegen 0.88.2",
+ "cranelift-entity 0.88.2",
+ "cranelift-frontend 0.88.2",
+ "cranelift-native 0.88.2",
+ "cranelift-wasm 0.88.2",
  "gimli 0.26.2",
  "log",
  "object 0.29.0",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.89.1",
- "wasmtime-environ",
+ "wasmtime-environ 1.0.2",
+]
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5bcb1d5ef211726b11e1286fe96cb40c69044c3632e1d6c67805d88a2e1a34"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen 0.91.0",
+ "cranelift-entity 0.91.0",
+ "cranelift-frontend 0.91.0",
+ "cranelift-native 0.91.0",
+ "cranelift-wasm 0.91.0",
+ "gimli 0.26.2",
+ "log",
+ "object 0.29.0",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.95.0",
+ "wasmtime-environ 4.0.0",
 ]
 
 [[package]]
@@ -5278,7 +5460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebb881c61f4f627b5d45c54e629724974f8a8890d455bcbe634330cc27309644"
 dependencies = [
  "anyhow",
- "cranelift-entity",
+ "cranelift-entity 0.88.2",
  "gimli 0.26.2",
  "indexmap",
  "log",
@@ -5287,7 +5469,26 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmparser 0.89.1",
- "wasmtime-types",
+ "wasmtime-types 1.0.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcab3fac5a2ff68ce9857166a7d7c0e5251b554839b9dda7ed3b5528e191936e"
+dependencies = [
+ "anyhow",
+ "cranelift-entity 0.91.0",
+ "gimli 0.26.2",
+ "indexmap",
+ "log",
+ "object 0.29.0",
+ "serde",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.95.0",
+ "wasmtime-types 4.0.0",
 ]
 
 [[package]]
@@ -5302,7 +5503,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpp_demangle",
  "gimli 0.26.2",
- "ittapi",
  "log",
  "object 0.29.0",
  "rustc-demangle",
@@ -5310,9 +5510,33 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmtime-environ",
- "wasmtime-runtime",
+ "wasmtime-environ 1.0.2",
+ "wasmtime-runtime 1.0.2",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "wasmtime-jit"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d866e2a84ee164739b7ed7bd7cc9e1f918639d2ec5e2817a31e24c148cab20"
+dependencies = [
+ "addr2line 0.17.0",
+ "anyhow",
+ "bincode",
+ "cfg-if 1.0.0",
+ "cpp_demangle",
+ "gimli 0.26.2",
+ "ittapi",
+ "log",
+ "object 0.29.0",
+ "rustc-demangle",
+ "serde",
+ "target-lexicon",
+ "wasmtime-environ 4.0.0",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-runtime 4.0.0",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5322,6 +5546,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f671b588486f5ccec8c5a3dba6b4c07eac2e66ab8c60e6f4e53717c77f709731"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "wasmtime-jit-debug"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0104c2b1ce443f2a2806216fcdf6dce09303203ec5797a698d313063b31e5bc8"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22d9c2e92b0fc124d2cad6cb497a4c840580a7dd2414a37109e8c7cfe699c0ea"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5337,16 +5581,39 @@ dependencies = [
  "libc",
  "log",
  "mach",
- "memfd",
  "memoffset 0.6.5",
  "paste",
  "rand",
  "rustix 0.35.13",
  "thiserror",
- "wasmtime-asm-macros",
- "wasmtime-environ",
- "wasmtime-jit-debug",
+ "wasmtime-asm-macros 1.0.2",
+ "wasmtime-environ 1.0.2",
+ "wasmtime-jit-debug 1.0.2",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "wasmtime-runtime"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1f0f99297a94cb20c511d1d4e864d9b54794644016d2530dc797cacfa7224a"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if 1.0.0",
+ "indexmap",
+ "libc",
+ "log",
+ "mach",
+ "memfd",
+ "memoffset 0.6.5",
+ "paste",
+ "rand",
+ "rustix 0.36.5",
+ "wasmtime-asm-macros 4.0.0",
+ "wasmtime-environ 4.0.0",
+ "wasmtime-jit-debug 4.0.0",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5355,10 +5622,22 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d23d61cb4c46e837b431196dd06abb11731541021916d03476a178b54dc07aeb"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.88.2",
  "serde",
  "thiserror",
  "wasmparser 0.89.1",
+]
+
+[[package]]
+name = "wasmtime-types"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f3d8ee409447cae51651fd812437a0047ed8d7f44e94171ee05ce7cb955c96"
+dependencies = [
+ "cranelift-entity 0.91.0",
+ "serde",
+ "thiserror",
+ "wasmparser 0.95.0",
 ]
 
 [[package]]

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -55,10 +55,10 @@ default-features = false
 features = ["cranelift", "pooling-allocator", "parallel-compilation"]
 
 [dependencies.wasmtime-environ]
-version = "1.0.2"
+version = "4.0.0"
 
 [dependencies.wasmtime-runtime]
-version = "1.0.1"
+version = "4.0.0"
 default-features = false
 
 [features]

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -50,9 +50,9 @@ pretty_assertions = "1.2.1"
 fvm = { path = ".", features = ["testing"], default-features = false }
 
 [dependencies.wasmtime]
-version = "1.0.2"
+version = "4.0.0"
 default-features = false
-features = ["cranelift", "pooling-allocator", "parallel-compilation", "memory-init-cow"]
+features = ["cranelift", "pooling-allocator", "parallel-compilation"]
 
 [dependencies.wasmtime-environ]
 version = "1.0.2"

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -596,11 +596,7 @@ where
                 // detected it and returned OutOfGas above. Any other invocation failure is returned
                 // here as an Abort
 
-                Ok(res.map_err(|e: anyhow::Error|match e.anyhow_kind() {
-                    // translate  anyhow error we get into an abort
-                    wasmtime::Trap => e,
-                    Abort => e,
-                })?)
+                Ok(res?)
             })();
 
             let invocation_data = store.into_data();

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -535,35 +535,14 @@ where
 
             // From this point on, there are no more syscall errors, only aborts.
             let result: std::result::Result<BlockId, Abort> = (|| {
-                use wasmtime_runtime::InstantiationError;
                 // Instantiate the module.
                 let instance = engine
                     .get_instance(&mut store, &state.code)
                     .and_then(|i| i.context("actor code not found"))
-                    .map_err(|e| match e.downcast::<InstantiationError>() {
-                        Ok(e) => match e {
-                            // This will be handled in validation.
-                            InstantiationError::Link(e) => Abort::Fatal(anyhow!(e)),
-                            // TODO: We may want a separate OOM exit code? However, normal ooms will usually exit with SYS_ILLEGAL_INSTRUCTION.
-                            InstantiationError::Resource(e) => Abort::Exit(
-                                ExitCode::SYS_ILLEGAL_INSTRUCTION,
-                                e.to_string(),
-                                NO_DATA_BLOCK_ID,
-                            ),
-                            // TODO: we probably shouldn't hit this unless we're running code? We
-                            // should check if we can "validate away" this case.
-                            InstantiationError::Trap(e) => Abort::Exit(
-                                ExitCode::SYS_ILLEGAL_INSTRUCTION,
-                                format!("actor initialization failed: {:?}", e),
-                                0,
-                            ),
-                            // TODO: Consider using the instance limit instead of an explicit stack depth?
-                            InstantiationError::Limit(limit) => Abort::Fatal(anyhow!(
-                                "did not expect to hit wasmtime instance limit: {}",
-                                limit
-                            )),
-                        },
-                        Err(e) => Abort::Fatal(e),
+                    .map_err(|e| {
+                        // todo try to distinguish resource limit / trap / fatal
+                        log::error!("failed to instantiate actor: {:?}", e);
+                        Abort::Fatal(e)
                     })?;
 
                 // Resolve and store a reference to the exported memory.

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -595,7 +595,12 @@ where
                 // If the invocation failed due to running out of exec_units, we have already
                 // detected it and returned OutOfGas above. Any other invocation failure is returned
                 // here as an Abort
-                Ok(res?)
+
+                Ok(res.map_err(|e: anyhow::Error|match e.anyhow_kind() {
+                    // translate  anyhow error we get into an abort
+                    wasmtime::Trap => e,
+                    Abort => e,
+                })?)
             })();
 
             let invocation_data = store.into_data();

--- a/fvm/src/engine.rs
+++ b/fvm/src/engine.rs
@@ -171,13 +171,15 @@ fn wasmtime_config(ec: &EngineConfig) -> anyhow::Result<wasmtime::Config> {
     c.generate_address_map(false);
     c.cranelift_debug_verifier(false);
     c.native_unwind_info(false);
-    #[allow(deprecated)] // TODO https://github.com/bytecodealliance/wasmtime/issues/5037
-    c.wasm_backtrace(false);
     c.wasm_reference_types(false);
 
     // Reiterate some defaults
     c.guard_before_linear_memory(true);
     c.parallel_compilation(true);
+
+    #[allow(deprecated)] // TODO https://github.com/bytecodealliance/wasmtime/issues/5037
+    // has to be enabled, otherwise returning errors from syscalls will not work
+    c.wasm_backtrace(true);
 
     #[cfg(feature = "wasmtime/async")]
     c.async_support(false);

--- a/fvm/src/engine.rs
+++ b/fvm/src/engine.rs
@@ -11,7 +11,10 @@ use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_wasm_instrument::gas_metering::GAS_COUNTER_NAME;
 use wasmtime::OptLevel::Speed;
-use wasmtime::{Global, GlobalType, InstanceAllocationStrategy, Linker, Memory, MemoryType, Module, Mutability, PoolingAllocationStrategy, Val, ValType};
+use wasmtime::{
+    Global, GlobalType, InstanceAllocationStrategy, Linker, Memory, MemoryType, Module, Mutability,
+    PoolingAllocationStrategy, Val, ValType,
+};
 
 use crate::gas::{GasTimer, WasmGasPrices};
 use crate::machine::limiter::MemoryLimiter;
@@ -106,7 +109,9 @@ fn wasmtime_config(ec: &EngineConfig) -> anyhow::Result<wasmtime::Config> {
 
     // Adjust the maximum amount of host memory that can be committed to an instance to
     // match the static linear memory size we reserve for each slot.
-    alloc_strat_cfg.instance_memory_pages(instance_memory_maximum_size / (wasmtime_environ::WASM_PAGE_SIZE as u64));
+    alloc_strat_cfg.instance_memory_pages(
+        instance_memory_maximum_size / (wasmtime_environ::WASM_PAGE_SIZE as u64),
+    );
     c.allocation_strategy(InstanceAllocationStrategy::Pooling(alloc_strat_cfg));
 
     // wasmtime default: true

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -7,6 +7,7 @@ use anyhow::anyhow;
 use derive_more::Display;
 use fvm_shared::error::ExitCode;
 use wasmtime::Trap;
+use std::fmt;
 
 use crate::call_manager::NO_DATA_BLOCK_ID;
 use crate::kernel::{BlockId, ExecutionError};
@@ -50,13 +51,33 @@ impl Abort {
     }
 }
 
-/// Wraps an execution error in a Trap.
+impl fmt::Display for Abort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use Abort::*;
+
+        // todo make this less bad
+        let desc = match self {
+            Exit(_, _, _) => "exit",
+            OutOfGas => "out of gas",
+            Fatal(_) => "fatal error",
+        };
+        write!(f, "wasm trap: {desc}")
+    }
+}
+
+impl std::error::Error for Abort {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self)
+    }
+}
+
+/*/// Wraps an execution error in a Trap.
 impl From<Abort> for Trap {
     fn from(a: Abort) -> Self {
         Trap::from(Box::new(Envelope::wrap(a)) as Box<dyn std::error::Error + Send + Sync + 'static>)
     }
-}
-
+}*/
+/*
 /// Unwraps a trap error from an actor into an "abort".
 impl From<Trap> for Abort {
     fn from(t: Trap) -> Self {
@@ -79,8 +100,8 @@ impl From<Trap> for Abort {
             .unwrap_or_else(|| Abort::Fatal(t.into()))
     }
 }
-
-/// A super special secret error type for stapling an error to a trap in a way that allows us to
+*/
+/*/// A super special secret error type for stapling an error to a trap in a way that allows us to
 /// pull it back out.
 ///
 /// BE VERY CAREFUL WITH THIS ERROR TYPE: Its source is self-referential.
@@ -105,4 +126,4 @@ impl std::error::Error for Envelope {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(self)
     }
-}
+}*/

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -1,25 +1,24 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 //! This module contains code used to convert errors to and from wasmtime traps.
-use std::sync::Mutex;
-
 use anyhow::anyhow;
-use derive_more::Display;
 use fvm_shared::error::ExitCode;
 use wasmtime::Trap;
-use std::fmt;
 
 use crate::call_manager::NO_DATA_BLOCK_ID;
 use crate::kernel::{BlockId, ExecutionError};
 
 /// Represents an actor "abort".
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Abort {
     /// The actor explicitly aborted with the given exit code (or panicked).
+    #[error("exit with code {0} ({2})")]
     Exit(ExitCode, String, BlockId),
     /// The actor ran out of gas.
+    #[error("out of gas")]
     OutOfGas,
     /// The system failed with a fatal error.
+    #[error("fatal error: {0}")]
     Fatal(anyhow::Error),
 }
 
@@ -51,79 +50,37 @@ impl Abort {
     }
 }
 
-impl fmt::Display for Abort {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Abort::*;
-
-        // todo make this less bad
-        let desc = match self {
-            Exit(_, _, _) => "exit",
-            OutOfGas => "out of gas",
-            Fatal(_) => "fatal error",
-        };
-        write!(f, "wasm trap: {desc}")
-    }
-}
-
-impl std::error::Error for Abort {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(self)
-    }
-}
-
-/*/// Wraps an execution error in a Trap.
-impl From<Abort> for Trap {
-    fn from(a: Abort) -> Self {
-        Trap::from(Box::new(Envelope::wrap(a)) as Box<dyn std::error::Error + Send + Sync + 'static>)
-    }
-}*/
-/*
 /// Unwraps a trap error from an actor into an "abort".
-impl From<Trap> for Abort {
-    fn from(t: Trap) -> Self {
-        use std::error::Error;
+impl From<anyhow::Error> for Abort {
+    fn from(e: anyhow::Error) -> Self {
+        if let Some(trap) = e.downcast_ref::<Trap>() {
+            return match trap {
+                | Trap::MemoryOutOfBounds
+                | Trap::TableOutOfBounds
+                | Trap::IndirectCallToNull
+                | Trap::BadSignature
+                | Trap::IntegerOverflow
+                | Trap::IntegerDivisionByZero
+                | Trap::BadConversionToInteger
+                | Trap::UnreachableCodeReached
 
-        // Actor panic/wasm error.
-        if let Some(code) = t.trap_code() {
-            return Abort::Exit(
-                ExitCode::SYS_ILLEGAL_INSTRUCTION,
-                code.to_string(),
-                NO_DATA_BLOCK_ID,
-            );
-        }
+                // Should require the atomic feature to be enabled, but we might as well just
+                // handle this.
+                | Trap::HeapMisaligned
+                | Trap::AtomicWaitNonSharedMemory
 
-        // Try to get a smuggled error back.
-        t.source()
-            .and_then(|e| e.downcast_ref::<Envelope>())
-            .and_then(|e| e.take())
-            // Otherwise, treat this as a fatal error.
-            .unwrap_or_else(|| Abort::Fatal(t.into()))
-    }
-}
-*/
-/*/// A super special secret error type for stapling an error to a trap in a way that allows us to
-/// pull it back out.
-///
-/// BE VERY CAREFUL WITH THIS ERROR TYPE: Its source is self-referential.
-#[derive(Display, Debug)]
-#[display(fmt = "wrapping error")]
-struct Envelope {
-    inner: Mutex<Option<Abort>>,
-}
-
-impl Envelope {
-    fn wrap(a: Abort) -> Self {
-        Self {
-            inner: Mutex::new(Some(a)),
+                // I think this is fatal? But I'm not sure.
+                | Trap::StackOverflow => Abort::Exit(
+                    ExitCode::SYS_ILLEGAL_INSTRUCTION,
+                    trap.to_string(),
+                    NO_DATA_BLOCK_ID,
+                ),
+                _ => Abort::Fatal(anyhow!("unexpected wasmtime trap: {}", trap)),
+            };
+        };
+        match e.downcast::<Abort>() {
+            Ok(abort) => abort,
+            Err(e) => Abort::Fatal(e),
         }
     }
-    fn take(&self) -> Option<Abort> {
-        self.inner.lock().ok().and_then(|mut a| a.take()).take()
-    }
 }
-
-impl std::error::Error for Envelope {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(self)
-    }
-}*/

--- a/testing/calibration/Cargo.toml
+++ b/testing/calibration/Cargo.toml
@@ -37,7 +37,7 @@ blake2b_simd = "1.0.0"
 
 
 [dependencies.wasmtime]
-version = "1.0.2"
+version = "4.0.0"
 default-features = false
 features = ["cranelift", "parallel-compilation"]
 

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4.14"
 byteorder = "1.4.3"
 futures = "0.3.19"
 async-std = { version = "1.9", features = ["attributes"] }
-wasmtime = { version = "1.0.2", default-features = false }
+wasmtime = { version = "4.0.0", default-features = false }
 base64 = "0.13.0"
 flate2 = { version = "1.0" }
 colored = "2"

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -31,7 +31,7 @@ serde_repr = "0.1"
 thiserror = "1.0.30"
 
 [dependencies.wasmtime]
-version = "1.0.2"
+version = "4.0.0"
 default-features = false
 features = ["cranelift", "parallel-compilation"]
 


### PR DESCRIPTION
Doesn't build yet because error handling hates me

```
   Compiling fvm v3.0.0-alpha.17 (/home/magik6k/github.com/filecoin-project/ref-fvm/fvm)
error[E0277]: `?` couldn't convert the error to `Abort`
   --> fvm/src/call_manager/default.rs:598:23
    |
598 |                 Ok(res?)
    |                       ^ the trait `From<anyhow::Error>` is not implemented for `Abort`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the trait `From<wasmtime::Trap>` is implemented for `Abort`
    = note: required for `std::result::Result<u32, Abort>` to implement `FromResidual<std::result::Result<Infallible, anyhow::Error>>`

error[E0277]: the trait bound `wasmtime::Trap: From<Box<dyn StdError + Sync + std::marker::Send>>` is not satisfied
  --> fvm/src/syscalls/error.rs:56:20
   |
56 |         Trap::from(Box::new(Envelope::wrap(a)) as Box<dyn std::error::Error + Send + Sync + 'static>)
   |         ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<Box<dyn StdError + Sync + std::marker::Send>>` is not implemented for `wasmtime::Trap`
   |         |
   |         required by a bound introduced by this call
   |
   = help: the trait `From<Abort>` is implemented for `wasmtime::Trap`

error[E0599]: no method named `trap_code` found for enum `wasmtime::Trap` in the current scope
  --> fvm/src/syscalls/error.rs:66:31
   |
66 |         if let Some(code) = t.trap_code() {
   |                               ^^^^^^^^^ method not found in `wasmtime::Trap`

error[E0277]: the trait bound `Abort: StdError` is not satisfied
   --> fvm/src/syscalls/bind.rs:126:53
    |
126 |                         charge_for_exec(&mut caller)?;
    |                                                     ^ the trait `StdError` is not implemented for `Abort`
...
196 | impl_bind_syscalls!();
    | --------------------- in this macro invocation
    |
    = help: the following other types implement trait `FromResidual<R>`:
              <std::result::Result<T, F> as FromResidual<Yeet<E>>>
              <std::result::Result<T, F> as FromResidual<std::result::Result<Infallible, E>>>
    = note: required for `anyhow::Error` to implement `From<Abort>`
    = note: required for `std::result::Result<u32, anyhow::Error>` to implement `FromResidual<std::result::Result<Infallible, Abort>>`
    = note: this error originates in the macro `impl_bind_syscalls` (in Nightly builds, run with -Z macro-backtrace for more info)


```