### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,18 +49,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,41 +1071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,17 +1097,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-getters"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "derive_arbitrary"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,37 +1104,6 @@ checksum = "8beee4701e2e229e8098bbdecdca12449bc3e322f137d269182fa1291e20bd00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
-dependencies = [
- "derive_builder_core",
  "syn",
 ]
 
@@ -1800,7 +1711,6 @@ dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.0.0",
  "fvm_shared 3.1.0",
- "serde",
 ]
 
 [[package]]
@@ -2089,12 +1999,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "forest_hash_utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,11 +2218,8 @@ version = "3.1.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "blake2b_simd",
  "byteorder",
  "cid",
- "derive-getters",
- "derive_builder",
  "derive_more",
  "filecoin-proofs-api",
  "fvm",
@@ -2332,7 +2233,6 @@ dependencies = [
  "log",
  "minstant",
  "multihash",
- "num-derive",
  "num-traits",
  "num_cpus",
  "once_cell",
@@ -2342,7 +2242,6 @@ dependencies = [
  "rayon",
  "replace_with",
  "serde",
- "serde_repr",
  "serde_tuple",
  "thiserror",
  "wasmtime",
@@ -2357,13 +2256,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 4.1.4",
- "fvm",
  "fvm_integration_tests",
- "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared 3.1.0",
  "hex",
- "serde",
 ]
 
 [[package]]
@@ -2401,27 +2297,20 @@ dependencies = [
 name = "fvm_conformance_tests"
 version = "0.1.0"
 dependencies = [
- "ahash 0.8.3",
  "anyhow",
  "async-std",
  "base64 0.21.0",
- "byteorder",
  "cid",
  "colored",
  "criterion",
- "derive-getters",
- "derive_builder",
- "derive_more",
  "either",
  "fil_builtin_actors_bundle",
  "flate2",
  "futures",
  "fvm",
- "fvm_ipld_amt 0.5.1",
  "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt 0.6.1",
  "fvm_shared 3.1.0",
  "itertools 0.10.5",
  "ittapi-rs",
@@ -2429,17 +2318,12 @@ dependencies = [
  "libipld-core 0.14.0",
  "log",
  "multihash",
- "num-derive",
  "num-traits",
  "num_cpus",
  "pretty_env_logger",
  "regex",
- "replace_with",
  "serde",
  "serde_json",
- "serde_repr",
- "serde_tuple",
- "thiserror",
  "walkdir",
  "wasmtime",
 ]
@@ -2735,7 +2619,6 @@ dependencies = [
  "quickcheck_macros",
  "rand",
  "serde",
- "sha2 0.10.6",
  "thiserror",
  "unsigned-varint",
 ]
@@ -2869,16 +2752,13 @@ dependencies = [
  "bitflags",
  "blake2b_simd",
  "bls-signatures",
- "byteorder",
  "cid",
  "data-encoding",
  "data-encoding-macro",
  "filecoin-proofs-api",
- "fvm_ipld_blockstore 0.1.1",
  "fvm_ipld_encoding 0.3.3",
  "lazy_static",
  "libsecp256k1",
- "log",
  "multihash",
  "num-bigint",
  "num-derive",
@@ -2889,9 +2769,7 @@ dependencies = [
  "rand_chacha",
  "serde",
  "serde_json",
- "serde_repr",
  "serde_tuple",
- "sha3",
  "thiserror",
  "unsigned-varint",
 ]
@@ -3001,7 +2879,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
 ]
 
 [[package]]
@@ -3098,12 +2976,6 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -15,8 +15,6 @@ crate-type = ["lib"]
 anyhow = { version = "1.0.47", features = ["backtrace"] }
 thiserror = "1.0.30"
 num-traits = "0.2"
-derive_builder = "0.12.0"
-num-derive = "0.3.3"
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.3", default-features = false }
 fvm_shared = { version = "3.1.0", path = "../shared", features = ["crypto"] }
@@ -26,9 +24,7 @@ fvm_ipld_blockstore = { version = "0.1.1", path = "../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../ipld/encoding" }
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = "0.5"
-serde_repr = "0.1"
 lazy_static = "1.4.0"
-derive-getters = "0.2.0"
 derive_more = "0.99.17"
 replace_with = "0.1.7"
 filecoin-proofs-api = { version = "13", default-features = false }
@@ -36,7 +32,6 @@ rayon = "1"
 num_cpus = "1.13.0"
 log = "0.4.14"
 byteorder = "1.4.3"
-blake2b_simd = "1.0.0"
 fvm-wasm-instrument = "0.4.0"
 yastl = "0.1.2"
 arbitrary = { version = "1.1.0", optional = true, features = ["derive"] }

--- a/ipld/kamt/Cargo.toml
+++ b/ipld/kamt/Cargo.toml
@@ -13,7 +13,6 @@ byteorder = "1.3.2"
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.0", default-features = false }
 thiserror = "1.0"
-sha2 = "0.10"
 once_cell = "1.5"
 forest_hash_utils = "0.1"
 anyhow = "1.0.51"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -17,16 +17,13 @@ num-integer = "0.1"
 data-encoding = "2.3.2"
 data-encoding-macro = "0.1.12"
 lazy_static = "1.4.0"
-log = "0.4.8"
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec", "std"] }
 multihash = { version = "0.16.3", default-features = false, features = ["multihash-impl", "sha2", "sha3", "ripemd"] }
 unsigned-varint = "0.7.1"
 anyhow = "1.0.51"
-fvm_ipld_blockstore = { version = "0.1", path = "../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.3", path = "../ipld/encoding" }
 serde = { version = "1", default-features = false }
 serde_tuple = "0.5"
-serde_repr = "0.1"
 arbitrary = { version = "1.1", optional = true, features = ["derive"]}
 quickcheck = { version = "1", optional = true }
 bitflags = "1.3.2"
@@ -37,8 +34,6 @@ bitflags = "1.3.2"
 filecoin-proofs-api = { version = "13", default-features = false, optional = true }
 libsecp256k1 = { version = "0.7", optional = true }
 bls-signatures = { version = "0.13", default-features = false, optional = true }
-byteorder = "1.4.3"
-sha3 = { version = "0.10.0", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = "0.8"

--- a/testing/common_fuzz/fuzz/Cargo.toml
+++ b/testing/common_fuzz/fuzz/Cargo.toml
@@ -11,18 +11,12 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1.1", features = ["derive"] }
-ahash = "0.7.6"
-itertools = "0.10.3"
 rand = "0.8.5"
-
 cid = { version = "0.8.4", default-features = false, features = ["serde-codec", "arb", "std"] }
-multihash = { version = "0.16.2", features = ["sha2"]}
-
 fvm_ipld_bitfield = { path = "../../../ipld/bitfield", features = ["enable-arbitrary"] }
 fvm_ipld_encoding = { path = "../../../ipld/encoding" }
 fvm_shared = { path = "../../../shared", features = ["arb"] }
 serde = { version = "1", features = ["derive"] }
-hex = "0.4"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -10,29 +10,17 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
 fvm_shared = { version = "3.1.0", path = "../../shared" }
-fvm_ipld_hamt = { version = "0.6.1", path = "../../ipld/hamt" }
-fvm_ipld_amt = { version = "0.5.1", path = "../../ipld/amt" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.1", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../ipld/encoding" }
 
 anyhow = "1.0.47"
-thiserror = "1.0.30"
 num-traits = "0.2"
-derive_builder = "0.12.0"
-ahash = "0.8"
-num-derive = "0.3.3"
 cid = { version = "0.8.5", default-features = false }
 multihash = { version = "0.16.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
-serde_tuple = "0.5"
-serde_repr = "0.1"
 lazy_static = "1.4.0"
-derive-getters = "0.2.0"
-derive_more = "0.99.17"
-replace_with = "0.1.7"
 log = "0.4.14"
-byteorder = "1.4.3"
 futures = "0.3.19"
 async-std = { version = "1.9", features = ["attributes"] }
 wasmtime = { version = "2.0.2", default-features = false }

--- a/testing/test_actors/actors/fil-address-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-address-actor/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
 fvm_shared = { version = "3.1.0", path = "../../../../shared" }
-serde = "1.0.145"
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/tools/fvm-bench/Cargo.toml
+++ b/tools/fvm-bench/Cargo.toml
@@ -5,11 +5,8 @@ edition = "2021"
 
 [dependencies]
 fvm_integration_tests = { path = "../../testing/integration" }
-fvm_ipld_blockstore = { path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { path = "../../ipld/encoding" }
 fvm_shared = { path = "../../shared" }
-fvm = { path = "../../fvm", default-features = false, features = ["testing"] }
 anyhow = "1.0.47"
 clap = { version = "4.0.27", features = ["derive"] }
 hex = "0.4.3"
-serde = { version = "1.0.148", features = ["derive"] }


### PR DESCRIPTION
Used cargo-machete tool that uses regexps against source code to find unused dependencies. Overall this removes 10 packages dependencies from Cargo.lock.

See: https://github.com/filecoin-project/ref-fvm/issues/1682