### PR TITLE
feat: use a struct for network versions

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -701,7 +701,7 @@ where
         let ctx = NetworkContext {
             chain_id: (*chain_id).into(),
             epoch: *epoch,
-            network_version: *network_version as u32,
+            network_version: *network_version,
             timestamp: *timestamp,
             base_fee: base_fee
                 .try_into()

--- a/sdk/src/network.rs
+++ b/sdk/src/network.rs
@@ -1,7 +1,5 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use std::convert::TryInto;
-
 use cid::Cid;
 use fvm_shared::chainid::ChainID;
 use fvm_shared::clock::ChainEpoch;
@@ -31,10 +29,7 @@ pub fn curr_epoch() -> ChainEpoch {
 }
 
 pub fn version() -> NetworkVersion {
-    NETWORK_CONTEXT
-        .network_version
-        .try_into()
-        .expect("invalid network version")
+    NETWORK_CONTEXT.network_version
 }
 
 pub fn base_fee() -> TokenAmount {

--- a/shared/src/sys/out.rs
+++ b/shared/src/sys/out.rs
@@ -106,6 +106,7 @@ pub mod vm {
 pub mod network {
     use crate::clock::ChainEpoch;
     use crate::sys::TokenAmount;
+    use crate::version::NetworkVersion;
 
     #[derive(Debug, Copy, Clone)]
     #[repr(packed, C)]
@@ -119,6 +120,6 @@ pub mod network {
         /// The Chain ID of the network.
         pub chain_id: u64,
         /// The network version.
-        pub network_version: u32,
+        pub network_version: NetworkVersion,
     }
 }

--- a/shared/src/version/mod.rs
+++ b/shared/src/version/mod.rs
@@ -4,85 +4,73 @@
 
 use std::fmt::Display;
 
-use fvm_ipld_encoding::repr::Serialize_repr;
+use serde::{Deserialize, Serialize};
 
 /// Specifies the network version
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd, Serialize_repr)]
-#[repr(u32)]
-#[non_exhaustive]
-pub enum NetworkVersion {
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd, Serialize, Deserialize)]
+#[repr(transparent)]
+#[serde(transparent)]
+pub struct NetworkVersion(u32);
+impl NetworkVersion {
     /// genesis (specs-actors v0.9.3)
-    V0 = 0,
+    pub const V0: Self = Self(0);
     /// breeze (specs-actors v0.9.7)
-    V1,
+    pub const V1: Self = Self(1);
     /// smoke (specs-actors v0.9.8)
-    V2,
+    pub const V2: Self = Self(2);
     /// ignition (specs-actors v0.9.11)
-    V3,
+    pub const V3: Self = Self(3);
     /// actors v2 (specs-actors v2.0.x)
-    V4,
+    pub const V4: Self = Self(4);
     /// tape (increases max prove commit size by 10x)
-    V5,
+    pub const V5: Self = Self(5);
     /// kumquat (specs-actors v2.2.0)
-    V6,
+    pub const V6: Self = Self(6);
     /// calico (specs-actors v2.3.2)
-    V7,
+    pub const V7: Self = Self(7);
     /// persian (post-2.3.2 behaviour transition)
-    V8,
+    pub const V8: Self = Self(8);
     /// orange
-    V9,
+    pub const V9: Self = Self(9);
     /// trust (specs-actors v3.0.x)
-    V10,
+    pub const V10: Self = Self(10);
     /// norwegian (specs-actors v3.1.x)
-    V11,
+    pub const V11: Self = Self(11);
     /// turbo (specs-actors v4.0.x)
-    V12,
+    pub const V12: Self = Self(12);
     /// HyperDrive
-    V13,
+    pub const V13: Self = Self(13);
     /// Chocolate v6
-    V14,
+    pub const V14: Self = Self(14);
     /// OhSnap v7
-    V15,
+    pub const V15: Self = Self(15);
     /// Skyr (builtin-actors v8)
-    V16,
+    pub const V16: Self = Self(16);
     /// Shark (builtin-actors v9)
-    V17,
+    pub const V17: Self = Self(17);
     /// Hygge (builtin-actors v10)
-    V18,
+    pub const V18: Self = Self(18);
+
+    /// Construct a new arbitrary network version.
+    pub const fn new(v: u32) -> Self {
+        Self(v)
+    }
 }
 
 impl Display for NetworkVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", *self as u32)
+        write!(f, "{}", self.0)
     }
 }
 
-impl TryFrom<u32> for NetworkVersion {
-    type Error = u32;
+impl From<u32> for NetworkVersion {
+    fn from(v: u32) -> Self {
+        Self(v)
+    }
+}
 
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        use NetworkVersion::*;
-        match value {
-            0 => Ok(V0),
-            1 => Ok(V1),
-            2 => Ok(V2),
-            3 => Ok(V3),
-            4 => Ok(V4),
-            5 => Ok(V5),
-            6 => Ok(V6),
-            7 => Ok(V7),
-            8 => Ok(V8),
-            9 => Ok(V9),
-            10 => Ok(V10),
-            11 => Ok(V11),
-            12 => Ok(V12),
-            13 => Ok(V13),
-            14 => Ok(V14),
-            15 => Ok(V15),
-            16 => Ok(V16),
-            17 => Ok(V17),
-            18 => Ok(V18),
-            _ => Err(value),
-        }
+impl From<NetworkVersion> for u32 {
+    fn from(v: NetworkVersion) -> Self {
+        v.0
     }
 }


### PR DESCRIPTION
The enum means we'd need to extend this for every network version added. We still have constants for every _named_ network version.