### PR TITLE
Add type parameter to Kernel::send specifying type for receiving kernel

### DIFF
--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -63,7 +63,6 @@ pub trait Kernel:
     + NetworkOps
     + RandomnessOps
     + SelfOps
-    + SendOps
     + LimiterOps
     + 'static
 {
@@ -97,6 +96,23 @@ pub trait Kernel:
 
     /// The kernel's underlying "machine".
     fn machine(&self) -> &<Self::CallManager as CallManager>::Machine;
+
+    /// Sends a message to another actor.
+    /// The method type parameter K is the type of the kernel to instantiate for
+    /// the receiving actor. This is necessary to support wrapping a kernel, so the outer
+    /// kernel can specify its Self as the receiver's kernel type, rather than the wrapped
+    /// kernel specifying its Self.
+    /// This method is part of the Kernel trait so it can refer to the Self::CallManager
+    /// associated type necessary to constrain K.
+    fn send<K: Kernel<CallManager = Self::CallManager>>(
+        &mut self,
+        recipient: &Address,
+        method: u64,
+        params: BlockId,
+        value: &TokenAmount,
+        gas_limit: Option<Gas>,
+        flags: SendFlags,
+    ) -> Result<SendResult>;
 }
 
 /// Network-related operations.
@@ -207,19 +223,6 @@ pub trait ActorOps {
 
     /// Returns the balance associated with an actor id
     fn balance_of(&self, actor_id: ActorID) -> Result<TokenAmount>;
-}
-
-/// Operations to send messages to other actors.
-pub trait SendOps {
-    fn send(
-        &mut self,
-        recipient: &Address,
-        method: u64,
-        params: BlockId,
-        value: &TokenAmount,
-        gas_limit: Option<Gas>,
-        flags: SendFlags,
-    ) -> Result<SendResult>;
 }
 
 /// Operations to query the circulating supply.

--- a/fvm/src/syscalls/send.rs
+++ b/fvm/src/syscalls/send.rs
@@ -13,8 +13,8 @@ use crate::Kernel;
 /// Send a message to another actor. The result is placed as a CBOR-encoded
 /// receipt in the block registry, and can be retrieved by the returned BlockId.
 #[allow(clippy::too_many_arguments)]
-pub fn send(
-    context: Context<'_, impl Kernel>,
+pub fn send<K: Kernel>(
+    context: Context<'_, K>,
     recipient_off: u32,
     recipient_len: u32,
     method: u64,
@@ -43,7 +43,7 @@ pub fn send(
         exit_code,
     } = context
         .kernel
-        .send(&recipient, method, params_id, &value, gas_limit, flags)?;
+        .send::<K>(&recipient, method, params_id, &value, gas_limit, flags)?;
 
     Ok(sys::out::send::Send {
         exit_code: exit_code.value(),


### PR DESCRIPTION
This type parameter supports a kernel to be wrapped, and have the wrapped type also be instantiated on the other side of the send. Something like this is necessary to support injecting kernel behaviour for testing.

@alexytsu and I couldn't get the TestKernel/TestCallManager pattern to work from github.com/anorth/fvm-workbench (where we need to fake out proof verification, and long term wish to be able to inject arbitrary kernel behaviour). This new scheme avoids the coupled TestCallManager and associated funky transmutation.

It's limited in that, unless we can figure out the right type constraints, a TestCallManager itself can't be wrapped, because it ignores the type parameter provided to it.

This is a partial resolution of #1779 (we're unblocked for now). But as noted there, still very limited because there's no facility for dynamic behaviour of an injected kernel. The kernel is constructed internally and short-lived. Passing a kernel construction method (i.e. factory) at runtime would be far more flexible.