### PR TITLE
feat: remove negative gas charges everywhere

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -102,7 +102,7 @@ where
     fn new(
         machine: M,
         engine: Engine,
-        gas_limit: i64,
+        gas_limit: u64,
         origin: ActorID,
         origin_address: Address,
         receiver: Option<ActorID>,
@@ -268,8 +268,7 @@ where
             ..
         } = *self.0.take().expect("call manager is poisoned");
 
-        // TODO: Having to check against zero here is fishy, but this is what lotus does.
-        let gas_used = gas_tracker.gas_used().max(Gas::zero()).round_up();
+        let gas_used = gas_tracker.gas_used().round_up();
 
         // Finalize any trace events, if we're tracing.
         if machine.context().tracing {
@@ -744,7 +743,8 @@ where
                 }))
                 .map_err(|panic| Abort::Fatal(anyhow!("panic within actor: {:?}", panic)))?;
 
-                // Charge for any remaining uncharged execution gas, returning an error if we run out.
+                // Charge for any remaining uncharged execution gas, returning an error if we run
+                // out.
                 charge_for_exec(&mut store)?;
 
                 // If the invocation failed due to running out of exec_units, we have already

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -51,7 +51,7 @@ pub trait CallManager: 'static {
     fn new(
         machine: Self::Machine,
         engine: Engine,
-        gas_limit: i64,
+        gas_limit: u64,
         origin: ActorID,
         origin_address: Address,
         receiver: Option<ActorID>,
@@ -191,7 +191,7 @@ impl Default for InvocationResult {
 
 /// The returned values upon finishing a call manager.
 pub struct FinishRet {
-    pub gas_used: i64,
+    pub gas_used: u64,
     pub backtrace: Backtrace,
     pub exec_trace: ExecutionTrace,
     pub events: Vec<StampedEvent>,

--- a/fvm/src/engine.rs
+++ b/fvm/src/engine.rs
@@ -11,6 +11,7 @@ use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::error::ExitCode;
 use fvm_wasm_instrument::gas_metering::GAS_COUNTER_NAME;
+use num_traits::Zero;
 use wasmtime::OptLevel::Speed;
 use wasmtime::{
     Global, GlobalType, InstanceAllocationStrategy, InstanceLimits, Linker, Memory, MemoryType,
@@ -19,7 +20,7 @@ use wasmtime::{
 use wasmtime_runtime::InstantiationError;
 
 use crate::call_manager::NO_DATA_BLOCK_ID;
-use crate::gas::{GasTimer, WasmGasPrices};
+use crate::gas::{Gas, GasTimer, WasmGasPrices};
 use crate::machine::limiter::MemoryLimiter;
 use crate::machine::{Machine, NetworkConfig};
 use crate::syscalls::error::Abort;
@@ -583,7 +584,7 @@ impl Engine {
             kernel,
             last_error: None,
             avail_gas_global: self.0.dummy_gas_global,
-            last_milligas_available: 0,
+            last_gas_available: Gas::zero(),
             last_memory_bytes: memory_bytes,
             last_charge_time: GasTimer::start(),
             memory: self.0.dummy_memory,

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -73,7 +73,7 @@ where
 
         struct MachineExecRet {
             result: crate::kernel::error::Result<InvocationResult>,
-            gas_used: i64,
+            gas_used: u64,
             backtrace: Backtrace,
             exec_trace: ExecutionTrace,
             events_root: Option<Cid>,

--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -84,8 +84,8 @@ pub struct ApplyRet {
     pub base_fee_burn: TokenAmount,
     pub over_estimation_burn: TokenAmount,
     pub refund: TokenAmount,
-    pub gas_refund: i64,
-    pub gas_burned: i64,
+    pub gas_refund: u64,
+    pub gas_burned: u64,
 
     /// Additional failure information for debugging, if any.
     pub failure_info: Option<ApplyFailure>,

--- a/fvm/src/gas/outputs.rs
+++ b/fvm/src/gas/outputs.rs
@@ -71,8 +71,8 @@ fn compute_gas_overestimation_burn(gas_used: u64, gas_limit: u64) -> (u64, u64) 
     let gas_used = gas_used as u128;
     let gas_limit = gas_limit as u128;
 
-    // Clamp the "overuse" between 0 and the gas used.
-    // This will charge for any "overuse" past 90%.
+    // This burns (N-10)% (clamped at 0% and 100%) of the remaining gas where N is the
+    // overestimation percentage.
     let over = gas_limit
         .saturating_sub((GAS_OVERUSE_NUM * gas_used) / GAS_OVERUSE_DENOM)
         .min(gas_used);
@@ -88,4 +88,77 @@ fn compute_gas_overestimation_burn(gas_used: u64, gas_limit: u64) -> (u64, u64) 
     let refund = gas_remaining.saturating_sub(gas_to_burn);
 
     (refund as u64, gas_to_burn as u64)
+}
+
+// Adapted from lotus.
+#[test]
+fn overestimation_burn_test() {
+    fn do_test(used: u64, limit: u64, refund: u64, toburn: u64) {
+        let (computed_refund, computed_toburn) = compute_gas_overestimation_burn(used, limit);
+        assert_eq!(refund, computed_refund, "refund");
+        assert_eq!(toburn, computed_toburn, "burned");
+    }
+
+    do_test(100, 200, 10, 90);
+    do_test(100, 150, 30, 20);
+    do_test(1_000, 1_300, 240, 60);
+    do_test(500, 700, 140, 60);
+    do_test(200, 200, 0, 0);
+    do_test(20_000, 21_000, 1_000, 0);
+    do_test(0, 2_000, 0, 2_000);
+    do_test(500, 651, 121, 30);
+    do_test(500, 5_000, 0, 4_500);
+    do_test(7_499_000_000, 7_500_000_000, 1_000_000, 0);
+    do_test(7_500_000_000 / 2, 7_500_000_000, 375_000_000, 3_375_000_000);
+    do_test(1, 7_500_000_000, 0, 7_499_999_999);
+}
+
+#[test]
+fn gas_outputs_test() {
+    #[allow(clippy::too_many_arguments)]
+    fn do_test(
+        used: u64,
+        limit: u64,
+        fee_cap: u64,
+        premium: u64,
+        base_fee_burn: u64,
+        over_estimation_burn: u64,
+        miner_penalty: u64,
+        miner_tip: u64,
+        refund: u64,
+    ) {
+        let base_fee = TokenAmount::from_atto(10);
+        let output = GasOutputs::compute(
+            used,
+            limit,
+            &base_fee,
+            &TokenAmount::from_atto(fee_cap),
+            &TokenAmount::from_atto(premium),
+        );
+        assert_eq!(
+            TokenAmount::from_atto(base_fee_burn),
+            output.base_fee_burn,
+            "base_fee_burn"
+        );
+        assert_eq!(
+            TokenAmount::from_atto(over_estimation_burn),
+            output.over_estimation_burn,
+            "over_estimation_burn"
+        );
+        assert_eq!(
+            TokenAmount::from_atto(miner_penalty),
+            output.miner_penalty,
+            "miner_penalty"
+        );
+        assert_eq!(
+            TokenAmount::from_atto(miner_tip),
+            output.miner_tip,
+            "miner_tip"
+        );
+        assert_eq!(TokenAmount::from_atto(refund), output.refund, "refund");
+    }
+    do_test(100, 110, 11, 1, 1_000, 0, 0, 110, 100);
+    do_test(100, 130, 11, 1, 1_000, 60, 0, 130, 240);
+    do_test(100, 110, 10, 1, 1_000, 0, 0, 0, 100);
+    do_test(100, 110, 6, 1, 600, 0, 400, 0, 60);
 }

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -1232,3 +1232,43 @@ fn test_read_write() {
     );
     assert_eq!(HYGGE_PRICES.on_block_create(10).total(), Gas::new(100));
 }
+
+#[test]
+fn test_step_cost() {
+    let costs = StepCost(vec![
+        Step {
+            start: 10,
+            cost: Gas::new(1),
+        },
+        Step {
+            start: 20,
+            cost: Gas::new(2),
+        },
+    ]);
+    assert!(costs.lookup(0).is_zero());
+    assert!(costs.lookup(5).is_zero());
+
+    assert_eq!(costs.lookup(10), Gas::new(1));
+    assert_eq!(costs.lookup(11), Gas::new(1));
+    assert_eq!(costs.lookup(19), Gas::new(1));
+
+    assert_eq!(costs.lookup(20), Gas::new(2));
+    assert_eq!(costs.lookup(100), Gas::new(2));
+}
+
+#[test]
+fn test_step_cost_empty() {
+    let costs = StepCost(vec![]);
+    assert!(costs.lookup(0).is_zero());
+    assert!(costs.lookup(10).is_zero());
+}
+
+#[test]
+fn test_step_cost_zero() {
+    let costs = StepCost(vec![Step {
+        start: 0,
+        cost: Gas::new(1),
+    }]);
+    assert_eq!(costs.lookup(0), Gas::new(1));
+    assert_eq!(costs.lookup(10), Gas::new(1));
+}

--- a/fvm/src/syscalls/gas.rs
+++ b/fvm/src/syscalls/gas.rs
@@ -11,7 +11,7 @@ pub fn charge_gas(
     context: Context<'_, impl Kernel>,
     name_off: u32,
     name_len: u32,
-    compute: i64,
+    compute: u64,
 ) -> Result<()> {
     let name =
         str::from_utf8(context.memory.try_slice(name_off, name_len)?).or_illegal_argument()?;

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -1,7 +1,5 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use std::mem;
-
 use anyhow::{anyhow, Context as _};
 use num_traits::Zero;
 use wasmtime::{AsContextMut, ExternType, Global, Linker, Memory, Module, Val};
@@ -47,7 +45,7 @@ pub struct InvocationData<K> {
     /// The last-set milligas limit. When `charge_for_exec` is called, we charge for the
     /// _difference_ between the current gas available (the wasm global) and the
     /// `last_milligas_available`.
-    pub last_milligas_available: i64,
+    pub last_gas_available: Gas,
 
     /// The total size of the memory used by the execution the last time we charged gas for it.
     pub last_memory_bytes: usize,
@@ -65,17 +63,25 @@ pub fn update_gas_available(
     ctx: &mut impl AsContextMut<Data = InvocationData<impl Kernel>>,
 ) -> Result<(), Abort> {
     let mut ctx = ctx.as_context_mut();
-    let avail_milligas = ctx.data_mut().kernel.gas_available().as_milligas();
+    let avail_gas = ctx.data_mut().kernel.gas_available();
 
     let gas_global = ctx.data_mut().avail_gas_global;
+    let avail_milligas = avail_gas
+        .as_milligas()
+        .try_into()
+        // The gas tracker guarantees that this can't be the case. If this does happen, it likely
+        // means there's a serious bug (e.g., some kind of wrap-around).
+        .map_err(|_| Abort::Fatal(anyhow!("available milligas exceeded i64::MAX")))?;
+
     gas_global
         .set(&mut ctx, Val::I64(avail_milligas))
         .map_err(|e| Abort::Fatal(anyhow!("failed to set available gas global: {}", e)))?;
 
-    ctx.data_mut().last_milligas_available = avail_milligas;
-
-    // Also adjust the instant we use in `charge_for_exec` to measure wasm execution time.
-    ctx.data_mut().last_charge_time = GasTimer::start();
+    // Finally, update the last-seen values. We'll use these values in `charge_for_exec` below.
+    let data = ctx.data_mut();
+    data.last_gas_available = avail_gas;
+    data.last_memory_bytes = data.kernel.limiter_mut().memory_used();
+    data.last_charge_time = GasTimer::start();
 
     Ok(())
 }
@@ -87,49 +93,60 @@ pub fn charge_for_exec<K: Kernel>(
     let mut ctx = ctx.as_context_mut();
     let global = ctx.data_mut().avail_gas_global;
 
-    let milligas_available = global
+    // Get the remaining milligas. This will go _negative_ if we run out.
+    let milligas_available_wasm = global
         .get(&mut ctx)
         .i64()
         .context("failed to get wasm gas")
         .map_err(Abort::Fatal)?;
 
-    // Determine milligas used, and update the gas tracker.
-    let mut exec_gas = {
-        let data = ctx.data_mut();
-        let last_milligas = mem::replace(&mut data.last_milligas_available, milligas_available);
-        // This should never be negative, but we might as well check.
-        Gas::from_milligas(last_milligas.saturating_sub(milligas_available))
-    };
-
     let data = ctx.data_mut();
+
+    let mut exec_gas_charge = if milligas_available_wasm < 0 {
+        // If the gas remaining is negative, we charge for all remaining gas, plus `-remaining_gas`.
+        // That way we actually run out.
+        data.last_gas_available
+            + Gas::from_milligas(milligas_available_wasm.saturating_abs() as u64)
+    } else {
+        // If it's non-negative, we charge for up-to all remaining gas.
+        data.last_gas_available - Gas::from_milligas(milligas_available_wasm as u64)
+    };
 
     // Separate the amount of gas charged for memory; this is only makes a difference in tracing.
     let memory_bytes = data.kernel.limiter_mut().memory_used();
     let memory_delta_bytes = memory_bytes.saturating_sub(data.last_memory_bytes);
-    let memory_gas = data.kernel.price_list().grow_memory_gas(memory_delta_bytes);
 
-    exec_gas = (exec_gas - memory_gas).max(Gas::zero());
+    // `exec_gas_charge` is the number we want to charge. If, for some reason, `memory_gas_charge`
+    // exceeds `exec_gas_charge`, we just set `memory_gas_charge` to `exec_gas_charge`, and set
+    // `exec_gas_charge` to zero.
+    let mut memory_gas_charge = data.kernel.price_list().grow_memory_gas(memory_delta_bytes);
+    if memory_gas_charge <= exec_gas_charge {
+        exec_gas_charge -= memory_gas_charge;
+    } else {
+        memory_gas_charge = exec_gas_charge;
+        exec_gas_charge = Gas::zero();
+    }
+
+    // Now we actually charge. If we go below 0, we run out of gas.
 
     let t = data
         .kernel
-        .charge_gas("wasm_exec", exec_gas)
+        .charge_gas("wasm_exec", exec_gas_charge)
         .map_err(Abort::from_error_as_fatal)?;
 
-    // It should be okay to record time associated with Wasm execution because `charge_for_exec` is called
-    // before syscalls `impl_bind_syscalls`, so the syscall timings are going to be interleaved, rather than
-    // nested inside it. But we also have to make sure to reset the timer after each syscall, when Wasm resumes,
-    // which happens in `update_gas_available`.
+    // It should be okay to record time associated with Wasm execution because `charge_for_exec` is
+    // called before syscalls `impl_bind_syscalls`, so the syscall timings are going to be
+    // interleaved, rather than nested inside it. But we also have to make sure to reset the timer
+    // after each syscall, when Wasm resumes, which happens in `update_gas_available`.
     t.stop_with(data.last_charge_time);
-    data.last_charge_time = GasTimer::start();
-    data.last_memory_bytes = memory_bytes;
 
-    if !memory_gas.is_zero() {
-        // Only recording time for the execution, not for the memory part, which is unknown.
-        // But we could perform stomething like a multi-variate linear regression to see if the amount of
+    if !memory_gas_charge.is_zero() {
+        // Only recording time for the execution, not for the memory part, which is unknown. But we
+        // could perform stomething like a multi-variate linear regression to see if the amount of
         // memory explains any of the exectuion time.
         let _ = data
             .kernel
-            .charge_gas("wasm_memory_grow", memory_gas)
+            .charge_gas("wasm_memory_grow", memory_gas_charge)
             .map_err(Abort::from_error_as_fatal)?;
     }
 

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -119,13 +119,13 @@ pub fn charge_for_exec<K: Kernel>(
         data.last_gas_available - Gas::from_milligas(milligas_available_wasm_abs)
     };
 
-    // Separate the amount of gas charged for memory; this is only makes a difference in tracing.
+    // Now we separate the amount of gas charged for memory; this is only makes a difference in
+    // tracing. `exec_gas_charge` is the number we want to charge. If, for some reason,
+    // `memory_gas_charge` exceeds `exec_gas_charge`, we just set `memory_gas_charge` to
+    // `exec_gas_charge`, and set `exec_gas_charge` to zero.
     let memory_bytes = data.kernel.limiter_mut().memory_used();
     let memory_delta_bytes = memory_bytes.saturating_sub(data.last_memory_bytes);
 
-    // `exec_gas_charge` is the number we want to charge. If, for some reason, `memory_gas_charge`
-    // exceeds `exec_gas_charge`, we just set `memory_gas_charge` to `exec_gas_charge`, and set
-    // `exec_gas_charge` to zero.
     let mut memory_gas_charge = data.kernel.price_list().grow_memory_gas(memory_delta_bytes);
     if memory_gas_charge <= exec_gas_charge {
         exec_gas_charge -= memory_gas_charge;

--- a/fvm/src/syscalls/send.rs
+++ b/fvm/src/syscalls/send.rs
@@ -28,7 +28,9 @@ pub fn send(
     let value = TokenAmount::from_atto((value_hi as u128) << 64 | value_lo as u128);
 
     // If that gas limit exceeds i64, treat it as infinity. u64::MAX is used to indicate "all gas".
-    let gas_limit = gas_limit.try_into().ok().map(Gas::new);
+    // Although really, this doesn't matter. Any gas exceeding the current gas available is treated
+    // as "all remaining gas".
+    let gas_limit = (gas_limit <= (i64::MAX as u64)).then(|| Gas::new(gas_limit));
 
     let flags = SendFlags::from_bits(flags)
         .with_context(|| format!("invalid send flags: {flags}"))

--- a/fvm/src/syscalls/send.rs
+++ b/fvm/src/syscalls/send.rs
@@ -27,10 +27,9 @@ pub fn send(
     let recipient: Address = context.memory.read_address(recipient_off, recipient_len)?;
     let value = TokenAmount::from_atto((value_hi as u128) << 64 | value_lo as u128);
 
-    // If that gas limit exceeds i64, treat it as infinity. u64::MAX is used to indicate "all gas".
-    // Although really, this doesn't matter. Any gas exceeding the current gas available is treated
-    // as "all remaining gas".
-    let gas_limit = (gas_limit <= (i64::MAX as u64)).then(|| Gas::new(gas_limit));
+    // If that gas is u64::MAX, treat it as "all gas". Although really, this doesn't matter. Any gas
+    // exceeding the current gas available is treated as "all remaining gas".
+    let gas_limit = (gas_limit < u64::MAX).then(|| Gas::new(gas_limit));
 
     let flags = SendFlags::from_bits(flags)
         .with_context(|| format!("invalid send flags: {flags}"))

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -204,6 +204,8 @@ pub struct TestData {
     pub charge_gas_calls: usize,
 }
 
+const BLOCK_GAS_LIMIT: Gas = Gas::new(10_000_000_000);
+
 impl DummyCallManager {
     pub fn new_stub() -> (Self, Rc<RefCell<TestData>>) {
         let rc = Rc::new(RefCell::new(TestData {
@@ -213,7 +215,7 @@ impl DummyCallManager {
         (
             Self {
                 machine: DummyMachine::new_stub().unwrap(),
-                gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0), false),
+                gas_tracker: GasTracker::new(BLOCK_GAS_LIMIT, Gas::new(0), false),
                 origin: 0,
                 nonce: 0,
                 test_data: rc,
@@ -252,7 +254,7 @@ impl CallManager for DummyCallManager {
     fn new(
         machine: Self::Machine,
         _engine: Engine,
-        _gas_limit: i64,
+        _gas_limit: u64,
         origin: ActorID,
         origin_address: Address,
         _receiver: Option<ActorID>,
@@ -266,7 +268,7 @@ impl CallManager for DummyCallManager {
         let limits = machine.new_limiter();
         Self {
             machine,
-            gas_tracker: GasTracker::new(Gas::new(i64::MAX), Gas::new(0), false),
+            gas_tracker: GasTracker::new(BLOCK_GAS_LIMIT, Gas::new(0), false),
             gas_premium,
             origin,
             origin_address,

--- a/shared/src/message.rs
+++ b/shared/src/message.rs
@@ -15,14 +15,14 @@ use crate::MethodNum;
 #[cfg_attr(feature = "testing", derive(Default))]
 #[derive(PartialEq, Clone, Debug, Hash, Eq)]
 pub struct Message {
-    pub version: i64,
+    pub version: u64,
     pub from: Address,
     pub to: Address,
     pub sequence: u64,
     pub value: TokenAmount,
     pub method_num: MethodNum,
     pub params: RawBytes,
-    pub gas_limit: i64,
+    pub gas_limit: u64,
     pub gas_fee_cap: TokenAmount,
     pub gas_premium: TokenAmount,
 }
@@ -33,8 +33,9 @@ impl Message {
         if self.gas_limit == 0 {
             return Err(anyhow!("Message has no gas limit set"));
         }
-        if self.gas_limit < 0 {
-            return Err(anyhow!("Message has negative gas limit"));
+        // TODO: max block limit?
+        if self.gas_limit > i64::MAX as u64 {
+            return Err(anyhow!("Message gas exceeds i64 max"));
         }
         Ok(())
     }
@@ -99,12 +100,12 @@ impl quickcheck::Arbitrary for Message {
         Self {
             to: Address::arbitrary(g),
             from: Address::arbitrary(g),
-            version: i64::arbitrary(g),
+            version: u64::arbitrary(g),
             sequence: u64::arbitrary(g),
             value: TokenAmount::arbitrary(g),
             method_num: u64::arbitrary(g),
             params: fvm_ipld_encoding::RawBytes::new(Vec::arbitrary(g)),
-            gas_limit: i64::arbitrary(g),
+            gas_limit: u64::arbitrary(g),
             gas_fee_cap: TokenAmount::arbitrary(g),
             gas_premium: TokenAmount::arbitrary(g),
         }

--- a/shared/src/receipt.rs
+++ b/shared/src/receipt.rs
@@ -13,7 +13,7 @@ use crate::error::ExitCode;
 pub struct Receipt {
     pub exit_code: ExitCode,
     pub return_data: RawBytes,
-    pub gas_used: i64,
+    pub gas_used: u64,
     /// If any actor events were emitted during execution, this field will contain the CID of the
     /// root of the AMT holding the StampedEvents. Otherwise, this will be None (serializing to a
     /// CBOR NULL value on the wire).

--- a/testing/calibration/src/lib.rs
+++ b/testing/calibration/src/lib.rs
@@ -91,7 +91,7 @@ pub struct Obs {
     pub label: String,
     pub elapsed_nanos: u128,
     pub variables: Vec<usize>,
-    pub compute_gas: i64,
+    pub compute_gas: u64,
 }
 
 #[derive(Serialize)]

--- a/testing/conformance/src/tracing.rs
+++ b/testing/conformance/src/tracing.rs
@@ -26,7 +26,7 @@ pub struct TestMessageTombstone {
     /// The path includes the name of the test, the ID of the variant, and the index of the message.
     pub trace_path: PathBuf,
     /// Overall gas burned.
-    pub gas_burned: i64,
+    pub gas_burned: u64,
     /// Overall time elapsed.
     pub elapsed_nanos: u128,
 }
@@ -38,8 +38,8 @@ pub struct TestMessageTombstone {
 #[derive(Serialize, Deserialize)]
 pub struct TestGasCharge {
     pub name: String,
-    pub compute_gas: i64,
-    pub other_gas: i64,
+    pub compute_gas: u64,
+    pub other_gas: u64,
     pub elapsed_nanos: Option<u128>,
 }
 

--- a/testing/conformance/src/vector.rs
+++ b/testing/conformance/src/vector.rs
@@ -244,7 +244,7 @@ mod message_receipt_vec {
         exit_code: ExitCode,
         #[serde(rename = "return", with = "base64_bytes")]
         return_value: Vec<u8>,
-        gas_used: i64,
+        gas_used: u64,
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Receipt>, D::Error>

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -220,7 +220,7 @@ where
     fn new(
         machine: Self::Machine,
         engine: Engine,
-        gas_limit: i64,
+        gas_limit: u64,
         origin: ActorID,
         origin_address: Address,
         receiver: Option<ActorID>,

--- a/testing/integration/src/testkit/fevm.rs
+++ b/testing/integration/src/testkit/fevm.rs
@@ -12,7 +12,7 @@ use fvm_shared::{ActorID, METHOD_CONSTRUCTOR};
 use crate::tester::{BasicAccount, BasicTester};
 
 pub const EAM_ADDRESS: Address = Address::new_id(10);
-pub const DEFAULT_GAS: i64 = 10_000_000_000;
+pub const DEFAULT_GAS: u64 = 10_000_000_000;
 
 pub fn create_contract(
     tester: &mut BasicTester,
@@ -42,7 +42,7 @@ pub fn invoke_contract(
     src: &mut BasicAccount,
     dest: Address,
     input_data: &[u8],
-    gas: i64,
+    gas: u64,
 ) -> Result<ApplyRet> {
     let invoke_msg = Message {
         from: src.account.1,

--- a/tools/fvm-bench/src/fevm.rs
+++ b/tools/fvm-bench/src/fevm.rs
@@ -11,7 +11,7 @@ pub fn run(
     contract: &[u8],
     entrypoint: &[u8],
     params: &[u8],
-    gas: i64,
+    gas: u64,
 ) -> anyhow::Result<()> {
     let mut account = tester.create_basic_account()?;
 

--- a/tools/fvm-bench/src/main.rs
+++ b/tools/fvm-bench/src/main.rs
@@ -44,7 +44,7 @@ struct Args {
     #[arg(short, long, default_value = "10000000000")]
     /// Gas limit in atto precision to use during invocation.
     /// Default: 10 billion gas
-    gas_limit: i64,
+    gas_limit: u64,
 }
 
 fn run() -> anyhow::Result<()> {


### PR DESCRIPTION
This removes negative gas charges and makes gas a u64. Motivations:

1. We (finally) no longer have negative gas charges.
2. This makes it easier to reason about gas and ensure that gas never goes "backwards".

If the gas limit starts above i64::MAX _milligas_, we saturate it to i64::MAX.