### PR TITLE
chore: release fvm v2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,12 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 2.3.0 [2023-05-03]
+
+- Update proofs to v14.
+- Update wasmtime to 8.0.1
+- Misc clippy fixes.
+
 ## 2.3.0 [2023-03-09]
 
 Update proofs. Unfortunately, this is a breaking change in a minor release, but we can't cut a v3...

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "2.3.0"
+version = "2.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -19,7 +19,7 @@ derive_builder = "0.11.2"
 num-derive = "0.3.3"
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.3", default-features = false }
-fvm_shared = { version = "2.3.0", path = "../shared", features = ["crypto"] }
+fvm_shared = { version = "2.4.0", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.5.1"}
 fvm_ipld_amt = { version = "0.4.2"}
 fvm_ipld_blockstore = { version = "0.1.2" }

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.0 [2023-05-03]
+
+Clippy fixes & non-debug build fixes. This release is optional.
+
 ## 2.2.0 [2023-01-05]
 
 Refactor: `send` uses `Option<IpldBlock>` for return value

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "2.2.0"
+version = "2.3.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { version = "0.8.5", default-features = false }
-fvm_shared = { version = "2.3.0", path = "../shared" }
+fvm_shared = { version = "2.4.0", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = { version = "1.4.0" }

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.0 [2023-05-03]
+
+- Update proofs to v14.
+- Misc clippy fixes.
+
 ## 2.3.0 [2023-03-09]
 
 Update proofs. Unfortunately, this is a breaking change in a minor release, but we can't cut a v3...

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "2.3.0", path = "../../shared" }
+fvm_shared = { version = "2.4.0", path = "../../shared" }
 fvm_ipld_hamt = { version = "0.5.1"}
 fvm_ipld_amt = { version = "0.4.2"}
 fvm_ipld_car = { version = "0.5.0" }
@@ -51,7 +51,7 @@ tar = { version = "0.4.38", default-features = false }
 zstd = { version = "0.12.3", default-features = false }
 
 [dependencies.fvm]
-version = "2.3.0"
+version = "2.4.0"
 path = "../../fvm"
 default-features = false
 features = ["testing"]


### PR DESCRIPTION
Along with fvm_shared 2.4 and fvm_sdk 2.3.