### PR TITLE
EVM: apply read-only early and reject events

### DIFF
--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -62,6 +62,7 @@ pub trait CallManager: 'static {
 
     /// Send a message. The type parameter `K` specifies the the _kernel_ on top of which the target
     /// actor should execute.
+    #[allow(clippy::too_many_arguments)]
     fn send<K: Kernel<CallManager = Self>>(
         &mut self,
         from: ActorID,
@@ -70,12 +71,12 @@ pub trait CallManager: 'static {
         params: Option<kernel::Block>,
         value: &TokenAmount,
         gas_limit: Option<Gas>,
+        read_only: bool,
     ) -> Result<InvocationResult>;
 
     /// Execute some operation (usually a send) within a transaction.
     fn with_transaction(
         &mut self,
-        read_only: bool,
         f: impl FnOnce(&mut Self) -> Result<InvocationResult>,
     ) -> Result<InvocationResult>;
 
@@ -104,9 +105,6 @@ pub trait CallManager: 'static {
     /// This method doesn't have any side-effects and will continue to return the same address until
     /// `create_actor` is called next.
     fn next_actor_address(&self) -> Address;
-
-    /// The call stack is currently in "read-only" mode. All state mutations will fail.
-    fn is_read_only(&self) -> bool;
 
     /// Create a new actor with the given code CID, actor ID, and delegated address. This method
     /// does not register the actor with the init actor. It just creates it in the state-tree.

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -152,10 +152,17 @@ where
                 )
             });
 
-            let result = cm.with_transaction(false, |cm| {
+            let result = cm.with_transaction(|cm| {
                 // Invoke the message.
-                let ret =
-                    cm.send::<K>(sender_id, msg.to, msg.method_num, params, &msg.value, None)?;
+                let ret = cm.send::<K>(
+                    sender_id,
+                    msg.to,
+                    msg.method_num,
+                    params,
+                    &msg.value,
+                    None,
+                    false,
+                )?;
 
                 // Charge for including the result (before we end the transaction).
                 if let Some(value) = &ret.value {
@@ -471,7 +478,7 @@ where
         sender_state.deduct_funds(&gas_cost)?;
 
         // Update the actor in the state tree
-        self.state_tree_mut().set_actor(sender_id, sender_state)?;
+        self.state_tree_mut().set_actor(sender_id, sender_state);
 
         Ok(Ok((sender_id, gas_cost, inclusion_cost)))
     }

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -90,6 +90,7 @@ pub trait Kernel:
         actor_id: ActorID,
         method: MethodNum,
         value_received: TokenAmount,
+        read_only: bool,
     ) -> Self
     where
         Self: Sized;

--- a/fvm/tests/default_kernel/mod.rs
+++ b/fvm/tests/default_kernel/mod.rs
@@ -29,6 +29,7 @@ pub fn build_inspecting_test() -> anyhow::Result<(TestingKernel, Rc<RefCell<Test
         0,
         0,
         Zero::zero(),
+        false,
     );
     Ok((kern, test_data))
 }
@@ -48,6 +49,7 @@ pub fn build_inspecting_gas_test(
         0,
         0,
         Zero::zero(),
+        false,
     );
     Ok((kern, test_data))
 }

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -284,6 +284,7 @@ impl CallManager for DummyCallManager {
         _params: Option<kernel::Block>,
         _value: &fvm_shared::econ::TokenAmount,
         _gas_limit: Option<Gas>,
+        _read_only: bool,
     ) -> kernel::Result<InvocationResult> {
         // Ok(InvocationResult::Return(None))
         todo!()
@@ -291,7 +292,6 @@ impl CallManager for DummyCallManager {
 
     fn with_transaction(
         &mut self,
-        _read_only: bool,
         _f: impl FnOnce(&mut Self) -> kernel::Result<InvocationResult>,
     ) -> kernel::Result<InvocationResult> {
         // Ok(InvocationResult::Return(None))
@@ -385,11 +385,13 @@ impl CallManager for DummyCallManager {
         id: ActorID,
         state: fvm::state_tree::ActorState,
     ) -> fvm::kernel::Result<()> {
-        self.machine.state_tree_mut().set_actor(id, state)
+        self.machine.state_tree_mut().set_actor(id, state);
+        Ok(())
     }
 
     fn delete_actor(&mut self, id: ActorID) -> fvm::kernel::Result<()> {
-        self.machine.state_tree_mut().delete_actor(id)
+        self.machine.state_tree_mut().delete_actor(id);
+        Ok(())
     }
 
     fn transfer(
@@ -399,9 +401,5 @@ impl CallManager for DummyCallManager {
         _value: &TokenAmount,
     ) -> fvm::kernel::Result<()> {
         todo!()
-    }
-
-    fn is_read_only(&self) -> bool {
-        self.machine().state_tree().is_read_only()
     }
 }

--- a/testing/integration/src/builtin.rs
+++ b/testing/integration/src/builtin.rs
@@ -10,7 +10,7 @@ use fvm_ipld_encoding::CborStore;
 use fvm_shared::ActorID;
 use multihash::Code;
 
-use crate::error::Error::{FailedToLoadManifest, FailedToSetActor, FailedToSetState};
+use crate::error::Error::{FailedToLoadManifest, FailedToSetState};
 
 // Retrieve system, init and accounts actors code CID
 pub fn fetch_builtin_code_cid(
@@ -45,10 +45,8 @@ pub fn set_sys_actor(
         balance: Default::default(),
         delegated_address: None,
     };
-    state_tree
-        .set_actor(system_actor::SYSTEM_ACTOR_ID, sys_actor_state)
-        .map_err(anyhow::Error::from)
-        .context(FailedToSetActor("system actor".to_owned()))
+    state_tree.set_actor(system_actor::SYSTEM_ACTOR_ID, sys_actor_state);
+    Ok(())
 }
 
 pub fn set_init_actor(
@@ -69,10 +67,8 @@ pub fn set_init_actor(
         delegated_address: None,
     };
 
-    state_tree
-        .set_actor(init_actor::INIT_ACTOR_ID, init_actor_state)
-        .map_err(anyhow::Error::from)
-        .context(FailedToSetActor("init actor".to_owned()))
+    state_tree.set_actor(init_actor::INIT_ACTOR_ID, init_actor_state);
+    Ok(())
 }
 
 pub fn set_eam_actor(state_tree: &mut StateTree<impl Blockstore>, eam_code_cid: Cid) -> Result<()> {
@@ -91,8 +87,6 @@ pub fn set_eam_actor(state_tree: &mut StateTree<impl Blockstore>, eam_code_cid: 
         delegated_address: None,
     };
 
-    state_tree
-        .set_actor(EAM_ACTOR_ID, eam_actor_state)
-        .map_err(anyhow::Error::from)
-        .context(FailedToSetActor("eam actor".to_owned()))
+    state_tree.set_actor(EAM_ACTOR_ID, eam_actor_state);
+    Ok(())
 }

--- a/testing/integration/src/error.rs
+++ b/testing/integration/src/error.rs
@@ -11,8 +11,6 @@ pub(crate) enum Error {
     FailedToLoadManifest,
     #[error("could not set state in tree for: {0}")]
     FailedToSetState(String),
-    #[error("could not set actor: {0}")]
-    FailedToSetActor(String),
     #[error("failed to flush tree")]
     FailedToFlushTree,
 }

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -147,7 +147,8 @@ where
 
         state.sequence = new_sequence;
 
-        state_tree.set_actor(id, state).map_err(anyhow::Error::from)
+        state_tree.set_actor(id, state);
+        Ok(())
     }
 
     pub fn create_placeholder(
@@ -175,9 +176,8 @@ where
             delegated_address: Some(*address),
         };
 
-        state_tree
-            .set_actor(id, actor_state)
-            .map_err(anyhow::Error::from)
+        state_tree.set_actor(id, actor_state);
+        Ok(())
     }
 
     /// Set a new state in the state tree
@@ -235,8 +235,7 @@ where
         self.state_tree
             .as_mut()
             .unwrap()
-            .set_actor(actor_id, actor_state)
-            .map_err(anyhow::Error::from)?;
+            .set_actor(actor_id, actor_state);
 
         Ok(code_cid)
     }
@@ -342,9 +341,7 @@ where
             delegated_address: None,
         };
 
