### PR TITLE
feat: add a basic block size limit

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -249,6 +249,10 @@ where
     }
 
     fn block_create(&mut self, codec: u64, data: &[u8]) -> Result<BlockId> {
+        if data.len() > self.machine().context().max_block_size {
+            return Err(syscall_error!(LimitExceeded; "blocks may not be larger than 1MiB").into());
+        }
+
         let t = self
             .call_manager
             .charge_gas(self.call_manager.price_list().on_block_create(data.len()))?;

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -131,6 +131,11 @@ pub struct NetworkConfig {
     /// DEFAULT: 2GiB
     pub max_memory_bytes: u64,
 
+    /// The maximum blocks size that can be created in the FVM.
+    ///
+    /// DEFAULT: 1MiB
+    pub max_block_size: usize,
+
     /// An override for builtin-actors. If specified, this should be the CID of a builtin-actors
     /// "manifest".
     ///
@@ -165,6 +170,7 @@ impl NetworkConfig {
             builtin_actors_override: None,
             price_list: price_list_by_network_version(network_version),
             actor_redirect: vec![],
+            max_block_size: 1 << 20,
         }
     }
 


### PR DESCRIPTION
Chosen to be 1MiB as that should be about 10x larger than anything in-use today.

fixes https://github.com/filecoin-project/ref-fvm/issues/1278