### PR TITLE
HAMT iteration

### DIFF
--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -362,6 +362,23 @@ where
         self.root.for_each(self.store.borrow(), &mut f)
     }
 
+    #[inline]
+    pub fn for_each_while<F>(&self, start_at: &[u8], limit: u64, mut f: F) -> Result<u64, Error>
+    where
+        V: DeserializeOwned,
+        F: FnMut(&K, &V) -> anyhow::Result<()>,
+    {
+        // TODO: use start passed in from outside
+        self.root.for_each_while(
+            self.store.borrow(),
+            start_at,
+            &[],
+            limit,
+            &self.conf,
+            &mut f,
+        )
+    }
+
     /// Consumes this HAMT and returns the Blockstore it owns.
     pub fn into_store(self) -> BS {
         self.store


### PR DESCRIPTION
A more general approach for iteration

Spiked in the HAMT library, showing skipping of nodes that are definitely "smaller" than a particular starting node

This technique should also work for the AMT. 

This API specifies a `max` number of values traversed, rather than nodes visited/expanded. Nodes visited/expanded can probably be passed back through the closure to the caller in order for the predicate to terminate iteration at a certain point if needed.