### PR TITLE
chore: upgrade proofs (v2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,12 @@ jobs:
             key: v3
             push: true
             command: build
+            args: --no-default-features
           - name: check-clippy
             key: v3
             command: clippy
-            args: --all --all-targets
+            # we disable default features because rust will otherwise unify them and turn on opencl in CI.
+            args: --all --all-targets --no-default-features
             components: clippy
           - name: test-fvm
             key: v3-cov

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -31,7 +31,7 @@ lazy_static = "1.4.0"
 derive-getters = "0.2.0"
 derive_more = "0.99.17"
 replace_with = "0.1.7"
-filecoin-proofs-api = { version = "12", default-features = false }
+filecoin-proofs-api = { version = "13", default-features = false }
 rayon = "1"
 num_cpus = "1.13.0"
 log = "0.4.14"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -33,9 +33,9 @@ arbitrary = { version = "1.1", optional = true, features = ["derive"]}
 ## non-wasm dependencies; these dependencies and the respective code is
 ## only activated through non-default features, which the Kernel enables, but
 ## not the actors.
-filecoin-proofs-api = { version = "12", default_features = false, optional = true }
+filecoin-proofs-api = { version = "13", default-features = false, optional = true }
 libsecp256k1 = { version = "0.7", optional = true }
-bls-signatures = { version = "0.12", default-features = false, optional = true }
+bls-signatures = { version = "0.13", default-features = false, optional = true }
 byteorder = "1.4.3"
 
 [dev-dependencies]


### PR DESCRIPTION
We need to do this on v3 and v2 because we can only link to one version of blstrs at a time.