### PR TITLE
test: gas stress fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2601,6 +2601,7 @@ dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
  "fvm_shared 3.0.0-alpha.20",
+ "hex",
  "lazy_static",
  "libsecp256k1",
  "multihash",

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -52,6 +52,7 @@ fil_gaslimit_actor = { path = "tests/fil-gaslimit-actor" }
 fil_readonly_actor = { path = "tests/fil-readonly-actor" }
 fil_create_actor = { path = "tests/fil-create-actor" }
 fil_oom_actor = { path = 'tests/fil-oom-actor' }
+hex = "0.4.3"
 
 actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -68,7 +68,7 @@ pub struct Tester<B: Blockstore + 'static, E: Externs + 'static> {
     pub options: Option<ExecutionOptions>,
 
     // ready if the machine has been instantiated
-    ready: bool,
+    pub ready: bool,
 }
 
 impl<B, E> Tester<B, E>

--- a/testing/integration/tests/bundles/mod.rs
+++ b/testing/integration/tests/bundles/mod.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use fvm::externs::Externs;
 use fvm_integration_tests::bundle;
-use fvm_integration_tests::tester::{Tester, BasicTester, ExecutionOptions};
+use fvm_integration_tests::tester::{BasicTester, ExecutionOptions, Tester};
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;

--- a/testing/integration/tests/bundles/mod.rs
+++ b/testing/integration/tests/bundles/mod.rs
@@ -36,7 +36,7 @@ pub fn new_basic_tester(options: ExecutionOptions) -> anyhow::Result<BasicTester
     let blockstore = MemoryBlockstore::default();
     let bundle = BUNDLES
         .get(&NetworkVersion::V18)
-        .with_context(|| format!("unsupported network version 18"))?;
+        .with_context(|| format!("unsupported network version {}", NetworkVersion::V18))?;
 
     let bundle_cid = bundle::import_bundle(&blockstore, bundle)?;
 

--- a/testing/integration/tests/bundles/mod.rs
+++ b/testing/integration/tests/bundles/mod.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use fvm::externs::Externs;
 use fvm_integration_tests::bundle;
-use fvm_integration_tests::tester::Tester;
-use fvm_ipld_blockstore::Blockstore;
+use fvm_integration_tests::tester::{Tester, BasicTester, ExecutionOptions};
+use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use lazy_static::lazy_static;
@@ -29,4 +29,26 @@ pub fn new_tester<B: Blockstore, E: Externs>(
         .with_context(|| format!("unsupported network version {nv}"))?;
     let root = bundle::import_bundle(&blockstore, bundle)?;
     Tester::new(nv, stv, root, blockstore)
+}
+
+#[allow(dead_code)]
+pub fn new_basic_tester(options: ExecutionOptions) -> anyhow::Result<BasicTester> {
+    let blockstore = MemoryBlockstore::default();
+    let bundle = BUNDLES
+        .get(&NetworkVersion::V18)
+        .with_context(|| format!("unsupported network version 18"))?;
+
+    let bundle_cid = bundle::import_bundle(&blockstore, bundle)?;
+
+    let mut tester = Tester::new(
+        NetworkVersion::V18,
+        StateTreeVersion::V5,
+        bundle_cid,
+        blockstore,
+    )?;
+
+    tester.options = Some(options);
+    tester.ready = false;
+
+    Ok(tester)
 }

