### PR TITLE
feat: kernel: don't auto-convert ExecutionError to anyhow

### DIFF
--- a/fvm/src/kernel/error.rs
+++ b/fvm/src/kernel/error.rs
@@ -160,18 +160,6 @@ impl Context for ExecutionError {
     }
 }
 
-// We only use this when converting to a fatal error, so we throw away the error code.
-impl From<ExecutionError> for anyhow::Error {
-    fn from(e: ExecutionError) -> Self {
-        use ExecutionError::*;
-        match e {
-            OutOfGas => anyhow::anyhow!("out of gas"),
-            Syscall(err) => anyhow::anyhow!(err.0),
-            Fatal(err) => err,
-        }
-    }
-}
-
 /// Represents an error from a syscall. It can optionally contain a
 /// syscall-advised exit code for the kind of error that was raised.
 /// We may want to add an optional source error here.

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -95,7 +95,7 @@ where
         // Create a new state tree from the supplied root.
         let state_tree = {
             let bstore = BufferedBlockstore::new(blockstore);
-            StateTree::new_from_root(bstore, &context.initial_state_root)?
+            StateTree::new_from_root(bstore, &context.initial_state_root).map_err(|e| anyhow!(e))?
         };
 
         // Load the built-in actors manifest.
@@ -108,7 +108,7 @@ where
                 (cid, version)
             }
             None => {
-                let (state, _) = SystemActorState::load(&state_tree)?;
+                let (state, _) = SystemActorState::load(&state_tree).map_err(|e| anyhow!(e))?;
                 (state.builtin_actors, 1)
             }
         };

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -94,7 +94,7 @@ where
 
         // Initialize state tree
         let init_state = init_actor::State::new_test(&blockstore);
-        let mut state_tree = StateTree::new(blockstore, stv).map_err(anyhow::Error::from)?;
+        let mut state_tree = StateTree::new(blockstore, stv).map_err(|e| anyhow!(e))?;
 
         // Deploy init, sys, and eam actors
         let sys_state = system_actor::State { builtin_actors };
@@ -142,7 +142,8 @@ where
             .ok_or_else(|| anyhow!("Expected state tree in set_account_sequence."))?;
 
         let mut state = state_tree
-            .get_actor(id)?
+            .get_actor(id)
+            .map_err(|e| anyhow!(e))?
             .ok_or_else(|| anyhow!("Can't set sequence of account that doesn't exist."))?;
 
         state.sequence = new_sequence;
@@ -268,7 +269,7 @@ where
         // Calculate the state root.
         let state_root = state_tree
             .flush()
-            .map_err(anyhow::Error::from)
+            .map_err(|e| anyhow!(e))
             .context(FailedToFlushTree)?;
 
         // Consume the state tree and take the blockstore.


### PR DESCRIPTION
#1488 

This PR demonstrates all of the current places where we auto-convert ExecutionErrors into fatal anyhow errors. Having looked at them all, I think we're comfortable with all of these conversions.

Next steps:
- Reviewers confirm the existing conversion sites are fine to treat as fatal
- Decide on whether we want to land this in FVM v3.
- Some way to make this more "explicitly" FATAL in code?
- Will fixup tests when we have a clearer direction.