### PR TITLE
Enable code coverage in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,10 @@ jobs:
             command: llvm-cov
             args: --all --exclude fvm --exclude fvm_conformance_tests --exclude fvm_integration_tests --exclude "*actor" --lcov --output-path lcov.info
           - name: integration
-            key: v3
-            command: test
-            args: --package fvm_integration_tests --package "*actor"
+            key: v3-cov
+            covname: itest-lcov.info
+            command: llvm-cov
+            args: --package fvm_integration_tests --package "*actor" --lcov --output-path itest-lcov.info
           - name: conformance
             key: v3
             command: test
@@ -103,6 +104,8 @@ jobs:
       with:
         files: ${{ matrix.covname }}
         token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+        verbose: true
     - name: Installing Cargo-Cache
       if: ${{ matrix.push }}
       run: cargo install cargo-cache


### PR DESCRIPTION
This PR enables code coverage for our integration tests, it seems to bump up our coverage from to 55% to 75% ([link](https://app.codecov.io/github/filecoin-project/ref-fvm/commit/167dc3b4de9c1086e64f4f67a640e4497c2e2887))

Fixes: https://github.com/filecoin-project/ref-fvm/issues/979