### PR TITLE
FVM: Use CBOR instead of DAG_CBOR for message params

### DIFF
--- a/fvm/src/blockstore/buffered.rs
+++ b/fvm/src/blockstore/buffered.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Result};
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
 use cid::Cid;
 use fvm_ipld_blockstore::{Blockstore, Buffered};
-use fvm_ipld_encoding::DAG_CBOR;
+use fvm_ipld_encoding::{CBOR, DAG_CBOR};
 use fvm_shared::commcid::{FIL_COMMITMENT_SEALED, FIL_COMMITMENT_UNSEALED};
 
 /// Wrapper around `Blockstore` to limit and have control over when values are written.
@@ -181,9 +181,10 @@ fn copy_rec<'a>(
     //    perf impact.
 
     // TODO(M2): Make this not cbor specific.
+    // TODO(M2): Allow CBOR (not just DAG_CBOR).
     match (root.codec(), root.hash().code(), root.hash().size()) {
         // Allow non-truncated blake2b-256 raw/cbor (code/state)
-        (DAG_RAW | DAG_CBOR, BLAKE2B_256, BLAKE2B_LEN) => (),
+        (DAG_RAW | DAG_CBOR | CBOR, BLAKE2B_256, BLAKE2B_LEN) => (),
         // Ignore raw identity cids (fake code cids)
         (DAG_RAW, IDENTITY, _) => return Ok(()),
         // Copy links from cbor identity cids.

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use anyhow::{anyhow, Context};
 use cid::Cid;
 use derive_more::{Deref, DerefMut};
-use fvm_ipld_encoding::{to_vec, RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::{to_vec, RawBytes, CBOR};
 use fvm_shared::address::{Address, Payload};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
@@ -415,7 +415,7 @@ where
             system_actor::SYSTEM_ACTOR_ID,
             id,
             fvm_shared::METHOD_CONSTRUCTOR,
-            Some(Block::new(DAG_CBOR, params)),
+            Some(Block::new(CBOR, params)),
             &TokenAmount::zero(),
         )?;
 

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -5,7 +5,7 @@ use std::result::Result as StdResult;
 
 use anyhow::{anyhow, Result};
 use cid::Cid;
-use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::{RawBytes, CBOR};
 use fvm_shared::address::Payload;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
@@ -114,9 +114,9 @@ where
                         // NOTE: this _may_ start to matter once we start _validating_ ipld (m2.2).
                         IPLD_RAW
                     } else {
-                        // TODO: This should probably be CBOR
-                        // See #987.
-                        DAG_CBOR
+                        // This is CBOR, not DAG_CBOR, because links sent from off-chain aren't
+                        // reachable.
+                        CBOR
                     },
                     msg.params.bytes(),
                 )

--- a/fvm/src/kernel/blocks.rs
+++ b/fvm/src/kernel/blocks.rs
@@ -3,7 +3,7 @@
 use std::convert::TryInto;
 use std::rc::Rc;
 
-use fvm_ipld_encoding::DAG_CBOR;
+use fvm_ipld_encoding::{CBOR, DAG_CBOR};
 use fvm_shared::IPLD_RAW;
 use thiserror::Error;
 
@@ -24,7 +24,7 @@ const FIRST_ID: BlockId = 1;
 const MAX_BLOCKS: u32 = i32::MAX as u32; // TODO(M2): Limit
 
 /// Codecs allowed by the IPLD subsytem.
