### PR TITLE
refactor: fixup fvm IPLD flush logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,7 +2326,6 @@ version = "3.5.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "byteorder",
  "cid 0.10.1",
  "derive_more",
  "filecoin-proofs-api",

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -31,7 +31,6 @@ filecoin-proofs-api = { version = "14", default-features = false }
 rayon = "1"
 num_cpus = "1.15.0"
 log = "0.4.19"
-byteorder = "1.4.3"
 fvm-wasm-instrument = "0.4.0"
 yastl = "0.1.2"
 arbitrary = { version = "1.3.0", optional = true, features = ["derive"] }


### PR DESCRIPTION
In preparation for reachability analysis (we're going to re-use this same code).

- Make it less generic (performance).
- Remove blocks from the write buffer as we write them to avoid duplicate writes.
- Simplify some of the checks around what is allowed. For example, I'm now allowing CBOR + Identity hash which should have been allowed previously but wasn't (we don't use it but still, it should have been allowed).
- Remove the explicit 100 byte CID length check. The `Cid` type already validates that the digest can be no longer than 64 bytes.
- Be less strict on DagCBOR validation. Counter-intuitively, being overly strict here is dangerous as it gives us more points where implementations can disagree and fork. Instead, we enforce the following rules for DAG_CBOR:
  1. Blocks must have a valid CBOR structure, but _values_ aren't validated. E.g., no utf-8 validation, no float validation, no minimum encoding requirements, no canonical ordering requirements, etc.
  2. All CBOR values tagged with 42 must be valid CIDs. I.e., a CBOR byte string starting with a 0x0 byte followed by a valid CID with at most a 64 byte digest.
- Remove recursion. We're likely going to implement a max IPLD graph depth anyways, but we might as well be safe. In terms of memory usage, this logic will allocate `O(blocks)` for blocks already in memory, so there should be no danger of running out of memory.

Working towards https://github.com/filecoin-project/fvm-pm/issues/715