### PR TITLE
[v2] Fix log initialisation to set max level, else all messages are discarded

### DIFF
--- a/sdk/src/debug.rs
+++ b/sdk/src/debug.rs
@@ -35,6 +35,7 @@ mod inner {
     pub fn init_logging() {
         if enabled() {
             log::set_logger(&Logger).expect("failed to enable logging");
+            log::set_max_level(log::LevelFilter::Trace);
         }
     }
 


### PR DESCRIPTION
Well, this took a very long time to discover.

This is already fixed on master, but built-in actors are still targeting v2.

Note that even after this change I _still_ can't get logs to produce syscalls when using the v2 SDK, but I can if I install my own logger, which is good enough for now.

Related: #1397