### PR TITLE
fix: fix build when testing isn't enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,7 +1894,7 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.16",
+ "fvm_shared 3.0.0-alpha.17",
  "substrate-wasm-builder",
 ]
 

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -823,9 +823,11 @@ where
         actor_id: ActorID,
         delegated_address: Option<Address>,
     ) -> Result<()> {
-        let is_allowed_to_create_actor = self.actor_id == INIT_ACTOR_ID
-            || (cfg!(feature = "testing")
-                && self.actor_id == TEST_ACTOR_ALLOWED_TO_CALL_CREATE_ACTOR);
+        let is_allowed_to_create_actor = self.actor_id == INIT_ACTOR_ID;
+
+        #[cfg(feature = "testing")]
+        let is_allowed_to_create_actor =
+            is_allowed_to_create_actor || self.actor_id == TEST_ACTOR_ALLOWED_TO_CALL_CREATE_ACTOR;
 
         if !is_allowed_to_create_actor {
             return Err(syscall_error!(


### PR DESCRIPTION
This appears to be a casualty of rust's feature unification. We should have caught this in CI, but feature unification ensured that this feature got _enabled_, so we didn't.