### PR TITLE
fix: use u64 for the block gas limit

### DIFF
--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -204,7 +204,7 @@ pub struct TestData {
     pub charge_gas_calls: usize,
 }
 
-const BLOCK_GAS_LIMIT: Gas = Gas::new(10_000_000_000);
+const BLOCK_GAS_LIMIT: Gas = Gas::new(fvm_shared::BLOCK_GAS_LIMIT);
 
 impl DummyCallManager {
     pub fn new_stub() -> (Self, Rc<RefCell<TestData>>) {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -61,7 +61,7 @@ pub type ActorID = u64;
 /// Default bit width for the hamt in the filecoin protocol.
 pub const HAMT_BIT_WIDTH: u32 = 5;
 /// Total gas limit allowed per block. This is shared across networks.
-pub const BLOCK_GAS_LIMIT: i64 = 10_000_000_000;
+pub const BLOCK_GAS_LIMIT: u64 = 10_000_000_000;
 /// Total Filecoin supply.
 pub const TOTAL_FILECOIN_BASE: i64 = 2_000_000_000;
 


### PR DESCRIPTION
This wasn't used internally, so it wasn't caught. We now use it.