### PR TITLE
chore: release fvm, kamt, amt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
  "fixed-hash",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_kamt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_kamt 0.1.0",
  "fvm_shared 3.0.0-alpha.15",
  "hex",
  "hex-literal",
@@ -1692,7 +1692,7 @@ dependencies = [
  "cid 0.8.6",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_amt 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_amt 0.5.0",
  "fvm_ipld_bitfield 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1839,7 +1839,7 @@ dependencies = [
  "byteorder",
  "castaway",
  "cid 0.8.6",
- "fvm_ipld_amt 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_amt 0.5.0",
  "fvm_ipld_bitfield 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2360,7 +2360,7 @@ dependencies = [
  "filecoin-proofs-api",
  "fvm",
  "fvm-wasm-instrument",
- "fvm_ipld_amt 0.5.0",
+ "fvm_ipld_amt 0.5.1",
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_hamt 0.6.1",
@@ -2439,7 +2439,7 @@ dependencies = [
  "flate2",
  "futures",
  "fvm",
- "fvm_ipld_amt 0.5.0",
+ "fvm_ipld_amt 0.5.1",
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.2",
@@ -2517,7 +2517,7 @@ dependencies = [
  "fil_syscall_actor",
  "futures",
  "fvm",
- "fvm_ipld_amt 0.5.0",
+ "fvm_ipld_amt 0.5.1",
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.2",
@@ -2558,12 +2558,13 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21efabb8ae696f1cfd90b176a3600176010bd6ad3fb9919b16a24b43ba866b3d"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
- "criterion",
- "fvm_ipld_blockstore 0.1.1",
- "fvm_ipld_encoding 0.3.2",
+ "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
  "once_cell",
  "serde",
@@ -2572,14 +2573,13 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_amt"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21efabb8ae696f1cfd90b176a3600176010bd6ad3fb9919b16a24b43ba866b3d"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
- "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion",
+ "fvm_ipld_blockstore 0.1.1",
+ "fvm_ipld_encoding 0.3.2",
  "itertools 0.10.5",
  "once_cell",
  "serde",
@@ -2782,6 +2782,26 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_kamt"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72011dfb8938afdd752563bbf43fb900494c9c220dda8d3029cf675f2b6cb8b8"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "cid 0.8.6",
+ "forest_hash_utils",
+ "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libipld-core 0.15.0",
+ "multihash 0.16.3",
+ "once_cell",
+ "serde",
+ "sha2 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_ipld_kamt"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2800,26 +2820,6 @@ dependencies = [
  "sha2 0.10.6",
  "thiserror",
  "unsigned-varint",
-]
-
-[[package]]
-name = "fvm_ipld_kamt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72011dfb8938afdd752563bbf43fb900494c9c220dda8d3029cf675f2b6cb8b8"
-dependencies = [
- "anyhow",
- "byteorder",
- "cid 0.8.6",
- "forest_hash_utils",
- "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libipld-core 0.15.0",
- "multihash 0.16.3",
- "once_cell",
- "serde",
- "sha2 0.10.6",
- "thiserror",
 ]
 
 [[package]]

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,12 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 3.0.0-alpha.19 [2022-01-13]
+
+- Adjust memory retention gas fees.
+- Add a basic block-size limit of 1MiB.
+- Update wasmtime to v2.0.2
+
 ## 3.0.0-alpha.18 [2022-01-10]
 
 - Remove the CBOR trait

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -21,7 +21,7 @@ cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] 
 multihash = { version = "0.16.3", default-features = false }
 fvm_shared = { version = "3.0.0-alpha.16", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.6.1", path = "../ipld/hamt" }
-fvm_ipld_amt = { version = "0.5.0", path = "../ipld/amt" }
+fvm_ipld_amt = { version = "0.5.1", path = "../ipld/amt" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.3.2", path = "../ipld/encoding" }
 serde = { version = "1.0", features = ["derive"] }

--- a/ipld/amt/CHANGELOG.md
+++ b/ipld/amt/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 0.5.1
+
+Avoid flushing the AMT if nothing has changed.
+
 ## 0.5.0
 
 - Bumps `fvm_ipld_encoding` and switches from `cs_serde_bytes` to `fvm_ipld_encoding::strict_bytes`.

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_amt"
 description = "Sharded IPLD Array implementation."
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/ipld/kamt/CHANGELOG.md
+++ b/ipld/kamt/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0 [2023-01-13]
+
+- Improve serialization format by avoiding maps.
+- Various performance improvements.
+
 ## [Unreleased]
 
 - ...

--- a/ipld/kamt/Cargo.toml
+++ b/ipld/kamt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_kamt"
 description = "Sharded IPLD Map implementation with level skipping."
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 [dependencies]
 fvm_shared = { version = "3.0.0-alpha.16", path = "../../shared" }
 fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
-fvm_ipld_amt = { version = "0.5.0", path = "../../ipld/amt" }
+fvm_ipld_amt = { version = "0.5.1", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.3.2", path = "../../ipld/encoding" }

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 fvm = { version = "3.0.0-alpha.18", path = "../../fvm", default-features = false, features = ["testing"] }
 fvm_shared = { version = "3.0.0-alpha.16", path = "../../shared", features = ["testing"] }
 fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
-fvm_ipld_amt = { version = "0.5.0", path = "../../ipld/amt" }
+fvm_ipld_amt = { version = "0.5.1", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.3.2", path = "../../ipld/encoding" }


### PR DESCRIPTION
I'm skipping the HAMT because that has some API changes and no new features.