### PR TITLE
Update make lint to only run fmt + clippy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 clean:
 	cargo clean
 
-lint: license clean
+lint:
 	cargo fmt --all
 	cargo clippy --all -- -D warnings -A clippy::upper_case_acronyms
 


### PR DESCRIPTION
This PR updates the `make lint` target to only run fmt + clippy lint.

The motivation is that I have often gotten lint errors in CI since I did not run the lint check locally before pushing due to running `make lint` having the following issues:
- It runs `cargo clean` which meant extra waiting
- It runs `add_license.sh` script which currently does not work on newest version of macos (has no -P option).