### PR TITLE
fix: correctly format syscall error messages

### DIFF
--- a/fvm/src/kernel/error.rs
+++ b/fvm/src/kernel/error.rs
@@ -11,13 +11,13 @@ pub type Result<T> = std::result::Result<T, ExecutionError>;
 /// Convenience macro for generating Actor Errors
 #[macro_export]
 macro_rules! syscall_error {
-    // Error with only one stringable expression
-    ( $code:ident; $msg:expr ) => { $crate::kernel::SyscallError::new(fvm_shared::error::ErrorNumber::$code, $msg) };
-
     // String with positional arguments
-    ( $code:ident; $msg:literal $(, $ex:expr)+ ) => {
+    ( $code:ident; $msg:literal $(, $ex:expr)* ) => {
         $crate::kernel::SyscallError::new(fvm_shared::error::ErrorNumber::$code, format_args!($msg, $($ex,)*))
     };
+
+    // Error with only one stringable expression
+    ( $code:ident; $msg:expr ) => { $crate::kernel::SyscallError::new(fvm_shared::error::ErrorNumber::$code, $msg) };
 
     // Error with only one stringable expression, with comma separator
     ( $code:ident, $msg:expr ) => { $crate::syscall_error!($code; $msg) };
@@ -185,4 +185,22 @@ impl SyscallError {
     pub fn new<D: Display>(c: ErrorNumber, d: D) -> Self {
         SyscallError(d.to_string(), c)
     }
+}
+
+#[test]
+fn test_syscall_error_formatting() {
+    let test_value = 1;
+    assert_eq!(
+        syscall_error!(IllegalArgument; "msg: {test_value}").0,
+        "msg: 1"
+    );
+    assert_eq!(
+        syscall_error!(IllegalArgument; "msg: {}", test_value).0,
+        "msg: 1"
+    );
+    assert_eq!(syscall_error!(IllegalArgument; "msg").0, "msg");
+    assert_eq!(
+        syscall_error!(IllegalArgument; String::from("msg")).0,
+        "msg"
+    );
 }


### PR DESCRIPTION
This makes string interpolation ("message: {some_variable}") work.

Previously, we'd apply string formatting to syscall error messages if and only if we had one or more format arguments. Now, we apply the formatting whenever the message is a string literal.

found by @fridrik01 in https://github.com/filecoin-project/ref-fvm/pull/1698