### PR TITLE
ci: disable incremental build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
           - os: macos-latest
             name: test-fvm
     env:
+      CARGO_INCREMENTAL: 0
       CARGO_TERM_COLOR: always
     name: ${{matrix.os}} - ${{ matrix.name }}
     steps:


### PR DESCRIPTION
- This causes build failures in CI (at least with sccache). We had disabled this before, but I re-enabled it when I upgraded CI.
- This is likely increasing cache sizes, and just isn't worth it.