### PR TITLE
Correct address field in `ActorState` arbitrary implementation

### DIFF
--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -452,7 +452,7 @@ impl Arbitrary for ActorState {
             state: cid,
             sequence: u64::arbitrary(g),
             balance: TokenAmount::from_atto(u64::arbitrary(g)),
-            address: None,
+            delegated_address: None,
         }
     }
 }


### PR DESCRIPTION
The `ActorState` struct `address` field was updated to `delegated_address`, however the `Arbitrary` implementation has not been updated and still references the old `address` field that no longer exists. This change simply updates the `Arbitrary` implementation to reference the new field.