### PR TITLE
Ranged iteration for AMTs

### DIFF
--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -383,6 +383,51 @@ where
             .map(|_| ())
     }
 
+    pub fn for_each_ranged<F>(
+        &self,
+        start_at: Option<u64>,
+        max: Option<u64>,
+        mut f: F,
+    ) -> Result<(u64, Option<u64>), Error>
+    where
+        F: FnMut(u64, &V) -> anyhow::Result<bool>,
+    {
+        let (_, num_traversed, next_index) = self.root.node.for_each_while_ranged(
+            &self.block_store,
+            start_at,
+            max,
+            self.height(),
+            self.bit_width(),
+            0,
+            &mut |i, v| {
+                f(i, v)?;
+                Ok(true)
+            },
+        )?;
+        Ok((num_traversed, next_index))
+    }
+
+    pub fn for_each_while_ranged<F>(
+        &self,
+        start_at: Option<u64>,
+        max: Option<u64>,
+        mut f: F,
+    ) -> Result<(u64, Option<u64>), Error>
+    where
+        F: FnMut(u64, &V) -> anyhow::Result<bool>,
+    {
+        let (_, num_traversed, next_index) = self.root.node.for_each_while_ranged(
+            &self.block_store,
+            start_at,
+            max,
+            self.height(),
+            self.bit_width(),
+            0,
+            &mut f,
+        )?;
+        Ok((num_traversed, next_index))
+    }
+
     /// Iterates over each value in the Amt and runs a function on the values that allows modifying
     /// each value.
     pub fn for_each_mut<F>(&mut self, mut f: F) -> Result<(), Error>

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -418,7 +418,7 @@ where
     pub fn for_each_ranged<F>(
         &self,
         start_at: Option<u64>,
-        max: Option<u64>,
+        limit: Option<u64>,
         mut f: F,
     ) -> Result<(u64, Option<u64>), Error>
     where
