### PR TITLE
feat: explicitly reject placeholder creation

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -303,6 +303,14 @@ where
     ) -> Result<()> {
         let start = GasTimer::start();
 
+        if self.machine.builtin_actors().is_placeholder_actor(&code_id) {
+            return Err(syscall_error!(
+                Forbidden,
+                "cannot explicitly construct a placeholder actor"
+            )
+            .into());
+        }
+
         // Check to make sure the actor doesn't exist, or is a placeholder.
         let (actor, is_new) = match self.machine.state_tree().get_actor(actor_id)? {
             // Replace the placeholder

--- a/testing/integration/tests/fil-create-actor/src/actor.rs
+++ b/testing/integration/tests/fil-create-actor/src/actor.rs
@@ -3,6 +3,7 @@
 use actors_v10_runtime::runtime::builtins::Type;
 use fvm_sdk as sdk;
 use fvm_shared::address::{Address, SECP_PUB_LEN};
+use fvm_shared::error::ErrorNumber;
 
 #[no_mangle]
 pub fn invoke(_: u32) -> u32 {
@@ -27,5 +28,13 @@ pub fn invoke(_: u32) -> u32 {
         acct_cid,
         sdk::actor::get_actor_code_cid(&Address::new_id(1001)).unwrap()
     );
+
+    // Check that we can't explicitly deploy a placeholder.
+    let placeholder_cid = sdk::actor::get_code_cid_for_type(Type::Placeholder as i32);
+    assert_eq!(
+        sdk::actor::create_actor(1002, &placeholder_cid, None),
+        Err(ErrorNumber::Forbidden)
+    );
+
     0
 }


### PR DESCRIPTION
Previously, this would have failed anyways when the constructor method call gets rejected (because placeholders were rejecting all calls).

However, we're changing this such that placeholders accept all calls, so we need to forbid their explicit creation here.

part of #1567.