### PR TITLE
fix: parse static addresses as mainnet addresses

### DIFF
--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -46,7 +46,7 @@ pub const FIRST_NON_SINGLETON_ADDR: ActorID = 100;
 
 lazy_static::lazy_static! {
     static ref BLS_ZERO_ADDR_BYTES: [u8; BLS_PUB_LEN] = {
-        let bz_addr = Address::from_str("f3yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaby2smx7a");
+        let bz_addr = Network::Mainnet.parse_address("f3yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaby2smx7a");
         if let Ok(Address {payload: Payload::BLS(pubkey), ..}) = bz_addr {
             pubkey
         } else {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -43,7 +43,7 @@ lazy_static! {
     /// Zero address used to avoid allowing it to be used for verification.
     /// This is intentionally disallowed because it is an edge case with Filecoin's BLS
     /// signature verification.
-    pub static ref ZERO_ADDRESS: Address = "f3yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaby2smx7a".parse().unwrap();
+    pub static ref ZERO_ADDRESS: Address = address::Network::Mainnet.parse_address("f3yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaby2smx7a").unwrap();
 }
 
 /// Codec for raw data.


### PR DESCRIPTION
The `fvm_shared` crate contains two mainnet addresses that are parsed at runtime. If `current_network()` is set to calibnet, this causes the parsing to fail. The fix is to always use the mainnet parser.