### PR TITLE
feat: tweak tipset lookback limits

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -706,10 +706,11 @@ where
         if epoch < 0 {
             return Err(syscall_error!(IllegalArgument; "epoch is negative").into());
         }
-        // TODO: https://github.com/filecoin-project/ref-fvm/issues/1023
         let offset = self.call_manager.context().epoch - epoch;
         if offset < 0 {
             Err(syscall_error!(IllegalArgument; "epoch {} is in the future", epoch).into())
+        } else if offset == 0 {
+            Err(syscall_error!(IllegalArgument; "cannot lookup the tipset cid for the current epoch").into())
         } else if offset >= FINALITY {
             Err(syscall_error!(IllegalArgument; "epoch {} is too far in the past", epoch).into())
         } else {


### PR DESCRIPTION
I'm currently specifying these limits in the FIP and figured this was the time to deal with the TODO.

This change forbids looking up the current tipset CID. This is technically possible in expected consensus, but may not be possible in all forms of consensus.

Fixes #1023