### PR TITLE
ci: avoid failing CI when codecov fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,5 +115,6 @@ jobs:
       with:
         files: ${{ matrix.covname }}
         token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: true
+        # Codecov is flaky and will randomly fail. We'd rather not have random failures on master.
+        fail_ci_if_error: false
         verbose: true


### PR DESCRIPTION
Because this happens all to frequently.