### PR TITLE
instance pool resource management

### DIFF
--- a/fvm/src/engine.rs
+++ b/fvm/src/engine.rs
@@ -675,8 +675,6 @@ struct InstancePool {
     cv: Condvar,
 }
 
-// temporarily allow dead_code
-#[allow(dead_code)]
 impl InstancePool {
     fn new(avail: u32, rsvp: u32) -> InstancePool {
         InstancePool {

--- a/fvm/src/engine.rs
+++ b/fvm/src/engine.rs
@@ -644,8 +644,8 @@ impl InstancePool {
     fn new(avail: i32, rsvp: i32) -> InstancePool {
         InstancePool {
             mx: Mutex::new(InstancePoolInner {
-                avail: avail,
-                rsvp: rsvp,
+                avail,
+                rsvp,
                 boost: None,
                 boosting: 0,
             }),

--- a/fvm/src/engine/concurrency.rs
+++ b/fvm/src/engine/concurrency.rs
@@ -10,7 +10,7 @@ pub(super) struct EngineConcurrency {
 }
 
 struct EngineConcurrencyInner {
-    engine_count: u64,
+    next_id: u64,
     limit: u32,
 }
 
@@ -18,7 +18,7 @@ impl EngineConcurrency {
     pub fn new(concurrency: u32) -> Self {
         EngineConcurrency {
             inner: Mutex::new(EngineConcurrencyInner {
-                engine_count: 0,
+                next_id: 0,
                 limit: concurrency,
             }),
             condv: Condvar::new(),
@@ -32,10 +32,10 @@ impl EngineConcurrency {
             .condv
             .wait_while(self.inner.lock().unwrap(), |inner| inner.limit == 0)
             .unwrap();
-        let id = guard.engine_count;
+        let id = guard.next_id;
 
         guard.limit -= 1;
-        guard.engine_count += 1;
+        guard.next_id += 1;
 
         id
     }

--- a/fvm/src/engine/concurrency.rs
+++ b/fvm/src/engine/concurrency.rs
@@ -1,0 +1,48 @@
+use std::sync::{Condvar, Mutex};
+
+/// An engine concurrency manages the concurrency available for a single engine. It's basically a
+/// semaphore that also assigns IDs to new engines.
+pub(super) struct EngineConcurrency {
+    inner: Mutex<EngineConcurrencyInner>,
+    condv: Condvar,
+}
+
+struct EngineConcurrencyInner {
+    engine_count: u64,
+    limit: u32,
+}
+
+impl EngineConcurrency {
+    pub fn new(concurrency: u32) -> Self {
+        EngineConcurrency {
+            inner: Mutex::new(EngineConcurrencyInner {
+                engine_count: 0,
+                limit: concurrency,
+            }),
+            condv: Condvar::new(),
+        }
+    }
+
+    /// Acquire a new engine (well, an engine ID). This function blocks until we're below the
+    /// maximum engine concurrency limit.
+    pub fn acquire(&self) -> u64 {
+        let mut guard = self
+            .condv
+            .wait_while(self.inner.lock().unwrap(), |inner| inner.limit == 0)
+            .unwrap();
+        let id = guard.engine_count;
+
+        guard.limit -= 1;
+        guard.engine_count += 1;
+
+        id
+    }
+
+    /// Release the engine. After this is called, the caller should not allocate any more instances
+    /// or continue to use their engine ID.
+    pub fn release(&self) {
+        let mut guard = self.inner.lock().unwrap();
+        guard.limit += 1;
+        self.condv.notify_one();
+    }
+}

--- a/fvm/src/engine/concurrency.rs
+++ b/fvm/src/engine/concurrency.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::sync::{Condvar, Mutex};
 
 /// An engine concurrency manages the concurrency available for a single engine. It's basically a

--- a/fvm/src/engine/instance_pool.rs
+++ b/fvm/src/engine/instance_pool.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::sync::{Condvar, Mutex};
 
 /// An instance pool manages the available pool of engine instances.

--- a/fvm/src/engine/instance_pool.rs
+++ b/fvm/src/engine/instance_pool.rs
@@ -5,9 +5,9 @@ use std::sync::{Condvar, Mutex};
 /// An instance pool manages the available pool of engine instances.
 ///
 /// - When there are enough instances to execute an entire message (a full call stack), requests to
-///   reserve an instance will succeed immediately.
+///   take an instance will succeed immediately.
 /// - When the number of available instances drops below the number required to execute a single
-///   message, the executor that reserved that last instance will get an exclusive "lock" on the
+///   message, the executor that took that last instance will get an exclusive "lock" on the
 ///   instance pool. This lock will be released when enough instances become available to execute an
 ///   entire message.
 pub(super) struct InstancePool {
@@ -73,7 +73,7 @@ impl InstancePool {
             "no instances available: we must have exceeded our stack depth"
         );
 
-        // Reserve our instance and lock the executor if we're below the reservation limit.
+        // Take our instance and lock the executor if we're below the reservation limit.
         guard.available -= 1;
         if guard.available < guard.per_engine_limit {
             guard.locked = Some(id);

--- a/fvm/src/engine/instance_pool.rs
+++ b/fvm/src/engine/instance_pool.rs
@@ -1,0 +1,80 @@
+use std::sync::{Condvar, Mutex};
+
+/// An instance pool manages the available pool of engine instances.
+///
+/// - When there are enough instances to execute an entire message (a full call stack), requests to
+///   reserve an instance will succeed immediately.
+/// - When the number of available instances drops below the number required to execute a single
+///   message, the executor that reserved that last instance will get an exclusive "lock" on the
+///   instance pool. This lock will be released when enough instances become available to execute an
+///   entire message.
+pub(super) struct InstancePool {
+    inner: Mutex<InstancePoolInner>,
+    condv: Condvar,
+}
+
+struct InstancePoolInner {
+    /// The number of instances available in the pool.
+    available: u32,
+    /// The maximum number of instances that can be in-use by any given engine. If available drops
+    /// to this limit, we'll "lock" the pool to the current executor and refuse to lend out any more
+    /// instances to any _other_ engine until we go back above this number.
+    per_engine_limit: u32,
+    /// The ID of the engine currently "locking" the instance pool.
+    locked: Option<u64>,
+}
+
+impl InstancePool {
+    /// Create a new instance pool.
+    pub fn new(available: u32, per_engine_limit: u32) -> InstancePool {
+        InstancePool {
+            inner: Mutex::new(InstancePoolInner {
+                available,
+                per_engine_limit,
+                locked: None,
+            }),
+            condv: Condvar::new(),
+        }
+    }
+
+    /// Put back an instance into the pool, signaling any engines waiting on an instance if
+    /// applicable.
+    pub fn put(&self) {
+        let mut guard = self.inner.lock().unwrap();
+        guard.available += 1;
+
+        // If we're above the limit, unlock and notify one.
+        if guard.available >= guard.per_engine_limit {
+            guard.locked = None;
+            self.condv.notify_one();
+        }
+    }
+
+    /// Take an instance out of the instance pool (where `id` is the engine's ID). This function
+    /// will block if the instance pool is locked to another engine.
+    ///
+    /// Panics if any engine tries to allocate more than the configured `per_engine_limit`.
+    pub fn take(&self, id: u64) {
+        let mut guard = self.inner.lock().unwrap();
+
+        // Wait until we have an instance available. Either:
+        // 1. We own the executor lock.
+        // 2. We _could_ own the executor lock.
+        guard = self
+            .condv
+            .wait_while(guard, |p| p.locked.unwrap_or(id) != id)
+            .unwrap();
+
+        // We either have, or could, lock the executor. So there should be instances available.
+        assert!(
+            guard.available > 0,
+            "no instances available: we must have exceeded our stack depth"
+        );
+
+        // Reserve our instance and lock the executor if we're below the reservation limit.
+        guard.available -= 1;
+        if guard.available < guard.per_engine_limit {
+            guard.locked = Some(id);
+        }
+    }
+}

--- a/fvm/src/engine/mod.rs
+++ b/fvm/src/engine/mod.rs
@@ -61,7 +61,7 @@ impl EngineConfig {
         std::cmp::min(
             // Allocate at least one full call depth worth of stack, plus some per concurrent call
             // we allow.
-            self.max_call_depth + EXPECTED_MAX_STACK_DEPTH * self.concurrency.saturating_sub(1),
+            self.max_call_depth + EXPECTED_MAX_STACK_DEPTH * self.concurrency,
             // Most machines simply can't handle any more than 48k instances (fails to allocate
             // address space).
             48 * 1024,

--- a/fvm/src/engine/mod.rs
+++ b/fvm/src/engine/mod.rs
@@ -35,7 +35,9 @@ use crate::Kernel;
 use self::concurrency::EngineConcurrency;
 use self::instance_pool::InstancePool;
 
-const EFFECTIVE_STACK_DEPTH: u32 = 20;
+/// The expected max stack depth used to determine the number of instances needed for a given
+/// concurrency level.
+const EXPECTED_MAX_STACK_DEPTH: u32 = 20;
 
 /// Container managing engines with different consensus-affecting configurations.
 pub struct MultiEngine {
@@ -59,7 +61,7 @@ impl EngineConfig {
         std::cmp::min(
             // Allocate at least one full call depth worth of stack, plus some per concurrent call
             // we allow.
-            self.max_call_depth + EFFECTIVE_STACK_DEPTH * self.concurrency.saturating_sub(1),
+            self.max_call_depth + EXPECTED_MAX_STACK_DEPTH * self.concurrency.saturating_sub(1),
             // Most machines simply can't handle any more than 48k instances (fails to allocate
             // address space).
             48 * 1024,

--- a/fvm/src/engine/mod.rs
+++ b/fvm/src/engine/mod.rs
@@ -57,10 +57,11 @@ pub struct EngineConfig {
 impl EngineConfig {
     fn instance_pool_size(&self) -> u32 {
         std::cmp::min(
-            // Allocate at leat one full call depth worth of stack, plus some per concurrent call we allow.
+            // Allocate at least one full call depth worth of stack, plus some per concurrent call
+            // we allow.
             self.max_call_depth + EFFECTIVE_STACK_DEPTH * self.concurrency.saturating_sub(1),
-            // Most machines simply can't handle any more than 48k instances (fails to allocate address
-            // space).
+            // Most machines simply can't handle any more than 48k instances (fails to allocate
+            // address space).
             48 * 1024,
         )
     }
@@ -596,7 +597,7 @@ impl Engine {
 
     /// Construct a new wasmtime "store" from the given kernel.
     pub fn new_store<K: Kernel>(&self, mut kernel: K) -> wasmtime::Store<InvocationData<K>> {
-        // Reserve a new instance and put it into a drop-guard that removes the reservation when
+        // Take a new instance and put it into a drop-guard that removes the reservation when
         // we're done.
         #[must_use]
         struct InstanceReservation(Arc<EngineInner>);

--- a/fvm/src/engine/mod.rs
+++ b/fvm/src/engine/mod.rs
@@ -1,8 +1,9 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 mod concurrency;
 mod instance_pool;
 
-// Copyright 2021-2023 Protocol Labs
-// SPDX-License-Identifier: Apache-2.0, MIT
 use std::any::{Any, TypeId};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;


### PR DESCRIPTION
This introduces a resource pool component for wasm instances, which allows oversubscription and but prevents deadlocks by "locking" the pool to the first engine that brings the number of available instances below the number required to execute a single message. When the pool is locked to a specific engine, only that engine will be able to acquire more instances to ensure it can completely execute its message.

Future work:

- Memory limits. Ideally we'd apply the same concept to memory as the current approach could lead to memory exhaustion if the user isn't careful and allows too much parallelism without enough memory to back it up.
- Optimal "locking" strategy. At the moment, we "lock" the pool to an engine when we drop below the number of instances required to execute a single message. However, we don't take the number of instances _already_ acquired by the engine in question when doing so. We _could_ do this, but it requires significantly more tracking.
- Fewer places where we can panic. The current code will panic (safely) if misused. I'd prefer to return results in some of these cases, but threading the errors through the call manager got a bit tricky.
- Fairness. Right now, there is no fairness. If this becomes a problem, we try switching to a fair condition variable (or implement our own fairness). But we should be "ok" for now.

Testing:

- Unit tests.
- Manual testing on a live lotus node.

We're not _adding_ parallelism here (we know that already works), just adding an oversubscription mechanism. So testing that mechanism should be sufficient (IMO).