### PR TITLE
chore: release fvm 3.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
 ]
 
 [[package]]
@@ -1805,7 +1805,7 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
 ]
 
 [[package]]
@@ -1814,7 +1814,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
  "serde",
  "serde_tuple",
 ]
@@ -1825,7 +1825,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
 ]
 
 [[package]]
@@ -1837,7 +1837,7 @@ dependencies = [
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
  "num-derive",
  "num-traits",
  "serde",
@@ -1849,7 +1849,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
  "log",
  "serde",
  "serde_tuple",
@@ -1860,7 +1860,7 @@ name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
 ]
 
 [[package]]
@@ -1872,7 +1872,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.2",
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
  "serde",
  "serde_tuple",
 ]
@@ -1883,7 +1883,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
  "minicov",
 ]
 
@@ -1892,7 +1892,7 @@ name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
 ]
 
 [[package]]
@@ -1900,7 +1900,7 @@ name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
 ]
 
 [[package]]
@@ -1926,7 +1926,7 @@ dependencies = [
  "cid",
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
 ]
 
 [[package]]
@@ -1936,7 +1936,7 @@ dependencies = [
  "cid",
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
 ]
 
 [[package]]
@@ -1944,7 +1944,7 @@ name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
 ]
 
 [[package]]
@@ -1954,7 +1954,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.3.3",
  "fvm_sdk 3.2.0",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
  "minicov",
  "multihash",
 ]
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.3.1"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2290,7 +2290,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.2",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
  "lazy_static",
  "log",
  "minstant",
@@ -2320,7 +2320,7 @@ dependencies = [
  "clap 4.2.1",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
  "hex",
 ]
 
@@ -2373,7 +2373,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.2",
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
  "itertools 0.10.5",
  "ittapi-rs",
  "lazy_static",
@@ -2395,7 +2395,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
  "num-derive",
  "num-traits",
  "serde",
@@ -2417,7 +2417,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.1.2",
  "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2681,7 +2681,7 @@ version = "3.2.0"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.3.0",
+ "fvm_shared 3.3.1",
  "lazy_static",
  "log",
  "num-traits",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 3.4.0 [2023-05-04]
+
+Update wasmtime to 8.0.1. This is a breaking change if you use any other wasmtime version.
+
 ## 3.3.1 [2023-04-26]
 
 This release contains a small hack for calibrationnet and is optional for users who only want to

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "3.3.1"
+version = "3.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -17,7 +17,7 @@ thiserror = "1.0.30"
 num-traits = "0.2"
 cid = { version = "0.8.5", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.3", default-features = false }
-fvm_shared = { version = "3.3.0", path = "../shared", features = ["crypto"] }
+fvm_shared = { version = "3.3.1", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.6.1", path = "../ipld/hamt" }
 fvm_ipld_amt = { version = "0.5.1", path = "../ipld/amt" }
 fvm_ipld_blockstore = { version = "0.1.2", path = "../ipld/blockstore" }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { version = "0.8.5", default-features = false }
-fvm_shared = { version = "3.3.0", path = "../shared" }
+fvm_shared = { version = "3.3.1", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = { version = "1.4.0" }

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 3.3.1 [2023-05-04]
+
+Fix some address constants (lazy statics, to be precise) when the current network is set to "testnet". Previously, if said constants were evaluated _after_ switching to testnet mode (calling `address::set_current_network`), they'd fail to parse and crash the program when dereferenced.
+
 ## 3.3.0 [2023-04-23]
 
 - Fixes an issue with proof bindings.

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "3.3.0"
+version = "3.3.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/testing/calibration/shared/Cargo.toml
+++ b/testing/calibration/shared/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Protocol Labs", "Filecoin Core Devs"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "3.3.0", path = "../../../shared", features = ["testing"] }
+fvm_shared = { version = "3.3.1", path = "../../../shared", features = ["testing"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 num-traits = "0.2"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "3.3.0", path = "../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../shared" }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.2", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../ipld/encoding" }
@@ -39,7 +39,7 @@ tar = { version = "0.4.38", default-features = false }
 zstd = { version = "0.12.3", default-features = false }
 
 [dependencies.fvm]
-version = "3.3.1"
+version = "3.4.0"
 path = "../../fvm"
 default-features = false
 features = ["testing"]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Protocol Labs", "Filecoin Core Devs", "Polyphene"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "3.3.1", path = "../../fvm", default-features = false, features = ["testing"] }
-fvm_shared = { version = "3.3.0", path = "../../shared", features = ["testing"] }
+fvm = { version = "3.4.0", path = "../../fvm", default-features = false, features = ["testing"] }
+fvm_shared = { version = "3.3.1", path = "../../shared", features = ["testing"] }
 fvm_ipld_car = { version = "0.6.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.1.2", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../ipld/encoding" }

--- a/testing/test_actors/actors/fil-address-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-address-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-create-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-create-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
 
 [lib]

--- a/testing/test_actors/actors/fil-events-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-events-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 serde = {version = "1.0.145", features = ["derive"] }
 serde_tuple = "0.5.0"
 

--- a/testing/test_actors/actors/fil-exit-data-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-exit-data-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 
 [lib]

--- a/testing/test_actors/actors/fil-gas-calibration-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-gas-calibration-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_gas_calibration_shared = { path = "../../../calibration/shared" }
 

--- a/testing/test_actors/actors/fil-gaslimit-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-gaslimit-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 serde = {version = "1.0.145", features = ["derive"] }
 serde_tuple = "0.5.0"
 log = "0.4.14"

--- a/testing/test_actors/actors/fil-hello-world-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-hello-world-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_ipld_blockstore = { version = "0.1.2", path = "../../../../ipld/blockstore" }
 

--- a/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 
 [target.'cfg(coverage)'.dependencies]
 minicov = "0.3"

--- a/testing/test_actors/actors/fil-malformed-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-malformed-syscall-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
 
 [lib]

--- a/testing/test_actors/actors/fil-oom-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-oom-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-readonly-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-readonly-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 cid = { version = "0.8.5", default-features = false }
 

--- a/testing/test_actors/actors/fil-sself-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-sself-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 cid = { version = "0.8.5", default-features = false }
 

--- a/testing/test_actors/actors/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-stack-overflow-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.3.3", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.2.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.3.0", path = "../../../../shared" }
+fvm_shared = { version = "3.3.1", path = "../../../../shared" }
 minicov = {version = "0.3", optional = true}
 actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
 multihash = "0.16.3"


### PR DESCRIPTION
And fvm_shared@v3.3.1 (to fix some issues with addresses).

But mostly to release fvm@3.4.0 with wasmtime 8.0.1 support.