### PR TITLE
release `fvm@v3.0.0-alpha.22`, `fvm_shared@v3.0.0-alpha.18`, `fvm_sdk@v3.0.0-alpha.23`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "num-derive",
  "num-traits",
  "serde",
@@ -1592,7 +1592,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "log",
  "num-derive",
  "num-traits",
@@ -1612,7 +1612,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "lazy_static",
  "log",
  "num-derive",
@@ -1629,7 +1629,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_encoding 0.3.2",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "hex-literal",
  "num-derive",
  "num-traits",
@@ -1652,7 +1652,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_kamt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "hex",
  "hex-literal",
  "impl-serde",
@@ -1684,7 +1684,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "log",
  "num-derive",
  "num-traits",
@@ -1705,7 +1705,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "integer-encoding",
  "libipld-core 0.13.1",
  "log",
@@ -1729,7 +1729,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -1752,7 +1752,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "indexmap",
  "integer-encoding",
  "num-derive",
@@ -1771,7 +1771,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "num-derive",
  "num-traits",
  "serde",
@@ -1782,8 +1782,8 @@ name = "fil_actor_placeholder"
 version = "10.0.0-alpha.1"
 source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#008bac85d5dae40507eb1627e11e3f61ceff39c5"
 dependencies = [
- "fvm_sdk 3.0.0-alpha.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 3.0.0-alpha.22",
+ "fvm_shared 3.0.0-alpha.17",
 ]
 
 [[package]]
@@ -1798,7 +1798,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -1816,7 +1816,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "lazy_static",
  "log",
  "num-derive",
@@ -1834,7 +1834,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "num-derive",
  "num-traits",
  "serde",
@@ -1854,7 +1854,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.0.0-alpha.17",
  "lazy_static",
  "log",
  "num-derive",
@@ -1876,8 +1876,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.2",
  "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 3.0.0-alpha.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 3.0.0-alpha.22",
+ "fvm_shared 3.0.0-alpha.17",
  "itertools 0.10.5",
  "log",
  "multihash",
@@ -1898,8 +1898,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "serde",
  "substrate-wasm-builder",
 ]
@@ -1936,8 +1936,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "substrate-wasm-builder",
 ]
 
@@ -1946,8 +1946,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "serde",
  "serde_tuple",
  "substrate-wasm-builder",
@@ -1958,8 +1958,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "substrate-wasm-builder",
 ]
 
@@ -1970,8 +1970,8 @@ dependencies = [
  "anyhow",
  "cid",
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "num-derive",
  "num-traits",
  "serde",
@@ -1983,8 +1983,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "log",
  "serde",
  "serde_tuple",
@@ -1995,8 +1995,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "substrate-wasm-builder",
 ]
 
@@ -2008,8 +2008,8 @@ dependencies = [
  "cid",
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "serde",
  "serde_tuple",
  "substrate-wasm-builder",
@@ -2020,8 +2020,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "minicov",
  "substrate-wasm-builder",
 ]
@@ -2030,8 +2030,8 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "substrate-wasm-builder",
 ]
 
@@ -2041,8 +2041,8 @@ version = "0.1.0"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "substrate-wasm-builder",
 ]
 
@@ -2050,8 +2050,8 @@ dependencies = [
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "substrate-wasm-builder",
 ]
 
@@ -2061,8 +2061,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.23",
+ "fvm_shared 3.0.0-alpha.18",
  "minicov",
  "multihash",
  "substrate-wasm-builder",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.0.0-alpha.21"
+version = "3.0.0-alpha.22"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2406,7 +2406,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.18",
  "lazy_static",
  "log",
  "minstant",
@@ -2440,7 +2440,7 @@ dependencies = [
  "fvm_integration_tests",
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.18",
  "hex",
  "serde",
 ]
