### PR TITLE
fix: expose the effective gas premium

### DIFF
--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -80,6 +80,27 @@ where
             events: Vec<StampedEvent>, // TODO consider removing if nothing in the client ends up using it.
         }
 
+        // Filecoin caps the premium plus the base-fee at the fee-cap.
+        // We expose the _effective_ premium to the user.
+        let effective_premium = msg
+            .gas_premium
+            .clone()
+            .min(&msg.gas_fee_cap - &self.context().base_fee)
+            .max(TokenAmount::zero());
+
+        // TODO: Remove after the upgrade.
+        // If we're on hyperspace with a network version less than 20, we need to disable this fix
+        // until the next upgrade (version 20).
+        //
+        // I've written it this way to nicely isolate the bugfix to make it easier to remove.
+        #[cfg(feature = "hyperspace")]
+        let effective_premium =
+            if self.context().network_version < fvm_shared::version::NetworkVersion::new(20) {
+                msg.gas_premium.clone()
+            } else {
+                effective_premium
+            };
+
         // Acquire an engine from the pool. This may block if there are concurrently executing
         // messages inside other executors sharing the same pool.
         let engine = self.engine_pool.acquire();
@@ -94,7 +115,7 @@ where
                 sender_id,
                 msg.from,
                 msg.sequence,
-                msg.gas_premium.clone(),
+                effective_premium,
             );
             // This error is fatal because it should have already been accounted for inside
             // preflight_message.

--- a/shared/src/sys/out.rs
+++ b/shared/src/sys/out.rs
@@ -96,7 +96,9 @@ pub mod vm {
         pub method_number: MethodNum,
         /// The value that was received.
         pub value_received: TokenAmount,
-        /// The current gas premium
+        /// The gas premium being paid by the currently executing message (on top of the base-fee).
+        /// This may be less than the premium specified in the message if the base fee plus the
+        /// premium would exceed the fee cap.
         pub gas_premium: TokenAmount,
         /// Flags pertaining to the currently executing actor's invocation context.
         pub flags: ContextFlags,


### PR DESCRIPTION
We previously exposed the specified gas premium, but that's not all that useful. The user pays the _effective_ gas premium, which is capped at `feecap - basefee`. I.e., the user never pays more than the fee cap.

Unfortunately, this needs to be behind a feature flag on hyperspace until the c.3 upgrade.

fixes #1471