### PR TITLE
Add exhaustive tests for fvm sdk api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,8 +2017,8 @@ version = "0.1.0"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.24",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_sdk 3.0.0",
+ "fvm_shared 3.1.0",
  "minicov",
  "substrate-wasm-builder",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,6 +2012,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_sself_actor"
+version = "0.1.0"
+dependencies = [
+ "cid",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_sdk 3.0.0-alpha.24",
+ "fvm_shared 3.0.0-alpha.20",
+ "minicov",
+ "substrate-wasm-builder",
+]
+
+[[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
@@ -2537,6 +2549,7 @@ dependencies = [
  "fil_malformed_syscall_actor",
  "fil_oom_actor",
  "fil_readonly_actor",
+ "fil_sself_actor",
  "fil_stack_overflow_actor",
  "fil_syscall_actor",
  "futures",

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use thiserror::Error;
 
-#[derive(Copy, Clone, Debug, Error)]
+#[derive(Copy, Clone, Debug, Error, Eq, PartialEq)]
 #[error("actor has been deleted")]
 pub struct StateReadError;
 

--- a/sdk/src/sself.rs
+++ b/sdk/src/sself.rs
@@ -56,7 +56,8 @@ pub fn current_balance() -> TokenAmount {
 /// Destroys the calling actor, sending its current balance
 /// to the supplied address, which cannot be itself.
 ///
-/// Fails if the beneficiary doesn't exist or is the actor being deleted.
+/// Fails when calling actor has a non zero balance and the beneficiary doesn't
+/// exist or is the actor being deleted.
 pub fn self_destruct(beneficiary: &Address) -> Result<(), ActorDeleteError> {
     let bytes = beneficiary.to_bytes();
     unsafe {

--- a/sdk/src/sys/ipld.rs
+++ b/sdk/src/sys/ipld.rs
@@ -113,6 +113,7 @@ super::fvm_syscalls! {
     /// |---------------------|---------------------------------------------------|
     /// | [`InvalidHandle`]   | if the handle isn't known.                        |
     /// | [`IllegalCid`]      | hash code and/or hash length aren't supported.    |
+    /// | [`BufferTooSmall`]  | if the passed buffer is too small                 |
     /// | [`IllegalArgument`] | if the passed buffer isn't valid, in memory, etc. |
     pub fn block_link(
         id: u32,

--- a/sdk/src/sys/sself.rs
+++ b/sdk/src/sys/sself.rs
@@ -51,6 +51,9 @@ super::fvm_syscalls! {
     /// Destroys the calling actor, sending its current balance
     /// to the supplied address, which cannot be itself.
     ///
+    /// Fails when calling actor has a non zero balance and the beneficiary doesn't
+    /// exist or is the actor being deleted.
+    ///
     /// # Arguments
     ///
     /// - `addr_off` and `addr_len` specify the location and length of beneficiary's address in wasm

--- a/shared/src/sys/mod.rs
+++ b/shared/src/sys/mod.rs
@@ -16,7 +16,7 @@ pub type Codec = u64;
 ///
 /// Internally, this type is a tuple of `u64`s storing the "low" and "high" bits of a little-endian
 /// u128.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(packed, C)]
 pub struct TokenAmount {
     pub lo: u64,

--- a/shared/src/sys/out.rs
+++ b/shared/src/sys/out.rs
@@ -17,7 +17,7 @@
 // Also, please also read the docs on super::SyscallSafe before modifying any of these types.
 
 pub mod ipld {
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     #[repr(packed, C)]
     pub struct IpldOpen {
         pub codec: u64,
@@ -25,7 +25,7 @@ pub mod ipld {
         pub size: u32,
     }
 
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     #[repr(packed, C)]
     pub struct IpldStat {
         pub codec: u64,
@@ -36,7 +36,7 @@ pub mod ipld {
 pub mod send {
     use crate::sys::BlockId;
 
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     #[repr(packed, C)]
     pub struct Send {
         pub exit_code: u32,
@@ -49,7 +49,7 @@ pub mod send {
 pub mod crypto {
     use crate::{ActorID, ChainEpoch};
 
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     #[repr(packed, C)]
     pub struct VerifyConsensusFault {
         pub epoch: ChainEpoch,
@@ -81,7 +81,7 @@ pub mod vm {
         }
     }
 
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     #[repr(packed, C)]
     pub struct MessageContext {
         /// The current call's origin actor ID.
@@ -110,7 +110,7 @@ pub mod network {
     use crate::sys::TokenAmount;
     use crate::version::NetworkVersion;
 
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     #[repr(packed, C)]
     pub struct NetworkContext {
         /// The current epoch.

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -52,6 +52,8 @@ fil_gaslimit_actor = { path = "tests/fil-gaslimit-actor" }
 fil_readonly_actor = { path = "tests/fil-readonly-actor" }
 fil_create_actor = { path = "tests/fil-create-actor" }
 fil_oom_actor = { path = 'tests/fil-oom-actor' }
+fil_sself_actor ={ path = 'tests/fil-sself-actor' }
+
 hex = "0.4.3"
 
 actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -193,7 +193,7 @@ where
         Ok(state_cid)
     }
 
-    /// Set a new at a given address, provided with a given token balance
+    /// Set a new actor at a given address, provided with a given token balance
     /// and returns the CodeCID of the installed actor
     pub fn set_actor_from_bin(
         &mut self,

--- a/testing/integration/tests/fil-create-actor/src/actor.rs
+++ b/testing/integration/tests/fil-create-actor/src/actor.rs
@@ -3,7 +3,7 @@
 use actors_v10_runtime::runtime::builtins::Type;
 use fvm_sdk as sdk;
 use fvm_shared::address::{Address, SECP_PUB_LEN};
-use fvm_shared::error::{ErrorNumber, ExitCode};
+use fvm_shared::error::ErrorNumber;
 
 #[no_mangle]
 pub fn invoke(_: u32) -> u32 {

--- a/testing/integration/tests/fil-create-actor/src/actor.rs
+++ b/testing/integration/tests/fil-create-actor/src/actor.rs
@@ -7,12 +7,7 @@ use fvm_shared::error::{ErrorNumber, ExitCode};
 
 #[no_mangle]
 pub fn invoke(_: u32) -> u32 {
-    std::panic::set_hook(Box::new(|info| {
-        sdk::vm::abort(
-            ExitCode::USR_ASSERTION_FAILED.value(),
-            Some(&format!("{}", info)),
-        )
-    }));
+    sdk::initialize();
 
     let method = sdk::message::method_number();
 

--- a/testing/integration/tests/fil-create-actor/src/actor.rs
+++ b/testing/integration/tests/fil-create-actor/src/actor.rs
@@ -3,38 +3,91 @@
 use actors_v10_runtime::runtime::builtins::Type;
 use fvm_sdk as sdk;
 use fvm_shared::address::{Address, SECP_PUB_LEN};
-use fvm_shared::error::ErrorNumber;
+use fvm_shared::error::{ErrorNumber, ExitCode};
 
 #[no_mangle]
 pub fn invoke(_: u32) -> u32 {
-    let msig_cid = sdk::actor::get_code_cid_for_type(Type::Multisig as i32);
-    let acct_cid = sdk::actor::get_code_cid_for_type(Type::Account as i32);
-    let acct_addr = Address::new_secp256k1(&[0u8; SECP_PUB_LEN]).unwrap();
+    std::panic::set_hook(Box::new(|info| {
+        sdk::vm::abort(
+            ExitCode::USR_ASSERTION_FAILED.value(),
+            Some(&format!("{}", info)),
+        )
+    }));
 
-    // Deploy
-    sdk::actor::create_actor(1000, &msig_cid, None).unwrap();
-    sdk::actor::create_actor(1001, &acct_cid, Some(acct_addr)).unwrap();
+    let method = sdk::message::method_number();
 
-    // Check addresses
-    assert_eq!(None, sdk::actor::lookup_delegated_address(1000));
-    assert_eq!(Some(acct_addr), sdk::actor::lookup_delegated_address(1001));
+    match method {
+        // our actor ID is allowed to call create actor
+        1 => {
+            // verify we can create a MultiSig actor without "delegated" address
+            //
+            let msig_addr = Address::new_id(1000);
+            let msig_cid = sdk::actor::get_code_cid_for_type(Type::Multisig as i32);
+            sdk::actor::create_actor(msig_addr.id().unwrap(), &msig_cid, None).unwrap();
+            assert_eq!(
+                None,
+                sdk::actor::lookup_delegated_address(msig_addr.id().unwrap())
+            );
+            assert_eq!(
+                msig_cid,
+                sdk::actor::get_actor_code_cid(&msig_addr).unwrap()
+            );
 
-    // Check code
-    assert_eq!(
-        msig_cid,
-        sdk::actor::get_actor_code_cid(&Address::new_id(1000)).unwrap()
-    );
-    assert_eq!(
-        acct_cid,
-        sdk::actor::get_actor_code_cid(&Address::new_id(1001)).unwrap()
-    );
+            // verify we can create an Account actor with "delegated" address
+            //
+            let acct_addr = Address::new_id(1001);
+            let acct_cid = sdk::actor::get_code_cid_for_type(Type::Account as i32);
+            let dlg_addr = Address::new_secp256k1(&[0u8; SECP_PUB_LEN]).unwrap();
+            sdk::actor::create_actor(acct_addr.id().unwrap(), &acct_cid, Some(dlg_addr)).unwrap();
+            assert_eq!(
+                Some(dlg_addr),
+                sdk::actor::lookup_delegated_address(acct_addr.id().unwrap())
+            );
+            assert_eq!(
+                acct_cid,
+                sdk::actor::get_actor_code_cid(&acct_addr).unwrap()
+            );
 
-    // Check that we can't explicitly deploy a placeholder.
-    let placeholder_cid = sdk::actor::get_code_cid_for_type(Type::Placeholder as i32);
-    assert_eq!(
-        sdk::actor::create_actor(1002, &placeholder_cid, None),
-        Err(ErrorNumber::Forbidden)
-    );
+            // creating a Placeholder without delegated" address should fail
+            //
+            let placeholder_cid = sdk::actor::get_code_cid_for_type(Type::Placeholder as i32);
+            assert_eq!(
+                Err(ErrorNumber::Forbidden),
+                sdk::actor::create_actor(1002, &placeholder_cid, None)
+            );
+
+            // verify that resolving address returns None if address cannot be resolved
+            //
+            let not_found_addresss = Address::new_actor(&[0u8; SECP_PUB_LEN]);
+            let res = sdk::actor::resolve_address(&not_found_addresss);
+            assert_eq!(res, None);
+
+            // verify that looking up code ID of an actor returns None if its not found
+            //
+            assert_eq!(None, sdk::actor::get_actor_code_cid(&Address::new_id(1919)));
+        }
+        // our actor ID is not allowed to call create actor
+        2 => {
+            // verify that creating a MultiSig actor without "delegated" address should fail
+            //
+            let msig_cid = sdk::actor::get_code_cid_for_type(Type::Multisig as i32);
+            let res = sdk::actor::create_actor(1000, &msig_cid, None);
+            assert_eq!(res, Err(ErrorNumber::Forbidden));
+
+            // verify that creating an Account actor with "delegated" address should fail
+            //
+            let acct_cid = sdk::actor::get_code_cid_for_type(Type::Account as i32);
+            let acct_addr = Address::new_secp256k1(&[0u8; SECP_PUB_LEN]).unwrap();
+            let res = sdk::actor::create_actor(1001, &acct_cid, Some(acct_addr));
+            assert_eq!(res, Err(ErrorNumber::Forbidden));
+        }
+        _ => {
+            sdk::vm::abort(
+                fvm_shared::error::ExitCode::FIRST_USER_EXIT_CODE,
+                Some(format!("bad method {}", method).as_str()),
+            );
+        }
+    }
 
     0
 }

--- a/testing/integration/tests/fil-ipld-actor/src/actor.rs
+++ b/testing/integration/tests/fil-ipld-actor/src/actor.rs
@@ -14,12 +14,7 @@ fn gen_test_bytes(size: i32) -> Vec<u8> {
 
 #[no_mangle]
 pub fn invoke(_: u32) -> u32 {
-    std::panic::set_hook(Box::new(|info| {
-        sdk::vm::abort(
-            ExitCode::USR_ASSERTION_FAILED.value(),
-            Some(&format!("{}", info)),
-        )
-    }));
+    sdk::initialize();
 
     test_open_block();
     test_read_block();

--- a/testing/integration/tests/fil-ipld-actor/src/actor.rs
+++ b/testing/integration/tests/fil-ipld-actor/src/actor.rs
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_ipld_encoding::{to_vec, BytesSer, DAG_CBOR};
 use fvm_sdk as sdk;
-use fvm_shared::error::ExitCode;
+use fvm_shared::error::{ErrorNumber, ExitCode};
+use fvm_shared::MAX_CID_LEN;
+
+fn gen_test_bytes(size: i32) -> Vec<u8> {
+    to_vec(&BytesSer(
+        &(0..size).map(|b| (b % 256) as u8).collect::<Vec<u8>>(),
+    ))
+    .unwrap()
+}
 
 #[no_mangle]
 pub fn invoke(_: u32) -> u32 {
@@ -13,20 +21,45 @@ pub fn invoke(_: u32) -> u32 {
         )
     }));
 
+    test_open_block();
     test_read_block();
+    test_create_block();
+    test_stat_block();
+    test_link_block();
 
     #[cfg(coverage)]
     sdk::debug::store_artifact("ipld_actor.profraw", minicov::capture_coverage());
     0
 }
 
+fn test_open_block() {
+    let test_bytes = gen_test_bytes(1 << 10);
+
+    unsafe {
+        let cid = sdk::ipld::put(0xb220, 32, DAG_CBOR, &test_bytes).unwrap();
+
+        // The cid should be valid
+        let mut buf = [0u8; MAX_CID_LEN];
+        cid.write_bytes(&mut buf[..])
+            .expect("CID encoding should not fail");
+        sdk::sys::ipld::block_open(buf.as_mut_ptr()).expect("shouldwork");
+
+        // Test for invalid Cid
+        buf.fill(0);
+        let res = sdk::sys::ipld::block_open(buf.as_mut_ptr());
+        assert_eq!(res, Err(ErrorNumber::IllegalArgument));
+
+        // Test for invalid Cid pointer
+        let some_big_number: i32 = 338473423;
+        let res = sdk::sys::ipld::block_open(some_big_number.to_le_bytes()[0] as *const u8);
+        assert_eq!(res, Err(ErrorNumber::IllegalArgument));
+
+        // TODO (fridrik): Test for very large cid
+    }
+}
+
 fn test_read_block() {
-    let test_bytes: Vec<u8> = to_vec(&BytesSer(
-        &(0..(10 << 10))
-            .map(|b| (b % 256) as u8)
-            .collect::<Vec<u8>>(),
-    ))
-    .unwrap();
+    let test_bytes = gen_test_bytes(10 << 10);
     let k = sdk::ipld::put(0xb220, 32, DAG_CBOR, &test_bytes).unwrap();
     {
         let block = sdk::ipld::get(&k).unwrap();
@@ -118,15 +151,109 @@ fn test_read_block() {
         );
 
         // Test an offset that overflows an i32:
-        sdk::sys::ipld::block_read(id, (i32::MAX as u32) + 1, buf.as_mut_ptr(), 0)
-            .expect_err("expected it to fail");
+        let res = sdk::sys::ipld::block_read(id, (i32::MAX as u32) + 1, buf.as_mut_ptr(), 0);
+        assert_eq!(res, Err(ErrorNumber::IllegalArgument));
 
         // Test a length that overflows an i32
-        sdk::sys::ipld::block_read(id, 0, buf.as_mut_ptr(), (i32::MAX as u32) + 1)
-            .expect_err("expected it to fail");
+        let res = sdk::sys::ipld::block_read(id, 0, buf.as_mut_ptr(), (i32::MAX as u32) + 1);
+        assert_eq!(res, Err(ErrorNumber::IllegalArgument));
 
         // Test a combined length + offset that overflow an i32
-        sdk::sys::ipld::block_read(id, (i32::MAX as u32) - 10, buf.as_mut_ptr(), 20)
-            .expect_err("expected it to fail");
+        let res = sdk::sys::ipld::block_read(id, (i32::MAX as u32) - 10, buf.as_mut_ptr(), 20);
+        assert_eq!(res, Err(ErrorNumber::IllegalArgument));
+    }
+}
+
+fn test_create_block() {
+    unsafe {
+        // Test creating a block with invalid codec
+        let test_bytes = gen_test_bytes(100);
+        let invalid_codec_id = 191919;
+        let res = sdk::sys::ipld::block_create(
+            invalid_codec_id,
+            test_bytes.as_ptr(),
+            test_bytes.len() as u32,
+        );
+        assert_eq!(res, Err(ErrorNumber::IllegalCodec));
+
+        // Creating a block just within the 1Mib limit should work
+        let test_bytes = gen_test_bytes((1 << 20) - 8);
+        sdk::sys::ipld::block_create(DAG_CBOR, test_bytes.as_ptr(), test_bytes.len() as u32)
+            .expect("should be within block limit");
+
+        // Test creating a too large block
+        let test_bytes = gen_test_bytes((1 << 20) + 8);
+        let res =
+            sdk::sys::ipld::block_create(DAG_CBOR, test_bytes.as_ptr(), test_bytes.len() as u32);
+        assert_eq!(res, Err(ErrorNumber::LimitExceeded));
+    }
+}
+
+fn test_stat_block() {
+    let bytes = gen_test_bytes(10 << 10);
+
+    unsafe {
+        let block_id =
+            sdk::sys::ipld::block_create(DAG_CBOR, bytes.as_ptr(), bytes.len() as u32).unwrap();
+
+        // Test happy case
+        let mut buf = [0u8; MAX_CID_LEN];
+        sdk::sys::ipld::block_link(block_id, 0xb220, 32, buf.as_mut_ptr(), buf.len() as u32)
+            .expect("should work");
+        let fvm_shared::sys::out::ipld::IpldStat { codec, size } =
+            sdk::sys::ipld::block_stat(block_id).unwrap();
+        assert_eq!(codec, DAG_CBOR);
+        assert_eq!(size, bytes.len() as u32);
+
+        // Test that giving invalid block id results in InvalidHandle error
+        let invalid_block_id = 1919;
+        let res = sdk::sys::ipld::block_stat(invalid_block_id);
+        assert_eq!(res, Err(ErrorNumber::InvalidHandle));
+    }
+}
+
+fn test_link_block() {
+    let bytes = gen_test_bytes(10 << 10);
+
+    unsafe {
+        let block_id =
+            sdk::sys::ipld::block_create(DAG_CBOR, bytes.as_ptr(), bytes.len() as u32).unwrap();
+
+        // Test happy case
+        let mut buf = [0u8; MAX_CID_LEN];
+        sdk::sys::ipld::block_link(block_id, 0xb220, 32, buf.as_mut_ptr(), buf.len() as u32)
+            .expect("should work");
+
+        // Test passing an invalid block id results in InvalidHandle error
+        let invalid_block_id = 1919;
+        let res = sdk::sys::ipld::block_link(
+            invalid_block_id,
+            0xb220,
+            32,
+            buf.as_mut_ptr(),
+            buf.len() as u32,
+        );
+        assert_eq!(res, Err(ErrorNumber::InvalidHandle));
+
+        // Test that giving too small buffer results in BufferTooSmall error
+        let mut short_buf = [0u8; 3];
+        let res = sdk::sys::ipld::block_link(
+            block_id,
+            0xb220,
+            32,
+            short_buf.as_mut_ptr(),
+            short_buf.len() as u32,
+        );
+        assert_eq!(res, Err(ErrorNumber::BufferTooSmall));
+
+        // Test that invalid hash function results in IllegalCid error
+        let res =
+            sdk::sys::ipld::block_link(block_id, 0x1919, 32, buf.as_mut_ptr(), buf.len() as u32);
+        assert_eq!(res, Err(ErrorNumber::IllegalCid));
+
+        // Test that invalid hash length results in IllegalCid error
+        let res =
+            sdk::sys::ipld::block_link(block_id, 0xb220, 31, buf.as_mut_ptr(), buf.len() as u32);
+        assert_eq!(res, Err(ErrorNumber::IllegalCid));
     }
 }

--- a/testing/integration/tests/fil-ipld-actor/src/actor.rs
+++ b/testing/integration/tests/fil-ipld-actor/src/actor.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_ipld_encoding::{to_vec, BytesSer, DAG_CBOR};
 use fvm_sdk as sdk;
-use fvm_shared::error::{ErrorNumber, ExitCode};
+use fvm_shared::error::ErrorNumber;
 use fvm_shared::MAX_CID_LEN;
 
 fn gen_test_bytes(size: i32) -> Vec<u8> {

--- a/testing/integration/tests/fil-oom-actor/Cargo.toml
+++ b/testing/integration/tests/fil-oom-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.24", path = "../../../../sdk" }
+fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
 fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-sself-actor/Cargo.toml
+++ b/testing/integration/tests/fil-sself-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.0.0-alpha.24", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.20", path = "../../../../shared" }
+fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 cid = { version = "0.8.5", default-features = false }
 

--- a/testing/integration/tests/fil-sself-actor/Cargo.toml
+++ b/testing/integration/tests/fil-sself-actor/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "fil_sself_actor"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+fvm_sdk = { version = "3.0.0-alpha.24", path = "../../../../sdk" }
+fvm_shared = { version = "3.0.0-alpha.20", path = "../../../../shared" }
+fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
+cid = { version = "0.8.5", default-features = false }
+
+
+[target.'cfg(coverage)'.dependencies]
+minicov = "0.3"
+
+[build-dependencies]
+substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-sself-actor/build.rs
+++ b/testing/integration/tests/fil-sself-actor/build.rs
@@ -1,0 +1,17 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+fn main() {
+    use substrate_wasm_builder::WasmBuilder;
+    WasmBuilder::new()
+        .with_current_project()
+        .import_memory()
+        .append_to_rust_flags("-Ctarget-feature=+crt-static")
+        .append_to_rust_flags("-Cpanic=abort")
+        .append_to_rust_flags("-Coverflow-checks=true")
+        .append_to_rust_flags("-Clto=true")
+        .append_to_rust_flags("-Copt-level=z")
+        .append_to_rust_flags("-Zinstrument-coverage")
+        .append_to_rust_flags("-Zno-profiler-runtime")
+        .append_to_rust_flags("-Clink-dead-code")
+        .build()
+}

--- a/testing/integration/tests/fil-sself-actor/src/actor.rs
+++ b/testing/integration/tests/fil-sself-actor/src/actor.rs
@@ -1,0 +1,73 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use cid::multihash::{Code, MultihashDigest};
+use cid::Cid;
+use fvm_ipld_encoding::{to_vec, DAG_CBOR};
+use fvm_sdk as sdk;
+use fvm_shared::address::Address;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
+use sdk::error::{ActorDeleteError, StateReadError, StateUpdateError};
+
+#[no_mangle]
+pub fn invoke(_: u32) -> u32 {
+    std::panic::set_hook(Box::new(|info| {
+        sdk::vm::abort(
+            ExitCode::USR_ASSERTION_FAILED.value(),
+            Some(&format!("{}", info)),
+        )
+    }));
+
+    assert!(!sdk::vm::read_only());
+
+    // test that root() returns the correct root
+    //
+    let empty = to_vec::<[(); 0]>(&[]).unwrap();
+    let expected_root = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));
+    let root = sdk::sself::root().unwrap();
+    assert_eq!(root, expected_root);
+
+    // test setting the root cid for the caling actor returns the correct root
+    //
+    let cid = sdk::ipld::put(0xb220, 32, 0x55, b"foo").unwrap();
+    sdk::sself::set_root(&cid).unwrap();
+    let root = sdk::sself::root().unwrap();
+    assert_eq!(root, cid);
+
+    let balance = sdk::sself::current_balance();
+    assert_eq!(TokenAmount::from_nano(1_000_000), balance);
+
+    // test that we can't destroy the calling actor when supplied beneficiary
+    // address does not exist or when its itself
+    //
+    assert_eq!(
+        sdk::sself::self_destruct(&Address::new_id(191919)),
+        Err(ActorDeleteError::BeneficiaryDoesNotExist),
+    );
+    assert_eq!(
+        sdk::sself::self_destruct(&Address::new_id(10000)),
+        Err(ActorDeleteError::BeneficiaryIsSelf),
+    );
+
+    // now lets destroy the calling actor
+    //
+    sdk::sself::self_destruct(&Address::new_id(sdk::message::origin())).unwrap();
+
+    // test that root/set_root/self_destruct fail when the actor has been deleted
+    // and balance is 0
+    assert_eq!(sdk::sself::root().unwrap_err(), StateReadError);
+    assert_eq!(
+        sdk::sself::set_root(&cid).unwrap_err(),
+        StateUpdateError::ActorDeleted
+    );
+    assert_eq!(TokenAmount::from_nano(0), sdk::sself::current_balance());
+
+    // TODO (fridrik): test that self_destruct fails with ActorDeleteError::BeneficiaryDoesNotExist
+    // always returns Ok() since the balance was 0 and it does not resolve beneficiary address in
+    // that case
+
+    #[cfg(coverage)]
+    sdk::debug::store_artifact("sself_actor.profraw", minicov::capture_coverage());
+
+    0
+}

--- a/testing/integration/tests/fil-sself-actor/src/actor.rs
+++ b/testing/integration/tests/fil-sself-actor/src/actor.rs
@@ -62,9 +62,14 @@ pub fn invoke(_: u32) -> u32 {
     );
     assert_eq!(TokenAmount::from_nano(0), sdk::sself::current_balance());
 
-    // TODO (fridrik): test that self_destruct fails with ActorDeleteError::BeneficiaryDoesNotExist
-    // always returns Ok() since the balance was 0 and it does not resolve beneficiary address in
-    // that case
+    // calling destroy on an already destroyed actor should succeed (since its
+    // balance is 0)
+    //
+    // TODO (fridrik): we should consider changing this behaviour in the future
+    // and disallow destroying actor with non-zero balance)
+    //
+    sdk::sself::self_destruct(&Address::new_id(sdk::message::origin()))
+        .expect("deleting an already deleted actor should succeed since it has zero balance");
 
     #[cfg(coverage)]
     sdk::debug::store_artifact("sself_actor.profraw", minicov::capture_coverage());

--- a/testing/integration/tests/fil-sself-actor/src/actor.rs
+++ b/testing/integration/tests/fil-sself-actor/src/actor.rs
@@ -11,12 +11,7 @@ use sdk::error::{ActorDeleteError, StateReadError, StateUpdateError};
 
 #[no_mangle]
 pub fn invoke(_: u32) -> u32 {
-    std::panic::set_hook(Box::new(|info| {
-        sdk::vm::abort(
-            ExitCode::USR_ASSERTION_FAILED.value(),
-            Some(&format!("{}", info)),
-        )
-    }));
+    sdk::initialize();
 
     assert!(!sdk::vm::read_only());
 

--- a/testing/integration/tests/fil-sself-actor/src/actor.rs
+++ b/testing/integration/tests/fil-sself-actor/src/actor.rs
@@ -6,7 +6,6 @@ use fvm_ipld_encoding::{to_vec, DAG_CBOR};
 use fvm_sdk as sdk;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::error::ExitCode;
 use sdk::error::{ActorDeleteError, StateReadError, StateUpdateError};
 
 #[no_mangle]

--- a/testing/integration/tests/fil-sself-actor/src/lib.rs
+++ b/testing/integration/tests/fil-sself-actor/src/lib.rs
@@ -1,0 +1,7 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+#[cfg(not(target_arch = "wasm32"))]
+include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+
+#[cfg(target_arch = "wasm32")]
+mod actor;

--- a/testing/integration/tests/fil-syscall-actor/src/actor.rs
+++ b/testing/integration/tests/fil-syscall-actor/src/actor.rs
@@ -28,12 +28,7 @@ pub enum SupportedHashes {
 
 #[no_mangle]
 pub fn invoke(_: u32) -> u32 {
-    std::panic::set_hook(Box::new(|info| {
-        sdk::vm::abort(
-            ExitCode::USR_ASSERTION_FAILED.value(),
-            Some(&format!("{}", info)),
-        )
-    }));
+    sdk::initialize();
 
     test_signature();
     test_expected_hash();

--- a/testing/integration/tests/fil-syscall-actor/src/actor.rs
+++ b/testing/integration/tests/fil-syscall-actor/src/actor.rs
@@ -169,11 +169,20 @@ fn test_expected_hash() {
 
         assert_eq!(local_digest.digest(), digest.as_slice());
     }
+
+    // hash_owned and hash_into should return the same digest
+    {
+        let digest = sdk::crypto::hash_owned(SharedSupportedHashes::Blake2b512, test_bytes);
+        let mut buffer = [0u8; 64];
+        let len =
+            sdk::crypto::hash_into(SharedSupportedHashes::Blake2b512, test_bytes, &mut buffer);
+        assert_eq!(digest.len(), len);
+        assert_eq!(digest.as_slice(), buffer.as_slice());
+    }
 }
 
 // do funky things with hash syscall directly
 fn test_hash_syscall() {
-    use fvm_shared::error::ErrorNumber;
     use sdk::sys::crypto;
 
     let test_bytes = b"the quick fox jumped over the lazy dog";

--- a/testing/integration/tests/fil-syscall-actor/src/actor.rs
+++ b/testing/integration/tests/fil-syscall-actor/src/actor.rs
@@ -5,7 +5,7 @@ use fvm_shared::address::Address;
 use fvm_shared::chainid::ChainID;
 use fvm_shared::crypto::hash::SupportedHashes as SharedSupportedHashes;
 use fvm_shared::crypto::signature::{Signature, SECP_SIG_LEN};
-use fvm_shared::error::{ErrorNumber, ExitCode};
+use fvm_shared::error::ErrorNumber;
 use fvm_shared::sector::RegisteredSealProof;
 use multihash::derive::Multihash;
 use multihash::{Blake2b256, Blake2b512, Keccak256, Ripemd160, Sha2_256};

--- a/testing/integration/tests/fil-syscall-actor/src/actor.rs
+++ b/testing/integration/tests/fil-syscall-actor/src/actor.rs
@@ -4,7 +4,7 @@ use fvm_sdk as sdk;
 use fvm_shared::address::Address;
 use fvm_shared::chainid::ChainID;
 use fvm_shared::crypto::hash::SupportedHashes as SharedSupportedHashes;
-use fvm_shared::crypto::signature::Signature;
+use fvm_shared::crypto::signature::{Signature, SECP_SIG_LEN};
 use fvm_shared::error::{ErrorNumber, ExitCode};
 use multihash::derive::Multihash;
 use multihash::{Blake2b256, Blake2b512, Keccak256, Ripemd160, Sha2_256};
@@ -34,7 +34,7 @@ pub fn invoke(_: u32) -> u32 {
         )
     }));
 
-    test_verify_signature();
+    test_signature();
     test_expected_hash();
     test_hash_syscall();
     test_network_context();
@@ -46,22 +46,22 @@ pub fn invoke(_: u32) -> u32 {
     0
 }
 
-fn test_verify_signature() {
+fn test_signature() {
     // the following vectors represent a valid secp256k1 signatures for an address and plaintext message
     //
-    let signature_bytes = vec![
+    let signature_bytes: Vec<u8> = vec![
         80, 210, 71, 248, 219, 226, 85, 142, 143, 235, 164, 155, 239, 68, 193, 23, 191, 215, 35,
         70, 25, 34, 203, 14, 116, 134, 214, 3, 91, 22, 196, 172, 105, 154, 134, 128, 228, 172, 12,
         25, 251, 166, 51, 0, 210, 45, 23, 91, 12, 18, 228, 43, 204, 157, 233, 81, 69, 3, 44, 121,
         167, 31, 168, 52, 0,
     ];
-    let pub_key_bytes = vec![
+    let pub_key_bytes: Vec<u8> = vec![
         4, 223, 38, 78, 238, 254, 121, 58, 63, 120, 109, 108, 179, 105, 76, 211, 252, 223, 226, 1,
         20, 220, 212, 77, 23, 190, 224, 138, 62, 103, 27, 48, 60, 150, 151, 233, 30, 217, 137, 151,
         208, 24, 212, 117, 32, 94, 44, 118, 125, 40, 25, 31, 67, 154, 106, 97, 110, 32, 209, 62,
         194, 146, 27, 16, 114,
     ];
-    let message = vec![3, 1, 4, 1, 5, 9, 2, 6, 5, 3];
+    let message: Vec<u8> = vec![3, 1, 4, 1, 5, 9, 2, 6, 5, 3];
 
     // test the happy path
     //
@@ -72,15 +72,15 @@ fn test_verify_signature() {
 
     // test with invalid signature
     //
-    let mut invalid_signature_bytes = signature_bytes;
+    let mut invalid_signature_bytes = signature_bytes.clone();
     invalid_signature_bytes[0] += 1;
-    let invalid_signature = Signature::new_secp256k1(invalid_signature_bytes);
+    let invalid_signature = Signature::new_secp256k1(invalid_signature_bytes.clone());
     let res = sdk::crypto::verify_signature(&invalid_signature, &address, &message.as_slice());
     assert_eq!(res, Ok(false));
 
     // test with invalid address
     //
-    let mut invalid_pub_key_bytes = pub_key_bytes;
+    let mut invalid_pub_key_bytes = pub_key_bytes.clone();
     invalid_pub_key_bytes[0] += 1;
     let invalid_address = Address::new_secp256k1(&invalid_pub_key_bytes).unwrap();
     let res = sdk::crypto::verify_signature(&signature, &invalid_address, &message.as_slice());
@@ -123,6 +123,20 @@ fn test_verify_signature() {
             message.as_ptr(),
             message.len() as u32,
         );
+        assert_eq!(res, Err(ErrorNumber::IllegalArgument));
+    }
+
+    // test we can recover the public key from the signature
+    //
+    let hash = sdk::crypto::hash_blake2b(&message);
+    let sig: [u8; SECP_SIG_LEN] = signature_bytes.clone().try_into().unwrap();
+    let res = sdk::crypto::recover_secp_public_key(&hash, &sig).unwrap();
+    assert_eq!(res, pub_key_bytes.as_slice());
+
+    // test that passing an invalid hash buffer results in IllegalArgument
+    //
+    unsafe {
+        let res = sdk::sys::crypto::recover_secp_public_key(hash.as_ptr(), (u32::MAX) as *const u8);
         assert_eq!(res, Err(ErrorNumber::IllegalArgument));
     }
 }

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -335,8 +335,6 @@ fn create_actor() {
                 panic!("non-zero exit code {}", res.msg_receipt.exit_code)
             }
         }
-
-        assert_eq!(res.msg_receipt.exit_code, ExitCode::OK);
     }
 
     {


### PR DESCRIPTION
This PR adds multiple tests for our fvm sdk api to confirm they behave according to fvm sdk [docs](https://docs.rs/fvm_sdk/3.0.0-alpha.24/fvm_sdk/index.html).

Fixes: https://github.com/filecoin-project/ref-fvm/issues/585 

Note that there are still tests to be written for `actor::next_actor_address` and `crypto::verify_consensus_fault`. 

