### PR TITLE
feat: cache new addresses

### DIFF
--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -358,7 +358,7 @@ where
     pub fn register_new_address(&mut self, addr: &Address) -> Result<ActorID> {
         let (mut state, mut actor) = InitActorState::load(self)?;
 
-        let new_addr = state.map_address_to_new_id(self.store(), addr)?;
+        let new_id = state.map_address_to_new_id(self.store(), addr)?;
 
         // Set state for init actor in store and update root Cid
         actor.state = self
@@ -367,8 +367,9 @@ where
             .or_fatal()?;
 
         self.set_actor(crate::init_actor::INIT_ACTOR_ID, actor)?;
+        self.resolve_cache.borrow_mut().insert(*addr, new_id);
 
-        Ok(new_addr)
+        Ok(new_id)
     }
 
     /// Begin a new state transaction. Transactions stack.


### PR DESCRIPTION
When we register a new address (e.g., when auto-creating an actor on first send), cache it.

This will be important for gas tracking.