### PR TITLE
add standard exit code for non-payable functions

### DIFF
--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -106,8 +106,8 @@ impl ExitCode {
     pub const USR_ASSERTION_FAILED: ExitCode = ExitCode::new(24);
     /// The requested operation cannot be performed in "read-only" mode.
     pub const USR_READ_ONLY: ExitCode = ExitCode::new(25);
-    // pub const RESERVED_25: ExitCode = ExitCode::new(25);
-    // pub const RESERVED_26: ExitCode = ExitCode::new(26);
+    /// The method cannot handle a transfer of value.
+    pub const USR_NOT_PAYABLE: ExitCode = ExitCode::new(26);
     // pub const RESERVED_27: ExitCode = ExitCode::new(27);
     // pub const RESERVED_28: ExitCode = ExitCode::new(28);
     // pub const RESERVED_29: ExitCode = ExitCode::new(29);


### PR DESCRIPTION
Adds a standard exit code that allows actors to indicate they are not prepared to receive funds: https://github.com/filecoin-project/builtin-actors/issues/836

Example usage in builtin-actors: https://github.com/filecoin-project/builtin-actors/pull/1241

