### PR TITLE
Fix failing CI check due to missing m2-native feature in builtin-actors

### DIFF
--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 walkdir = "2.3"
 regex = { version = "1.0" }
 ittapi-rs = { version = "0.3.0", optional = true }
-actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
+actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
 libipld-core = { version = "0.14.0", features = ["serde-codec"] }
 
 [dependencies.fvm]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -33,7 +33,7 @@ default-features = false
 features = ["cranelift", "parallel-compilation"]
 
 [dev-dependencies]
-actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
+actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
 fvm_test_actors = { path = "../test_actors" }
 wat = "1.0.51"
 hex = "0.4.3"

--- a/testing/test_actors/actors/fil-create-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-create-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
 fvm_shared = { version = "3.1.0", path = "../../../../shared" }
-actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
+actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -9,7 +9,7 @@ fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.0.0", path = "../../../../sdk" }
 fvm_shared = { version = "3.1.0", path = "../../../../shared" }
 minicov = {version = "0.3", optional = true}
-actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
+actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
 multihash = "0.16.3"
 
 [lib]


### PR DESCRIPTION
This commit removes the m2-native feature for builtin-actors which has been removed from the project.

With this PR all CI tests :heavy_check_mark: pass on master 