### PR TITLE
Ranged HAMT iteration specified via keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ target
 !testing/integration/tests/assets/*
 testing/conformance/traces
 .idea/
+.vscode/
 lcov.info

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -212,7 +212,7 @@ where
                             f,
                         )?;
                         traversed_count += traversed;
-                        if limit.map_or(false, |l| traversed_count > l) && key.is_some() {
+                        if limit.map_or(false, |l| traversed_count >= l) && key.is_some() {
                             return Ok((traversed_count, key));
                         }
                     } else {

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -731,10 +731,12 @@ fn tstring(v: impl Display) -> BytesKey {
 }
 
 mod test_default {
-    use fvm_ipld_blockstore::tracking::BSStats;
+    use fvm_ipld_blockstore::tracking::{BSStats, TrackingBlockstore};
+    use fvm_ipld_blockstore::MemoryBlockstore;
+    use fvm_ipld_hamt::{BytesKey, Hamt};
     use quickcheck_macros::quickcheck;
 
-    use crate::{CidChecker, HamtFactory, LimitedKeyOps, UniqueKeyValuePairs};
+    use crate::{tstring, CidChecker, HamtFactory, LimitedKeyOps, UniqueKeyValuePairs};
 
     #[test]
     fn test_basics() {
@@ -821,6 +823,118 @@ mod test_default {
             "bafy2bzaceczhz54xmmz3xqnbmvxfbaty3qprr6dq7xh5vzwqbirlsnbd36z7a",
         ]);
         super::for_each(HamtFactory::default(), Some(stats), cids);
+    }
+
+    #[test]
+    fn for_each_ranged() {
+        #[rustfmt::skip]
+        let factory = HamtFactory::default();
+        let mem = MemoryBlockstore::default();
+        let store = TrackingBlockstore::new(&mem);
+
+        let mut hamt: Hamt<_, usize> = factory.new_with_bit_width(&store, 5);
+
+        const RANGE: usize = 200;
+        for i in 0..RANGE {
+            hamt.set(tstring(i), i).unwrap();
+        }
+
+        // collect all KV paris by iterating through the entire hamt
+        let mut kvs = Vec::new();
+        hamt.for_each(|k, v| {
+            assert_eq!(k, &tstring(v));
+            kvs.push((k.clone(), *v));
+            Ok(())
+        })
+        .unwrap();
+
+        // Iterate through the array, requesting pages of different sizes
+        for page_size in 0..RANGE {
+            let mut kvs_variable_page = Vec::new();
+            let (num_traversed, next_key) = hamt
+                .for_each_ranged::<BytesKey, _>(None, Some(page_size), |k, v| {
+                    kvs_variable_page.push((k.clone(), *v));
+                    Ok(())
+                })
+                .unwrap();
+
+            assert_eq!(num_traversed, page_size);
+            assert_eq!(kvs_variable_page.len(), num_traversed);
+            assert_eq!(next_key.unwrap(), kvs[page_size].0);
+
+            // Items iterated over should match the ordering of for_each
+            assert_eq!(kvs_variable_page, kvs[..page_size]);
+        }
+
+        // Iterate through the array, requesting more items than are remaining
+        let (num_traversed, next_key) = hamt
+            .for_each_ranged::<BytesKey, _>(None, Some(RANGE + 10), |k, v| Ok(()))
+            .unwrap();
+        assert_eq!(num_traversed, RANGE);
+        assert_eq!(next_key, None);
+
+        // Iterate through it again starting at a certain key
+        for start_at in 0..RANGE as usize {
+            let mut kvs_variable_start = Vec::new();
+            let (num_traversed, next_key) = hamt
+                .for_each_ranged(Some(&kvs[start_at].0), None, |k, v| {
+                    assert_eq!(k, &tstring(v));
+                    kvs_variable_start.push((k.clone(), *v));
+
+                    Ok(())
+                })
+                .unwrap();
+
+            // No limit specified, iteration should be exhaustive
+            assert_eq!(next_key, None);
+            assert_eq!(num_traversed, kvs_variable_start.len());
+            assert_eq!(kvs_variable_start.len(), kvs.len() - start_at,);
+
+            // Items iterated over should match the ordering of for_each
+            assert_eq!(kvs_variable_start, kvs[start_at..]);
+        }
+
+        // Chain paginated requests to iterate over entire HAMT
+        {
+            let mut kvs_paginated_requests = Vec::new();
+            let mut iterations = 0;
+            let mut cursor: Option<BytesKey> = None;
+
+            // Request all items in pages of 20 items each
+            const PAGE_SIZE: usize = 20;
+            loop {
+                let (page_size, next) = match cursor {
+                    Some(ref start) => hamt
+                        .for_each_ranged::<BytesKey, _>(Some(start), Some(PAGE_SIZE), |k, v| {
+                            kvs_paginated_requests.push((k.clone(), *v));
+                            Ok(())
+                        })
+                        .unwrap(),
+                    None => hamt
+                        .for_each_ranged::<BytesKey, _>(None, Some(PAGE_SIZE), |k, v| {
+                            kvs_paginated_requests.push((k.clone(), *v));
+                            Ok(())
+                        })
+                        .unwrap(),
+                };
+                iterations += 1;
+                assert_eq!(page_size, PAGE_SIZE);
+                assert_eq!(kvs_paginated_requests.len(), iterations * PAGE_SIZE);
+
+                if next.is_none() {
+                    break;
+                } else {
+                    assert_eq!(next.clone().unwrap(), kvs[(iterations * PAGE_SIZE)].0);
+                    cursor = next;
+                }
+            }
+
+            // should have retrieved all key value pairs in the same order
+            assert_eq!(kvs_paginated_requests.len(), kvs.len(), "{}", iterations);
+            assert_eq!(kvs_paginated_requests, kvs);
+            // should have used the expected number of iterations
+            assert_eq!(iterations, RANGE / PAGE_SIZE);
+        }
     }
 
     #[test]

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -386,6 +386,168 @@ fn for_each(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidChecker) 
     }
 }
 
+fn for_each_ranged(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidChecker) {
+    let mem = MemoryBlockstore::default();
+    let store = TrackingBlockstore::new(&mem);
+
+    let mut hamt: Hamt<_, usize> = factory.new_with_bit_width(&store, 5);
+
+    const RANGE: usize = 200;
+    for i in 0..RANGE {
+        hamt.set(tstring(i), i).unwrap();
+    }
+
+    // collect all KV paris by iterating through the entire hamt
+    let mut kvs = Vec::new();
+    hamt.for_each(|k, v| {
+        assert_eq!(k, &tstring(v));
+        kvs.push((k.clone(), *v));
+        Ok(())
+    })
+    .unwrap();
+
+    // Iterate through the array, requesting pages of different sizes
+    for page_size in 0..RANGE {
+        let mut kvs_variable_page = Vec::new();
+        let (num_traversed, next_key) = hamt
+            .for_each_ranged::<BytesKey, _>(None, Some(page_size), |k, v| {
+                kvs_variable_page.push((k.clone(), *v));
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(num_traversed, page_size);
+        assert_eq!(kvs_variable_page.len(), num_traversed);
+        assert_eq!(next_key.unwrap(), kvs[page_size].0);
+
+        // Items iterated over should match the ordering of for_each
+        assert_eq!(kvs_variable_page, kvs[..page_size]);
+    }
+
+    // Iterate through the array, requesting more items than are remaining
+    let (num_traversed, next_key) = hamt
+        .for_each_ranged::<BytesKey, _>(None, Some(RANGE + 10), |_k, _v| Ok(()))
+        .unwrap();
+    assert_eq!(num_traversed, RANGE);
+    assert_eq!(next_key, None);
+
+    // Iterate through it again starting at a certain key
+    for start_at in 0..RANGE as usize {
+        let mut kvs_variable_start = Vec::new();
+        let (num_traversed, next_key) = hamt
+            .for_each_ranged(Some(&kvs[start_at].0), None, |k, v| {
+                assert_eq!(k, &tstring(v));
+                kvs_variable_start.push((k.clone(), *v));
+
+                Ok(())
+            })
+            .unwrap();
+
+        // No limit specified, iteration should be exhaustive
+        assert_eq!(next_key, None);
+        assert_eq!(num_traversed, kvs_variable_start.len());
+        assert_eq!(kvs_variable_start.len(), kvs.len() - start_at,);
+
+        // Items iterated over should match the ordering of for_each
+        assert_eq!(kvs_variable_start, kvs[start_at..]);
+    }
+
+    // Chain paginated requests to iterate over entire HAMT
+    {
+        let mut kvs_paginated_requests = Vec::new();
+        let mut iterations = 0;
+        let mut cursor: Option<BytesKey> = None;
+
+        // Request all items in pages of 20 items each
+        const PAGE_SIZE: usize = 20;
+        loop {
+            let (page_size, next) = match cursor {
+                Some(ref start) => hamt
+                    .for_each_ranged::<BytesKey, _>(Some(start), Some(PAGE_SIZE), |k, v| {
+                        kvs_paginated_requests.push((k.clone(), *v));
+                        Ok(())
+                    })
+                    .unwrap(),
+                None => hamt
+                    .for_each_ranged::<BytesKey, _>(None, Some(PAGE_SIZE), |k, v| {
+                        kvs_paginated_requests.push((k.clone(), *v));
+                        Ok(())
+                    })
+                    .unwrap(),
+            };
+            iterations += 1;
+            assert_eq!(page_size, PAGE_SIZE);
+            assert_eq!(kvs_paginated_requests.len(), iterations * PAGE_SIZE);
+
+            if next.is_none() {
+                break;
+            } else {
+                assert_eq!(next.clone().unwrap(), kvs[(iterations * PAGE_SIZE)].0);
+                cursor = next;
+            }
+        }
+
+        // should have retrieved all key value pairs in the same order
+        assert_eq!(kvs_paginated_requests.len(), kvs.len(), "{}", iterations);
+        assert_eq!(kvs_paginated_requests, kvs);
+        // should have used the expected number of iterations
+        assert_eq!(iterations, RANGE / PAGE_SIZE);
+    }
+
+    let c = hamt.flush().unwrap();
+    cids.check_next(c);
+
+    // Chain paginated requests over a HAMT with committed nodes
+    let mut hamt: Hamt<_, usize> = factory.load_with_bit_width(&c, &store, 5).unwrap();
+    {
+        let mut kvs_paginated_requests = Vec::new();
+        let mut iterations = 0;
+        let mut cursor: Option<BytesKey> = None;
+
+        // Request all items in pages of 20 items each
+        const PAGE_SIZE: usize = 20;
+        loop {
+            let (page_size, next) = match cursor {
+                Some(ref start) => hamt
+                    .for_each_ranged::<BytesKey, _>(Some(start), Some(PAGE_SIZE), |k, v| {
+                        kvs_paginated_requests.push((k.clone(), *v));
+                        Ok(())
+                    })
+                    .unwrap(),
+                None => hamt
+                    .for_each_ranged::<BytesKey, _>(None, Some(PAGE_SIZE), |k, v| {
+                        kvs_paginated_requests.push((k.clone(), *v));
+                        Ok(())
+                    })
+                    .unwrap(),
+            };
+            iterations += 1;
+            assert_eq!(page_size, PAGE_SIZE);
+            assert_eq!(kvs_paginated_requests.len(), iterations * PAGE_SIZE);
+
+            if next.is_none() {
+                break;
+            } else {
+                assert_eq!(next.clone().unwrap(), kvs[(iterations * PAGE_SIZE)].0);
+                cursor = next;
+            }
+        }
+
+        // should have retrieved all key value pairs in the same order
+        assert_eq!(kvs_paginated_requests.len(), kvs.len(), "{}", iterations);
+        assert_eq!(kvs_paginated_requests, kvs);
+        // should have used the expected number of iterations
+        assert_eq!(iterations, RANGE / PAGE_SIZE);
+    }
+
+    let c = hamt.flush().unwrap();
+    cids.check_next(c);
+
+    if let Some(stats) = stats {
+        assert_eq!(*store.stats.borrow(), stats);
+    }
+}
+
 #[cfg(feature = "identity")]
 fn add_and_remove_keys(
     bit_width: u32,
@@ -731,12 +893,10 @@ fn tstring(v: impl Display) -> BytesKey {
 }
 
 mod test_default {
-    use fvm_ipld_blockstore::tracking::{BSStats, TrackingBlockstore};
-    use fvm_ipld_blockstore::MemoryBlockstore;
-    use fvm_ipld_hamt::{BytesKey, Hamt};
+    use fvm_ipld_blockstore::tracking::BSStats;
     use quickcheck_macros::quickcheck;
 
-    use crate::{tstring, CidChecker, HamtFactory, LimitedKeyOps, UniqueKeyValuePairs};
+    use crate::{CidChecker, HamtFactory, LimitedKeyOps, UniqueKeyValuePairs};
 
     #[test]
     fn test_basics() {
@@ -828,156 +988,12 @@ mod test_default {
     #[test]
     fn for_each_ranged() {
         #[rustfmt::skip]
-        let factory = HamtFactory::default();
-        let mem = MemoryBlockstore::default();
-        let store = TrackingBlockstore::new(&mem);
-
-        let mut hamt: Hamt<_, usize> = factory.new_with_bit_width(&store, 5);
-
-        const RANGE: usize = 200;
-        for i in 0..RANGE {
-            hamt.set(tstring(i), i).unwrap();
-        }
-
-        // collect all KV paris by iterating through the entire hamt
-        let mut kvs = Vec::new();
-        hamt.for_each(|k, v| {
-            assert_eq!(k, &tstring(v));
-            kvs.push((k.clone(), *v));
-            Ok(())
-        })
-        .unwrap();
-
-        // Iterate through the array, requesting pages of different sizes
-        for page_size in 0..RANGE {
-            let mut kvs_variable_page = Vec::new();
-            let (num_traversed, next_key) = hamt
-                .for_each_ranged::<BytesKey, _>(None, Some(page_size), |k, v| {
-                    kvs_variable_page.push((k.clone(), *v));
-                    Ok(())
-                })
-                .unwrap();
-
-            assert_eq!(num_traversed, page_size);
-            assert_eq!(kvs_variable_page.len(), num_traversed);
-            assert_eq!(next_key.unwrap(), kvs[page_size].0);
-
-            // Items iterated over should match the ordering of for_each
-            assert_eq!(kvs_variable_page, kvs[..page_size]);
-        }
-
-        // Iterate through the array, requesting more items than are remaining
-        let (num_traversed, next_key) = hamt
-            .for_each_ranged::<BytesKey, _>(None, Some(RANGE + 10), |k, v| Ok(()))
-            .unwrap();
-        assert_eq!(num_traversed, RANGE);
-        assert_eq!(next_key, None);
-
-        // Iterate through it again starting at a certain key
-        for start_at in 0..RANGE as usize {
-            let mut kvs_variable_start = Vec::new();
-            let (num_traversed, next_key) = hamt
-                .for_each_ranged(Some(&kvs[start_at].0), None, |k, v| {
-                    assert_eq!(k, &tstring(v));
-                    kvs_variable_start.push((k.clone(), *v));
-
-                    Ok(())
-                })
-                .unwrap();
-
-            // No limit specified, iteration should be exhaustive
-            assert_eq!(next_key, None);
-            assert_eq!(num_traversed, kvs_variable_start.len());
-            assert_eq!(kvs_variable_start.len(), kvs.len() - start_at,);
-
-            // Items iterated over should match the ordering of for_each
-            assert_eq!(kvs_variable_start, kvs[start_at..]);
-        }
-
-        // Chain paginated requests to iterate over entire HAMT
-        {
-            let mut kvs_paginated_requests = Vec::new();
-            let mut iterations = 0;
-            let mut cursor: Option<BytesKey> = None;
-
-            // Request all items in pages of 20 items each
-            const PAGE_SIZE: usize = 20;
-            loop {
-                let (page_size, next) = match cursor {
-                    Some(ref start) => hamt
-                        .for_each_ranged::<BytesKey, _>(Some(start), Some(PAGE_SIZE), |k, v| {
-                            kvs_paginated_requests.push((k.clone(), *v));
-                            Ok(())
-                        })
-                        .unwrap(),
-                    None => hamt
-                        .for_each_ranged::<BytesKey, _>(None, Some(PAGE_SIZE), |k, v| {
-                            kvs_paginated_requests.push((k.clone(), *v));
-                            Ok(())
-                        })
-                        .unwrap(),
-                };
-                iterations += 1;
-                assert_eq!(page_size, PAGE_SIZE);
-                assert_eq!(kvs_paginated_requests.len(), iterations * PAGE_SIZE);
-
-                if next.is_none() {
-                    break;
-                } else {
-                    assert_eq!(next.clone().unwrap(), kvs[(iterations * PAGE_SIZE)].0);
-                    cursor = next;
-                }
-            }
-
-            // should have retrieved all key value pairs in the same order
-            assert_eq!(kvs_paginated_requests.len(), kvs.len(), "{}", iterations);
-            assert_eq!(kvs_paginated_requests, kvs);
-            // should have used the expected number of iterations
-            assert_eq!(iterations, RANGE / PAGE_SIZE);
-        }
-
-        // Chain paginated requests over a HAMT with committed nodes
-        hamt.flush().unwrap();
-        {
-            let mut kvs_paginated_requests = Vec::new();
-            let mut iterations = 0;
-            let mut cursor: Option<BytesKey> = None;
-
-            // Request all items in pages of 20 items each
-            const PAGE_SIZE: usize = 20;
-            loop {
-                let (page_size, next) = match cursor {
-                    Some(ref start) => hamt
-                        .for_each_ranged::<BytesKey, _>(Some(start), Some(PAGE_SIZE), |k, v| {
-                            kvs_paginated_requests.push((k.clone(), *v));
-                            Ok(())
-                        })
-                        .unwrap(),
-                    None => hamt
-                        .for_each_ranged::<BytesKey, _>(None, Some(PAGE_SIZE), |k, v| {
-                            kvs_paginated_requests.push((k.clone(), *v));
-                            Ok(())
-                        })
-                        .unwrap(),
-                };
-                iterations += 1;
-                assert_eq!(page_size, PAGE_SIZE);
-                assert_eq!(kvs_paginated_requests.len(), iterations * PAGE_SIZE);
-
-                if next.is_none() {
-                    break;
-                } else {
-                    assert_eq!(next.clone().unwrap(), kvs[(iterations * PAGE_SIZE)].0);
-                    cursor = next;
-                }
-            }
-
-            // should have retrieved all key value pairs in the same order
-            assert_eq!(kvs_paginated_requests.len(), kvs.len(), "{}", iterations);
-            assert_eq!(kvs_paginated_requests, kvs);
-            // should have used the expected number of iterations
-            assert_eq!(iterations, RANGE / PAGE_SIZE);
-        }
+        let stats = BSStats {r: 30, w: 30, br: 2895, bw: 2895};
+        let cids = CidChecker::new(vec![
+            "bafy2bzacedy4ypl2vedhdqep3llnwko6vrtfiys5flciz2f3c55pl4whlhlqm",
+            "bafy2bzacedy4ypl2vedhdqep3llnwko6vrtfiys5flciz2f3c55pl4whlhlqm",
+        ]);
+        super::for_each_ranged(HamtFactory::default(), Some(stats), cids);
     }
 
     #[test]


### PR DESCRIPTION
Thank you @Stebalien for the alternative approach to the "path" based approach explored in https://github.com/filecoin-project/ref-fvm/pull/1636. This implementation uses the keys of the HAMT as a starting point. The iteration returns the next-to-be-traversed key or `None` if all values have been traversed.

One caveat of this approach is that for ranged_iteration, the keys of the HAMT must be `Clone`. 

`mut starting_cursor: Option<(HashBits, &Q)>` acts as a sentinel value. At each depth, we can use it to determine which subtree contains the starting node. Subtrees to the left of it can be skipped entirely leading to significant gas savings when those nodes would have been expanded from the Blockstore. Subtrees to the right are passed `None` indicating that all leaves must be traversed. 

In the `Pointer::Values` leaves, KV pairs are skipped until the matching key is found. 