@@ -2501,7 +2501,7 @@ dependencies = [
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.18",
  "itertools 0.10.5",
  "ittapi-rs",
  "lazy_static",
@@ -2539,7 +2539,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.18",
  "lazy_static",
  "libsecp256k1",
  "multihash",
@@ -2580,7 +2580,7 @@ dependencies = [
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.18",
  "lazy_static",
  "libsecp256k1",
  "multihash",
@@ -2897,9 +2897,11 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.0.0-alpha.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51908aab9e7564fbcb278d78e31c12402b68c70517661780feb29adbb234aaf"
 dependencies = [
  "cid",
- "fvm_ipld_encoding 0.3.3",
+ "fvm_ipld_encoding 0.3.2",
  "fvm_shared 3.0.0-alpha.17",
  "lazy_static",
  "log",
@@ -2909,13 +2911,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51908aab9e7564fbcb278d78e31c12402b68c70517661780feb29adbb234aaf"
+version = "3.0.0-alpha.23"
 dependencies = [
  "cid",
- "fvm_ipld_encoding 0.3.2",
- "fvm_shared 3.0.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0-alpha.18",
  "lazy_static",
  "log",
  "num-traits",
@@ -2954,6 +2954,35 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.0.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779876441e390f414161474701404b5641e02a5b9acfece9b212f6d24e482e1"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "blake2b_simd",
+ "byteorder",
+ "cid",
+ "data-encoding",
+ "data-encoding-macro",
+ "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.3.2",
+ "lazy_static",
+ "log",
+ "multihash",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "serde_repr",
+ "serde_tuple",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "fvm_shared"
+version = "3.0.0-alpha.18"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2983,35 +3012,6 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "sha3",
- "thiserror",
- "unsigned-varint",
-]
-
-[[package]]
-name = "fvm_shared"
-version = "3.0.0-alpha.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779876441e390f414161474701404b5641e02a5b9acfece9b212f6d24e482e1"
-dependencies = [
- "anyhow",
- "bitflags",
- "blake2b_simd",
- "byteorder",
- "cid",
- "data-encoding",
- "data-encoding-macro",
- "fvm_ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.3.2",
- "lazy_static",
- "log",
- "multihash",
- "num-bigint",
- "num-derive",
- "num-integer",
- "num-traits",
- "serde",
- "serde_repr",
- "serde_tuple",
  "thiserror",
  "unsigned-varint",
 ]

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,16 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 3.0.0-alpha.22 [2022-02-01]
+
+- Align events implementation with FIP-0049 (#1481)
+- feat: explicitly reject placeholder creation (#1568)
+- Integrate fvm-bench and the basics of a testkit (#1493)
+- feat: simplify gas tracking stack (#1526)
+- feat: `CarReader::read_into()` (#1524)
+- feat: normalize transaction signatures (#1525)
+- fix: expose the effective gas premium (#1512)
+
 ## 3.0.0-alpha.21 [2022-01-19]
 
 - Machine: Put the Empty Array object in the blockstore on creation

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "3.0.0-alpha.21"
+version = "3.0.0-alpha.22"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -19,7 +19,7 @@ derive_builder = "0.12.0"
 num-derive = "0.3.3"
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.3", default-features = false }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../shared", features = ["crypto"] }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.6.1", path = "../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.1", path = "../ipld/amt" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../ipld/blockstore" }

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 3.0.0-alpha.23 [2023-02-01]
+
+- feat: use a struct for network versions (#1496)
+
 ## 3.0.0-alpha.22 [2023-01-12]
 
 - Refactor: Move Response from SDK to shared

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "3.0.0-alpha.22"
+version = "3.0.0-alpha.23"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { version = "0.8.5", default-features = false }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../shared" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = { version = "1.4.0" }

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## [Unreleased]
 
+## 3.0.0-alpha.18 [2022-02-01]
+
+- Improve rustdocs around events and gas premium.
+
 ## 3.0.0-alpha.17 [2022-01-17]
 
 - Add `hyperspace` feature to loosen up network version restrictions.
-- 
+
 ## 3.0.0-alpha.16 [2023-01-12]
 
 - Remove uses of the Cbor trait

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "3.0.0-alpha.17"
+version = "3.0.0-alpha.18"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/testing/calibration/Cargo.toml
+++ b/testing/calibration/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Protocol Labs", "Filecoin Core Devs"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "3.0.0-alpha.21", path = "../../fvm", default-features = false, features = ["testing"] }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../shared", features = ["testing"] }
+fvm = { version = "3.0.0-alpha.22", path = "../../fvm", default-features = false, features = ["testing"] }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../shared", features = ["testing"] }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../ipld/encoding" }

--- a/testing/calibration/contract/fil-gas-calibration-actor/Cargo.toml
+++ b/testing/calibration/contract/fil-gas-calibration-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 cid = { version = "0.8.2", default-features = false }
 num-derive = "0.3"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../shared" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../shared" }
 fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.1", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
@@ -50,7 +50,7 @@ actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/
 libipld-core = { version = "0.14.0", features = ["serde-codec"] }
 
 [dependencies.fvm]
-version = "3.0.0-alpha.21"
+version = "3.0.0-alpha.22"
 path = "../../fvm"
 default-features = false
 features = ["testing"]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Protocol Labs", "Filecoin Core Devs", "Polyphene"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "3.0.0-alpha.21", path = "../../fvm", default-features = false, features = ["testing"] }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../shared", features = ["testing"] }
+fvm = { version = "3.0.0-alpha.22", path = "../../fvm", default-features = false, features = ["testing"] }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../shared", features = ["testing"] }
 fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.1", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }

--- a/testing/integration/tests/fil-address-actor/Cargo.toml
+++ b/testing/integration/tests/fil-address-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 serde = "1.0.145"
 
 [build-dependencies]

--- a/testing/integration/tests/fil-create-actor/Cargo.toml
+++ b/testing/integration/tests/fil-create-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.19", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.15", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-events-actor/Cargo.toml
+++ b/testing/integration/tests/fil-events-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 serde = {version = "1.0.145", features = ["derive"] }
 serde_tuple = "0.5.0"
 

--- a/testing/integration/tests/fil-exit-data-actor/Cargo.toml
+++ b/testing/integration/tests/fil-exit-data-actor/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 publish = false
 
 [dependencies]
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-gaslimit-actor/Cargo.toml
+++ b/testing/integration/tests/fil-gaslimit-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 serde = {version = "1.0.145", features = ["derive"] }
 serde_tuple = "0.5.0"
 log = "0.4.14"

--- a/testing/integration/tests/fil-hello-world-actor/Cargo.toml
+++ b/testing/integration/tests/fil-hello-world-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../../../ipld/blockstore" }
 

--- a/testing/integration/tests/fil-ipld-actor/Cargo.toml
+++ b/testing/integration/tests/fil-ipld-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 
 [target.'cfg(coverage)'.dependencies]
 minicov = "0.3"

--- a/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-readonly-actor/Cargo.toml
+++ b/testing/integration/tests/fil-readonly-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 cid = { version = "0.8.5", default-features = false }
 

--- a/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-syscall-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "3.0.0-alpha.22", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.17", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0-alpha.23", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.18", path = "../../../../shared" }
 minicov = {version = "0.3", optional = true}
 actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 multihash = "0.16.3"


### PR DESCRIPTION
It's not absolutely necessary to release the SDK and shared, but might as well.