--- a/testing/integration/tests/gasfuzz.rs
+++ b/testing/integration/tests/gasfuzz.rs
@@ -21,13 +21,10 @@ fn test_gasfuzz() {
     let mut charge_points_milligas = Vec::new();
     let mut aggregate_charge = 0u64;
     for tr in trace.iter() {
-        match tr {
-            ExecutionEvent::GasCharge(ch) => {
-                let this_charge = ch.total();
-                aggregate_charge += this_charge.as_milligas();
-                charge_points_milligas.push(aggregate_charge);
-            }
-            _ => {}
+        if let ExecutionEvent::GasCharge(ch) = tr {
+            let this_charge = ch.total();
+            aggregate_charge += this_charge.as_milligas();
+            charge_points_milligas.push(aggregate_charge);
         }
     }
 

--- a/testing/integration/tests/gasfuzz.rs
+++ b/testing/integration/tests/gasfuzz.rs
@@ -1,0 +1,101 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+mod bundles;
+
+use std::fs;
+use anyhow::Context;
+use fvm::trace::{ExecutionTrace, ExecutionEvent};
+use fvm_integration_tests::{tester, testkit};
+use fvm_shared::error::ExitCode;
+use fvm_shared::address::Address;
+
+const CONTRACT_PATH: &str = "../../tools/contracts/gas-stress/recursive.bin";
+
+#[test]
+fn test_gasfuzz() {
+    // get all charge points we want to fuzz at
+    let trace = gasfuzz_get_exec_trace();
+
+    let mut charge_points_milligas = Vec::new();
+    let mut aggregate_charge = 0u64;
+    for tr in trace.iter() {
+        match tr {
+            ExecutionEvent::GasCharge(ch) => {
+                let this_charge = ch.total();
+                aggregate_charge += this_charge.as_milligas();
+                charge_points_milligas.push(aggregate_charge);
+            }
+            _ => {}
+        }
+    }
+
+    gasfuzz_fuzz(charge_points_milligas);
+}
+
+fn gasfuzz_fuzz(charge_points_milligas: Vec<u64>) {
+    // set up the tester
+    let options = tester::ExecutionOptions {
+        debug: false,
+        trace: false,
+        events: false,
+    };
+
+    let mut tester = bundles::new_basic_tester(options).unwrap();
+    let mut account = tester.create_basic_account().unwrap();
+    let contract = hex::decode(fs::read_to_string(CONTRACT_PATH).unwrap()).context("error decoding contract").unwrap();
+
+    // create the contract
+    let create_res = testkit::fevm::create_contract(&mut tester, &mut account, &contract).unwrap();
+    assert!(create_res.msg_receipt.exit_code.is_success());
+
+    let create_return: testkit::fevm::CreateReturn =
+        create_res.msg_receipt.return_data.deserialize().unwrap();
+    let actor = Address::new_id(create_return.actor_id);
+
+
+    println!("Fuzzing gas for {} charge points", charge_points_milligas.len());
+    // invoke contract at every charge point +/- 1 gas.; we should still  error with OutOfGas
+    // skip the first chage, as that results in SYS_SENDER_STATE_INVALID
+    for cpm in charge_points_milligas[1..].iter() {
+
+        println!("Fuzzing gas at {}", cpm/1000);
+
+        let gas_lo = (cpm-500)/1000;
+        let invoke_res = testkit::fevm::invoke_contract(&mut tester, &mut account, actor, &[], gas_lo).unwrap();
+        assert_eq!(invoke_res.msg_receipt.exit_code, ExitCode::SYS_OUT_OF_GAS);
+
+
+        let gas_hi = (cpm+500)/1000;
+        let invoke_res = testkit::fevm::invoke_contract(&mut tester, &mut account, actor, &[], gas_hi).unwrap();
+        assert_eq!(invoke_res.msg_receipt.exit_code, ExitCode::SYS_OUT_OF_GAS);
+    }
+}
+
+fn gasfuzz_get_exec_trace() -> ExecutionTrace {
+    let options = tester::ExecutionOptions {
+        debug: false,
+        trace: true,
+        events: false,
+    };
+
+    let mut tester = bundles::new_basic_tester(options).unwrap();
+    let mut account = tester.create_basic_account().unwrap();
+    let contract = hex::decode(fs::read_to_string(CONTRACT_PATH).unwrap()).context("error decoding contract").unwrap();
+
+    let create_res = testkit::fevm::create_contract(& mut tester, &mut account, &contract).unwrap();
+    assert!(create_res.msg_receipt.exit_code.is_success());
+
+    let create_return: testkit::fevm::CreateReturn =
+        create_res.msg_receipt.return_data.deserialize().unwrap();
+    let actor = Address::new_id(create_return.actor_id);
+
+    // this number is not arbitrary.
+    // contract recurses if gas > 10M, and empty contract run takes a tad less than 2M.
+    // So upon execution the contract shoud have just enough for 1 recursive call.
+    let gas = 12_000_000;
+    let invoke_res = testkit::fevm::invoke_contract(&mut tester, &mut account, actor, &[], gas).unwrap();
+    assert_eq!(invoke_res.msg_receipt.exit_code, ExitCode::SYS_OUT_OF_GAS);
+
+    invoke_res.exec_trace
+}


### PR DESCRIPTION
See #1667 

Note: In the very first fuzzpoint, execution fails with `SYS_SENDER_STATE_INVALID` instead of `SYS_OUT_OF_GAS`.
Not sure if this is a bug, ie execution should fail with out of gas or that's correct.

If it _is_ a bug, we should fix it and update the test to not skip the first fuzzpoint.
[EDIT: not a bug in ref-fvm, but rather in the test; see comment below]

Note2: The test exercises 96 fuzzpoints and takes 67.36s on my laptop.