### PR TITLE
Remove unstable rustfmt configuration

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,1 @@
-imports_granularity = "Module"
 reorder_imports = true
-group_imports = "StdExternalCrate"


### PR DESCRIPTION
We switched to Rust stable toolchain in https://github.com/filecoin-project/ref-fvm/pull/1718 and with that we are not able to use unstable rustfmt configuration.