### PR TITLE
chore: release fvm & fvm_shared v3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,7 +1839,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "serde",
  "substrate-wasm-builder",
 ]
@@ -1877,7 +1877,7 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "substrate-wasm-builder",
 ]
 
@@ -1887,7 +1887,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "serde",
  "serde_tuple",
  "substrate-wasm-builder",
@@ -1899,7 +1899,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "substrate-wasm-builder",
 ]
 
@@ -1911,7 +1911,7 @@ dependencies = [
  "cid",
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1924,7 +1924,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "log",
  "serde",
  "serde_tuple",
@@ -1936,7 +1936,7 @@ name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "substrate-wasm-builder",
 ]
 
@@ -1949,7 +1949,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "serde",
  "serde_tuple",
  "substrate-wasm-builder",
@@ -1961,7 +1961,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "minicov",
  "substrate-wasm-builder",
 ]
@@ -1971,7 +1971,7 @@ name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "substrate-wasm-builder",
 ]
 
@@ -1980,7 +1980,7 @@ name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "substrate-wasm-builder",
 ]
 
@@ -2007,7 +2007,7 @@ dependencies = [
  "cid",
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "substrate-wasm-builder",
 ]
 
@@ -2016,7 +2016,7 @@ name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "substrate-wasm-builder",
 ]
 
@@ -2027,7 +2027,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.0.0",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "minicov",
  "multihash",
  "substrate-wasm-builder",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2370,7 +2370,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "lazy_static",
  "log",
  "minstant",
@@ -2404,7 +2404,7 @@ dependencies = [
  "fvm_integration_tests",
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "hex",
  "serde",
 ]
@@ -2465,7 +2465,7 @@ dependencies = [
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "itertools 0.10.5",
  "ittapi-rs",
  "lazy_static",
@@ -2503,7 +2503,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "lazy_static",
  "libsecp256k1",
  "multihash",
@@ -2546,7 +2546,7 @@ dependencies = [
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "hex",
  "lazy_static",
  "libsecp256k1",
@@ -2844,7 +2844,7 @@ version = "3.0.0"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0",
+ "fvm_shared 3.1.0",
  "lazy_static",
  "log",
  "num-traits",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 3.1.0 [2023-03-09]
+
+Update proofs. Unfortunately, this is a breaking change in a minor release but we need to do the same on the v2 release as well. The correct solution is to introduce two crates, fvm1 and fvm2, but that's a future project.
+
 ## 3.0.0 [2023-02-24]
 
 - Final release for NV18.

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "3.0.0"
+version = "3.1.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -19,7 +19,7 @@ derive_builder = "0.12.0"
 num-derive = "0.3.3"
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.3", default-features = false }
-fvm_shared = { version = "3.0.0", path = "../shared", features = ["crypto"] }
+fvm_shared = { version = "3.1.0", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.6.1", path = "../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.1", path = "../ipld/amt" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../ipld/blockstore" }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { version = "0.8.5", default-features = false }
-fvm_shared = { version = "3.0.0", path = "../shared" }
+fvm_shared = { version = "3.1.0", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = { version = "1.4.0" }

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.0 [2023-03-09]
+
+Update proofs. Unfortunately, this is a breaking change in a minor release but we need to do the same on the v2 release as well. The correct solution is to introduce two crates, fvm1 and fvm2, but that's a future project.
+
 ## 3.0.0 [2022-02-24]
 
 - Final release for NV18.

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/testing/calibration/Cargo.toml
+++ b/testing/calibration/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Protocol Labs", "Filecoin Core Devs"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "3.0.0", path = "../../fvm", default-features = false, features = ["testing", "gas_calibration"] }
-fvm_shared = { version = "3.0.0", path = "../../shared", features = ["testing"] }
+fvm = { version = "3.1.0", path = "../../fvm", default-features = false, features = ["testing", "gas_calibration"] }
+fvm_shared = { version = "3.1.0", path = "../../shared", features = ["testing"] }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../ipld/encoding" }

--- a/testing/calibration/contract/fil-gas-calibration-actor/Cargo.toml
+++ b/testing/calibration/contract/fil-gas-calibration-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 cid = { version = "0.8.2", default-features = false }
 num-derive = "0.3"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "3.0.0", path = "../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../shared" }
 fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.1", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
@@ -50,7 +50,7 @@ actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/
 libipld-core = { version = "0.14.0", features = ["serde-codec"] }
 
 [dependencies.fvm]
-version = "3.0.0"
+version = "3.1.0"
 path = "../../fvm"
 default-features = false
 features = ["testing"]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Protocol Labs", "Filecoin Core Devs", "Polyphene"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "3.0.0", path = "../../fvm", default-features = false, features = ["testing"] }
-fvm_shared = { version = "3.0.0", path = "../../shared", features = ["testing"] }
+fvm = { version = "3.1.0", path = "../../fvm", default-features = false, features = ["testing"] }
+fvm_shared = { version = "3.1.0", path = "../../shared", features = ["testing"] }
 fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.1", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }

--- a/testing/integration/tests/fil-address-actor/Cargo.toml
+++ b/testing/integration/tests/fil-address-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 serde = "1.0.145"
 
 [build-dependencies]

--- a/testing/integration/tests/fil-create-actor/Cargo.toml
+++ b/testing/integration/tests/fil-create-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-events-actor/Cargo.toml
+++ b/testing/integration/tests/fil-events-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 serde = {version = "1.0.145", features = ["derive"] }
 serde_tuple = "0.5.0"
 

--- a/testing/integration/tests/fil-exit-data-actor/Cargo.toml
+++ b/testing/integration/tests/fil-exit-data-actor/Cargo.toml
@@ -6,12 +6,12 @@ publish = false
 
 [dependencies]
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-gaslimit-actor/Cargo.toml
+++ b/testing/integration/tests/fil-gaslimit-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 serde = {version = "1.0.145", features = ["derive"] }
 serde_tuple = "0.5.0"
 log = "0.4.14"

--- a/testing/integration/tests/fil-hello-world-actor/Cargo.toml
+++ b/testing/integration/tests/fil-hello-world-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-integer-overflow-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../../../ipld/blockstore" }
 

--- a/testing/integration/tests/fil-ipld-actor/Cargo.toml
+++ b/testing/integration/tests/fil-ipld-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 
 [target.'cfg(coverage)'.dependencies]
 minicov = "0.3"

--- a/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-malformed-syscall-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
 
 [build-dependencies]

--- a/testing/integration/tests/fil-oom-actor/Cargo.toml
+++ b/testing/integration/tests/fil-oom-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.0.0-alpha.24", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0-alpha.20", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-readonly-actor/Cargo.toml
+++ b/testing/integration/tests/fil-readonly-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 cid = { version = "0.8.5", default-features = false }
 

--- a/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/integration/tests/fil-stack-overflow-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"

--- a/testing/integration/tests/fil-syscall-actor/Cargo.toml
+++ b/testing/integration/tests/fil-syscall-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.0.0", path = "../../../../shared" }
+fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 minicov = {version = "0.3", optional = true}
 actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
 multihash = "0.16.3"


### PR DESCRIPTION
This release updates the proofs code and nothing else.