@@ -427,7 +427,7 @@ where
         let (_, num_traversed, next_index) = self.root.node.for_each_while_ranged(
             &self.block_store,
             start_at,
-            max,
+            limit,
             self.height(),
             self.bit_width(),
             0,
@@ -451,7 +451,7 @@ where
     pub fn for_each_while_ranged<F>(
         &self,
         start_at: Option<u64>,
-        max: Option<u64>,
+        limit: Option<u64>,
         mut f: F,
     ) -> Result<(u64, Option<u64>), Error>
     where
@@ -460,7 +460,7 @@ where
         let (_, num_traversed, next_index) = self.root.node.for_each_while_ranged(
             &self.block_store,
             start_at,
-            max,
+            limit,
             self.height(),
             self.bit_width(),
             0,

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -383,6 +383,37 @@ where
             .map(|_| ())
     }
 
+    /// Iterates over values in the Amt and runs a function on the values.
+    ///
+    /// The index in the amt is a `u64` and the value is the generic parameter `V` as defined
+    /// in the Amt. If `start_at` is provided traversal begins at that index, otherwise it begins
+    /// from the first element. If `max` is provided, traversal will stop after `max` elements have
+    /// been traversed. Returns a tuple describing the number of elements iterated over and
+    /// optionally the index of the next element in the AMT if more elements remain.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fvm_ipld_amt::Amt;
+    ///
+    /// let store = fvm_ipld_blockstore::MemoryBlockstore::default();
+    ///
+    /// let mut map: Amt<String, _> = Amt::new(&store);
+    /// map.set(1, "One".to_owned()).unwrap();
+    /// map.set(4, "Four".to_owned()).unwrap();
+    /// map.set(5, "Five".to_owned()).unwrap();
+    /// map.set(6, "Six".to_owned()).unwrap();
+    /// map.set(10, "Ten".to_owned()).unwrap();
+    ///
+    /// let mut values: Vec<(u64, String)> = Vec::new();
+    /// let (num_traversed, next_idx) = map.for_each_ranged(Some(4), Some(3), |i, v| {
+    ///    values.push((i, v.clone()));
+    ///    Ok(())
+    /// }).unwrap();
+    /// assert_eq!(&values, &[(4, "Four".to_owned()), (5, "Five".to_owned()), (6, "Six".to_owned())]);
+    /// assert_eq!(num_traversed, 3);
+    /// assert_eq!(next_idx, Some(10));
+    /// ```
     pub fn for_each_ranged<F>(
         &self,
         start_at: Option<u64>,
@@ -390,7 +421,7 @@ where
         mut f: F,
     ) -> Result<(u64, Option<u64>), Error>
     where
-        F: FnMut(u64, &V) -> anyhow::Result<bool>,
+        F: FnMut(u64, &V) -> anyhow::Result<()>,
     {
         let (_, num_traversed, next_index) = self.root.node.for_each_while_ranged(
             &self.block_store,
@@ -407,6 +438,14 @@ where
         Ok((num_traversed, next_index))
     }
 
+    /// Iterates over values in the Amt and runs a function on the values, for as long as that
+    /// function keeps returning true.
+    ///
+    /// The index in the amt is a `u64` and the value is the generic parameter `V` as defined
+    /// in the Amt. If `start_at` is provided traversal begins at that index, otherwise it begins
+    /// from the first element. If `max` is provided, traversal will stop after `max` elements have
+    /// been traversed. Returns a tuple describing the number of elements iterated over and
+    /// optionally the index of the next element in the AMT if more elements remain.
     pub fn for_each_while_ranged<F>(
         &self,
         start_at: Option<u64>,

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -386,10 +386,11 @@ where
     /// Iterates over values in the Amt and runs a function on the values.
     ///
     /// The index in the amt is a `u64` and the value is the generic parameter `V` as defined
-    /// in the Amt. If `start_at` is provided traversal begins at that index, otherwise it begins
-    /// from the first element. If `max` is provided, traversal will stop after `max` elements have
-    /// been traversed. Returns a tuple describing the number of elements iterated over and
-    /// optionally the index of the next element in the AMT if more elements remain.
+    /// in the Amt. If `start_at` is provided traversal begins at the first index >= `start_at`,
+    /// otherwise it begins from the first element. If `max` is provided, traversal will stop after
+    /// `max` elements have been traversed. Returns a tuple describing the number of elements
+    /// iterated over and optionally the index of the next element in the AMT if more elements
+    /// remain.
     ///
     /// # Examples
     ///
@@ -442,10 +443,11 @@ where
     /// function keeps returning true.
     ///
     /// The index in the amt is a `u64` and the value is the generic parameter `V` as defined
-    /// in the Amt. If `start_at` is provided traversal begins at that index, otherwise it begins
-    /// from the first element. If `max` is provided, traversal will stop after `max` elements have
-    /// been traversed. Returns a tuple describing the number of elements iterated over and
-    /// optionally the index of the next element in the AMT if more elements remain.
+    /// in the Amt. If `start_at` is provided traversal begins at the first index >= `start_at`,
+    /// otherwise it begins from the first element. If `max` is provided, traversal will stop after
+    /// `max` elements have been traversed. Returns a tuple describing the number of elements
+    /// iterated over and optionally the index of the next element in the AMT if more elements
+    /// remain.
     pub fn for_each_while_ranged<F>(
         &self,
         start_at: Option<u64>,

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -552,6 +552,91 @@ where
 
         Ok((true, did_mutate))
     }
+
+    pub(super) fn for_each_while_ranged<S, F>(
+        &self,
+        bs: &S,
+        start_at: Option<u64>,
+        limit: Option<u64>,
+        height: u32,
+        bit_width: u32,
+        offset: u64,
+        f: &mut F,
+    ) -> Result<(bool, u64, Option<u64>), Error>
+    where
+        F: FnMut(u64, &V) -> anyhow::Result<bool>,
+        S: Blockstore,
+    {
+        let mut traversed_count = 0_u64;
+        match self {
+            Node::Leaf { vals } => {
+                let start_idx = start_at.map_or(0, |s| s.saturating_sub(offset));
+                let mut keep_going = true;
+                for (i, v) in (start_idx..).zip(vals[start_idx as usize..].iter()) {
+                    let idx = offset + i;
+                    if let Some(v) = v {
+                        if limit.map_or(false, |l| traversed_count >= l) {
+                            return Ok((keep_going, traversed_count, Some(idx)));
+                        } else if !keep_going {
+                            return Ok((false, traversed_count, Some(idx)));
+                        }
+                        keep_going = f(idx, v)?;
+                        traversed_count += 1;
+                    }
+                }
+            }
+            Node::Link { links } => {
+                let nfh = nodes_for_height(bit_width, height);
+                let idx: usize = ((start_at.map_or(0, |s| s.saturating_sub(offset))) / nfh)
+                    .try_into()
+                    .expect("index overflow");
+                for (i, link) in (idx..).zip(links[idx..].iter()) {
+                    if let Some(l) = link {
+                        let offs = offset + (i as u64 * nfh);
+                        let (keep_going, count, next) = match l {
+                            Link::Dirty(sub) => sub.for_each_while_ranged(
+                                bs,
+                                start_at,
+                                limit.map(|l| l.checked_sub(traversed_count).unwrap()),
+                                height - 1,
+                                bit_width,
+                                offs,
+                                f,
+                            )?,
+                            Link::Cid { cid, cache } => {
+                                let cached_node = cache.get_or_try_init(|| {
+                                    bs.get_cbor::<CollapsedNode<V>>(cid)?
+                                        .ok_or_else(|| Error::CidNotFound(cid.to_string()))?
+                                        .expand(bit_width)
+                                        .map(Box::new)
+                                })?;
+
+                                cached_node.for_each_while_ranged(
+                                    bs,
+                                    start_at,
+                                    limit.map(|l| l.checked_sub(traversed_count).unwrap()),
+                                    height - 1,
+                                    bit_width,
+                                    offs,
+                                    f,
+                                )?
+                            }
+                        };
+
+                        traversed_count += count;
+
+                        if limit.map_or(false, |l| traversed_count >= l) && next.is_some() {
+                            return Ok((keep_going, traversed_count, next));
+                        } else if !keep_going {
+                            return Ok((false, traversed_count, next));
+                        }
+                    }
+                }
+            }
+        };
+
+        Ok((true, traversed_count, None))
+    }
 }
 
 #[cfg(test)]

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -553,6 +553,10 @@ where
         Ok((true, did_mutate))
     }
 
+    /// Iterates through the current node in the tree and all subtrees. `start_at` refers to the
+    /// global AMT index, before which no values should be traversed and `limit` is the maximum
+    /// number of leaf nodes that should be traversed in this subtree. `offset` refers the offset
+    /// in the global AMT address space that this subtree is rooted at.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn for_each_while_ranged<S, F>(
         &self,

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -553,6 +553,7 @@ where
         Ok((true, did_mutate))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn for_each_while_ranged<S, F>(
         &self,
         bs: &S,

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -483,9 +483,9 @@ fn for_each_ranged() {
     let mut start_cursor = None;
     loop {
         let (num_traversed, next_cursor) = a
-            .for_each_while_ranged(start_cursor, Some(page_size), |idx, _val: &BytesDe| {
+            .for_each_ranged(start_cursor, Some(page_size), |idx, _val: &BytesDe| {
                 retrieved_values.push(idx);
-                Ok(true)
+                Ok(())
             })
             .unwrap();
 


### PR DESCRIPTION
Follow up to https://github.com/filecoin-project/ref-fvm/pull/1665/files applying the same principles to AMTs

Since keys on AMTs are definitely clone-able, we don't introduce any new trait bounds with the new method `Node::for_each_while_ranged`. Therefore, we could merge some code paths and have `Amt::for_each_while` call `Node::for_each_while_ranged` passing `None` for start_at and max. This of course incurs a slight performance penalty for the extra bounds checks during complete traversals.