### PR TITLE
nit: fix naming

### DIFF
--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Rename `window_post_partitions_sectors` on both the `RegisteredPoStProof` and `RegisteredSealProof` types to `window_post_partition_sectors` to match the builtin actors (from @zhinqiangxu). This is a small breaking change.
+
 ## 4.5.3 [2024-12-04]
 
 - chore: remove the nv25-dev feature flag [#2093](https://github.com/filecoin-project/ref-fvm/pull/2093)

--- a/shared/src/sector/registered_proof.rs
+++ b/shared/src/sector/registered_proof.rs
@@ -174,7 +174,7 @@ impl RegisteredPoStProof {
     }
     /// Returns the partition size, in sectors, associated with a proof type.
     /// The partition size is the number of sectors proven in a single PoSt proof.
-    pub fn window_post_partitions_sector(self) -> Result<u64, String> {
+    pub fn window_post_partition_sectors(self) -> Result<u64, String> {
         // Resolve to post proof and then compute size from that.
         use RegisteredPoStProof::*;
         match self {
@@ -219,7 +219,7 @@ impl RegisteredSealProof {
 
     /// Returns the partition size, in sectors, associated with a proof type.
     /// The partition size is the number of sectors proven in a single PoSt proof.
-    pub fn window_post_partitions_sector(self) -> Result<u64, String> {
+    pub fn window_post_partition_sectors(self) -> Result<u64, String> {
         // Resolve to seal proof and then compute size from that.
         use RegisteredSealProof::*;
         match self {


### PR DESCRIPTION
This makes the naming consistent with [built-actors side](https://github.com/filecoin-project/builtin-actors/blob/f414380b417bcdcab859ba5efd55fc085a83358f/actors/miner/src/state.rs#L1278-L1279).