-        state_tree
-            .set_actor(assigned_addr, actor_state)
-            .map_err(anyhow::Error::from)?;
+        state_tree.set_actor(assigned_addr, actor_state);
         Ok((assigned_addr, pub_key_addr))
     }
 }

--- a/testing/integration/tests/fil-readonly-actor/src/lib.rs
+++ b/testing/integration/tests/fil-readonly-actor/src/lib.rs
@@ -151,13 +151,14 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
             assert!(output.exit_code.is_success());
             assert_eq!(output.return_data.unwrap().data, b"output");
 
-            // Should be able to emit events.
+            // Should fail to emit events.
             let evt = vec![Entry {
                 flags: Flags::all(),
                 key: "foo".to_owned(),
                 value: RawBytes::new(empty),
             }];
-            sdk::event::emit_event(&evt.into()).unwrap();
+            let err = sdk::event::emit_event(&evt.into()).unwrap_err();
+            assert_eq!(err, ErrorNumber::ReadOnly);
 
             // Should not be able to delete self.
             let err =


### PR DESCRIPTION
This moves read-only handling from inside the state-tree to the kernel, and rejects events when read-only.

I originally put it inside the state-tree to simplify things, but it meant that that the read-only state only got applied at the end, and somewhat inconsistently:

1. Non-zero value transfers to self technically worked.
2. Gas was charged up to the first time a state-update was attempted.

Now, read-only is applied in the kernel _except_ when automatically creating new actors on send (because we don't know if it exists yet).

fixes #1628
fixes #1624