### PR TITLE
feat: `CarReader::read_into()`

### DIFF
--- a/ipld/car/tests/car_file_test.rs
+++ b/ipld/car/tests/car_file_test.rs
@@ -5,7 +5,7 @@
 use async_std::fs::File;
 use async_std::io::BufReader;
 use fvm_ipld_blockstore::MemoryBlockstore;
-use fvm_ipld_car::load_car;
+use fvm_ipld_car::{CarReader, load_car, load_car_reader};
 
 #[async_std::test]
 async fn load_into_blockstore() {
@@ -14,4 +14,18 @@ async fn load_into_blockstore() {
     let bs = MemoryBlockstore::default();
 
     let _ = load_car(&bs, buf_reader).await.unwrap();
+}
+
+#[async_std::test]
+async fn load_car_reader_into_blockstore() {
+    let file = File::open("tests/test.car").await.unwrap();
+    let buf_reader = BufReader::new(file);
+    let car_reader = CarReader::new(buf_reader).await.unwrap();
+    let bs = MemoryBlockstore::default();
+
+    let roots = car_reader.header.roots.clone();
+
+    let res = load_car_reader(&bs, car_reader).await.unwrap();
+
+    assert_eq!(res, roots);
 }

--- a/ipld/car/tests/car_file_test.rs
+++ b/ipld/car/tests/car_file_test.rs
@@ -5,7 +5,7 @@
 use async_std::fs::File;
 use async_std::io::BufReader;
 use fvm_ipld_blockstore::MemoryBlockstore;
-use fvm_ipld_car::{CarReader, load_car, load_car_reader};
+use fvm_ipld_car::{load_car, CarReader};
 
 #[async_std::test]
 async fn load_into_blockstore() {
@@ -23,9 +23,11 @@ async fn load_car_reader_into_blockstore() {
     let car_reader = CarReader::new(buf_reader).await.unwrap();
     let bs = MemoryBlockstore::default();
 
+    // perform some action with the reader
     let roots = car_reader.header.roots.clone();
 
-    let res = load_car_reader(&bs, car_reader).await.unwrap();
+    // load it into the blockstore
+    let res = car_reader.read_into(&bs).await.unwrap();
 
     assert_eq!(res, roots);
 }

--- a/ipld/car/tests/car_file_test.rs
+++ b/ipld/car/tests/car_file_test.rs
@@ -19,8 +19,7 @@ async fn load_into_blockstore() {
 #[async_std::test]
 async fn load_car_reader_into_blockstore() {
     let file = File::open("tests/test.car").await.unwrap();
-    let buf_reader = BufReader::new(file);
-    let car_reader = CarReader::new(buf_reader).await.unwrap();
+    let car_reader = CarReader::new(file).await.unwrap();
     let bs = MemoryBlockstore::default();
 
     // perform some action with the reader


### PR DESCRIPTION
# Why

resolves #1522 

# What

- Move private fn `load_car_inner` to `CarReader::read_into()`
- `load_car` and `load_car_unchecked` construct their own car readers and call `read_into`
- Add file test using CarReader directly 

# Summary

Provide a way for users to perform actions/checks on car data before loading it into the store
