### PR TITLE
fix: Github integration tests failed due to running out of disk space

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ overflow-checks = true
 lto = true
 opt-level = "z"
 #strip = true
+
+# so we don't run out of disk space on Github CI
+[profile.dev.package.fvm_gas_calibration]
+strip = true


### PR DESCRIPTION
This commit overrides the development profile for our fvm_gas_calibration integration test so it strips all the generated binaries (6 in total) of debug symbols.

This reduces disk space usage by over 4GB so it should give us enough headroom for running integration tests on Gibhug (which only has 12GB SSD).

fixes: https://github.com/filecoin-project/ref-fvm/issues/1710