### PR TITLE
feat: put blocks with codecs in the trace

### DIFF
--- a/fvm/src/kernel/blocks.rs
+++ b/fvm/src/kernel/blocks.rs
@@ -3,6 +3,7 @@
 use std::convert::TryInto;
 use std::rc::Rc;
 
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::{CBOR, DAG_CBOR};
 use fvm_shared::IPLD_RAW;
 use thiserror::Error;
@@ -71,6 +72,27 @@ impl Block {
         BlockStat {
             codec: self.codec(),
             size: self.size(),
+        }
+    }
+}
+
+impl From<IpldBlock> for Block {
+    fn from(b: IpldBlock) -> Self {
+        Block::new(b.codec, b.data)
+    }
+}
+
+impl From<&IpldBlock> for Block {
+    fn from(b: &IpldBlock) -> Self {
+        Block::new(b.codec, &*b.data)
+    }
+}
+
+impl From<&Block> for IpldBlock {
+    fn from(b: &Block) -> Self {
+        IpldBlock {
+            codec: b.codec,
+            data: Vec::from(&**b.data),
         }
     }
 }

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use fvm_ipld_encoding::RawBytes;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -23,9 +23,9 @@ pub enum ExecutionEvent {
         from: ActorID,
         to: Address,
         method: MethodNum,
-        params: RawBytes,
+        params: Option<IpldBlock>,
         value: TokenAmount,
     },
-    CallReturn(ExitCode, RawBytes),
+    CallReturn(ExitCode, Option<IpldBlock>),
     CallError(SyscallError),
 }


### PR DESCRIPTION
Otherwise, users can't decode them. Requested by the @frrist.