-const ALLOWED_CODECS: &[u64; 2] = &[DAG_CBOR, IPLD_RAW];
+const ALLOWED_CODECS: &[u64; 3] = &[CBOR, DAG_CBOR, IPLD_RAW];
 
 #[derive(Debug, Copy, Clone)]
 pub struct BlockStat {

--- a/ipld/encoding/src/lib.rs
+++ b/ipld/encoding/src/lib.rs
@@ -19,7 +19,13 @@ pub use self::cbor_store::CborStore;
 pub use self::errors::*;
 pub use self::vec::*;
 
+/// CBOR should be used to pass CBOR data when internal links don't need to be
+/// traversable/reachable. When a CBOR block is loaded, said links will not be added to the
+/// reachable set.
+pub const CBOR: u64 = 0x51;
+/// DagCBOR should be used for all IPLD-CBOR data where CIDs need to be traversable.
 pub const DAG_CBOR: u64 = 0x71;
+/// RAW should be used for raw data.
 pub const IPLD_RAW: u64 = 0x55;
 
 // TODO: these really don't work all that well in a shared context like this as anyone importing

--- a/testing/integration/tests/fil-address-actor/src/actor.rs
+++ b/testing/integration/tests/fil-address-actor/src/actor.rs
@@ -15,7 +15,7 @@ pub fn invoke(params: u32) -> u32 {
         1 => {
             // Check our address.
             let msg_params = sdk::message::params_raw(params).unwrap().unwrap();
-            assert_eq!(msg_params.codec, fvm_ipld_encoding::DAG_CBOR);
+            assert_eq!(msg_params.codec, fvm_ipld_encoding::CBOR);
             let expected_address: Option<Address> =
                 fvm_ipld_encoding::from_slice(msg_params.data.as_slice()).unwrap();
             let actual_address = sdk::actor::lookup_delegated_address(sdk::message::receiver());

--- a/testing/integration/tests/fil-events-actor/src/actor.rs
+++ b/testing/integration/tests/fil-events-actor/src/actor.rs
@@ -80,7 +80,7 @@ pub fn invoke(params: u32) -> u32 {
         },
         EMIT_SUBCALLS => {
             let msg_params = sdk::message::params_raw(params).unwrap().unwrap();
-            assert_eq!(msg_params.codec, fvm_ipld_encoding::DAG_CBOR);
+            assert_eq!(msg_params.codec, fvm_ipld_encoding::CBOR);
 
             let mut counter: u64 = fvm_ipld_encoding::from_slice(msg_params.data.as_slice())
                 .expect("failed to deserialize param");
@@ -107,7 +107,7 @@ pub fn invoke(params: u32) -> u32 {
         }
         EMIT_SUBCALLS_REVERT => {
             let msg_params = sdk::message::params_raw(params).unwrap().unwrap();
-            assert_eq!(msg_params.codec, fvm_ipld_encoding::DAG_CBOR);
+            assert_eq!(msg_params.codec, fvm_ipld_encoding::CBOR);
 
             let mut counter: u64 =
                 fvm_ipld_encoding::from_slice(msg_params.data.as_slice()).unwrap();

--- a/testing/integration/tests/fil-exit-data-actor/src/lib.rs
+++ b/testing/integration/tests/fil-exit-data-actor/src/lib.rs
@@ -4,7 +4,7 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::DAG_CBOR;
+use fvm_ipld_encoding::CBOR;
 use fvm_sdk as sdk;
 
 /// Placeholder invoke for testing
@@ -25,7 +25,7 @@ fn invoke_method(_: u32) -> ! {
     sdk::vm::exit(
         exit_code,
         Some(IpldBlock {
-            codec: DAG_CBOR,
+            codec: CBOR,
             data: vec![1u8, 2u8, 3u8, 3u8, 7u8],
         }),
         None,

--- a/testing/integration/tests/fil-gaslimit-actor/src/actor.rs
+++ b/testing/integration/tests/fil-gaslimit-actor/src/actor.rs
@@ -27,7 +27,7 @@ pub fn invoke(params_id: u32) -> u32 {
     // Gas limit to use is supplied as a param.
     let params: Params = {
         let msg_params = sdk::message::params_raw(params_id).unwrap().unwrap();
-        assert_eq!(msg_params.codec, fvm_ipld_encoding::DAG_CBOR);
+        assert_eq!(msg_params.codec, fvm_ipld_encoding::CBOR);
         fvm_ipld_encoding::from_slice(msg_params.data.as_slice()).unwrap()
     };
 

--- a/testing/integration/tests/fil-integer-overflow-actor/src/actor/mod.rs
+++ b/testing/integration/tests/fil-integer-overflow-actor/src/actor/mod.rs
@@ -3,7 +3,7 @@
 use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::{to_vec, CborStore, RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::{to_vec, CborStore, RawBytes, CBOR, DAG_CBOR};
 use fvm_sdk::message::params_raw;
 use fvm_sdk::vm::abort;
 use fvm_sdk::NO_DATA_BLOCK_ID;
@@ -117,7 +117,7 @@ pub fn invoke(params_pointer: u32) -> u32 {
 
     match ret {
         None => NO_DATA_BLOCK_ID,
-        Some(v) => match fvm_sdk::ipld::put_block(DAG_CBOR, v.bytes()) {
+        Some(v) => match fvm_sdk::ipld::put_block(CBOR, v.bytes()) {
             Ok(id) => id,
             Err(err) => abort(
                 ExitCode::USR_SERIALIZATION.value(),

--- a/testing/integration/tests/fil-readonly-actor/src/lib.rs
+++ b/testing/integration/tests/fil-readonly-actor/src/lib.rs
@@ -6,7 +6,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::{to_vec, RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::{to_vec, RawBytes, CBOR, DAG_CBOR};
 use fvm_sdk as sdk;
 use fvm_shared::address::{Address, SECP_PUB_LEN};
 use fvm_shared::econ::TokenAmount;
@@ -112,7 +112,7 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
                 &Address::new_id(sdk::message::receiver()),
                 4,
                 Some(IpldBlock {
-                    codec: DAG_CBOR,
+                    codec: CBOR,
                     data: "input".into(),
                 }),
                 Default::default(),
@@ -140,7 +140,7 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
                 &Address::new_id(sdk::message::receiver()),
                 4,
                 Some(IpldBlock {
-                    codec: DAG_CBOR,
+                    codec: CBOR,
                     data: "input".into(),
                 }),
                 Default::default(),


### PR DESCRIPTION
Fixes #1001 