### PR TITLE
feat: kernel: use specified proof type when verifying PoSts

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -18,7 +18,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::event::ActorEvent;
 use fvm_shared::piece::{zero_piece_commitment, PaddedPieceSize};
-use fvm_shared::sector::SectorInfo;
+use fvm_shared::sector::{RegisteredPoStProof, SectorInfo};
 use fvm_shared::sys::out::vm::ContextFlags;
 use fvm_shared::{commcid, ActorID};
 use lazy_static::lazy_static;
@@ -284,7 +284,7 @@ where
         // We perform operations as u64, because we know that the buffer length and offset must fit
         // in a u32.
         let end = i32::try_from((offset as u64) + (buf.len() as u64))
-            .map_err(|_|syscall_error!(IllegalArgument; "offset plus buffer length did not fit into an i32"))?;
+            .map_err(|_| syscall_error!(IllegalArgument; "offset plus buffer length did not fit into an i32"))?;
 
         // Then get the block.
         let block = self.blocks.get(id)?;
@@ -715,7 +715,7 @@ where
         match offset.cmp(&0) {
             Less => return Err(syscall_error!(IllegalArgument; "epoch {} is in the future", epoch).into()),
             Equal => return Err(syscall_error!(IllegalArgument; "cannot lookup the tipset cid for the current epoch").into()),
-            Greater => {},
+            Greater => {}
         }
 
         // Can't lookup tipset CIDs beyond finality.
@@ -1076,13 +1076,6 @@ fn validate_actor_event(evt: &ActorEvent) -> Result<()> {
     Ok(())
 }
 
-/// PoSt proof variants.
-enum ProofType {
-    #[allow(unused)]
-    Winning,
-    Window,
-}
-
 fn prover_id_from_u64(id: u64) -> ProverId {
     let mut prover_id = ProverId::default();
     let prover_bytes = Address::new_id(id).payload().to_raw_bytes();
@@ -1114,18 +1107,14 @@ fn get_required_padding(
 
 fn to_fil_public_replica_infos(
     src: &[SectorInfo],
-    typ: ProofType,
+    typ: RegisteredPoStProof,
 ) -> Result<BTreeMap<SectorId, PublicReplicaInfo>> {
     let replicas = src
         .iter()
         .map::<core::result::Result<(SectorId, PublicReplicaInfo), String>, _>(
             |sector_info: &SectorInfo| {
                 let commr = commcid::cid_to_replica_commitment_v1(&sector_info.sealed_cid)?;
-                let proof = match typ {
-                    ProofType::Winning => sector_info.proof.registered_winning_post_proof()?,
-                    ProofType::Window => sector_info.proof.registered_window_post_proof()?,
-                };
-                let replica = PublicReplicaInfo::new(proof.try_into()?, commr);
+                let replica = PublicReplicaInfo::new(typ.try_into()?, commr);
                 Ok((SectorId::from(sector_info.sector_number), replica))
             },
         )
@@ -1173,8 +1162,10 @@ fn verify_post(verify_info: &WindowPoStVerifyInfo) -> Result<bool> {
     // Necessary to be valid bls12 381 element.
     randomness[31] &= 0x3f;
 
+    let proof_type = proofs[0].post_proof;
+
     // Convert sector info into public replica
-    let replicas = to_fil_public_replica_infos(challenged_sectors, ProofType::Window)?;
+    let replicas = to_fil_public_replica_infos(challenged_sectors, proof_type)?;
 
     // Convert PoSt proofs into proofs-api format
     let proofs: Vec<(proofs::RegisteredPoStProof, _)> = proofs


### PR DESCRIPTION
We no longer have only one PoSt proof type corresponding to each Seal proof type. As a result, when verifying PoSts, we must supply the proof type that the proof "announces" as the public Replica's PoSt proof type. This is still secure as proofs code checks that all replicas have the same proof type, and actors code confirms that the proof type of the first PoSt is valid.

If we wanted to, we could revert this change in FVM4, at which point we'll have a one PoSt per Seal restriction again. If we _really_ wanted to, we could make this code network version dependent, and only apply this change to nv19, but I think that belongs in actors code.