### PR TITLE
Implement `span_begin` and `span_end` syscalls

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -31,7 +31,7 @@ use crate::machine::Machine;
 use crate::state_tree::ActorState;
 use crate::syscalls::error::Abort;
 use crate::syscalls::{charge_for_exec, update_gas_available};
-use crate::trace::{ExecutionEvent, ExecutionTrace};
+use crate::trace::{ExecutionEvent, ExecutionTrace, SpanBegin, SpanEnd};
 use crate::{syscall_error, system_actor};
 
 /// The default [`CallManager`] implementation.
@@ -502,6 +502,14 @@ where
         log::trace!("transferred {} from {} to {}", value, from, to);
 
         Ok(())
+    }
+
+    fn trace_span_begin(&mut self, begin: SpanBegin) {
+        self.trace(ExecutionEvent::SpanBegin(begin));
+    }
+
+    fn trace_span_end(&mut self, end: SpanEnd) {
+        self.trace(ExecutionEvent::SpanEnd(end));
     }
 }
 

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -170,10 +170,10 @@ pub trait CallManager: 'static {
     /// Appends an event to the event accumulator.
     fn append_event(&mut self, evt: StampedEvent);
 
-    // TODO Docs
+    /// Begin a new tracing span.
     fn trace_span_begin(&mut self, begin: SpanBegin);
 
-    // TODO Docs
+    /// End a tracing span.
     fn trace_span_end(&mut self, end: SpanEnd);
 }
 

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -22,7 +22,7 @@ mod default;
 pub use default::DefaultCallManager;
 use fvm_shared::event::StampedEvent;
 
-use crate::trace::ExecutionTrace;
+use crate::trace::{ExecutionTrace, SpanBegin, SpanEnd};
 
 /// BlockID representing nil parameters or return data.
 pub const NO_DATA_BLOCK_ID: u32 = 0;
@@ -169,6 +169,12 @@ pub trait CallManager: 'static {
 
     /// Appends an event to the event accumulator.
     fn append_event(&mut self, evt: StampedEvent);
+
+    // TODO Docs
+    fn trace_span_begin(&mut self, begin: SpanBegin);
+
+    // TODO Docs
+    fn trace_span_end(&mut self, end: SpanEnd);
 }
 
 /// The result of a method invocation.

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -39,7 +39,7 @@ use crate::init_actor::INIT_ACTOR_ID;
 use crate::machine::{MachineContext, NetworkConfig};
 use crate::state_tree::ActorState;
 use crate::syscall_error;
-use crate::trace::{SpanBegin, SpanEnd, TraceClock};
+use crate::trace::{SpanBegin, SpanEnd, SpanId, TraceClock};
 
 lazy_static! {
     static ref NUM_CPUS: usize = num_cpus::get();
@@ -937,7 +937,6 @@ where
         println!("{}", msg)
     }
 
-    /// Begin a new span.
     fn span_begin(&mut self, label: String, tag: String, parent: SpanId) -> Result<SpanId> {
         let actor = self
             .get_self()?
@@ -958,7 +957,6 @@ where
         Ok(self.call_manager.machine_mut().next_span_id())
     }
 
-    /// End a span.
     fn span_end(&mut self, id: SpanId) {
         let timestamp = self
             .call_manager

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -39,6 +39,7 @@ use crate::machine::limiter::MemoryLimiter;
 use crate::machine::Machine;
 
 // TODO Still not sure what the best place to define this is
+// TODO Document that the value zero means global span
 pub type SpanId = u64;
 
 pub struct SendResult {

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -37,10 +37,7 @@ use crate::call_manager::CallManager;
 use crate::gas::{Gas, GasTimer, PriceList};
 use crate::machine::limiter::MemoryLimiter;
 use crate::machine::Machine;
-
-// TODO Still not sure what the best place to define this is
-// TODO Document that the value zero means global span
-pub type SpanId = u64;
+use crate::trace::SpanId;
 
 pub struct SendResult {
     pub block_id: BlockId,
@@ -355,12 +352,12 @@ pub trait DebugOps {
     /// Log a message.
     fn log(&self, msg: String);
 
-    // TODO More docs, e.g. parent is not checked, what this actually does (produce a trace)
-    /// Begin a new span.
+    /// Begin a new span. The parent span ID is not checked. This produces a new execution trace
+    /// event of type SpanBegin. The returned SpanId uniquely identifies the span.
     fn span_begin(&mut self, label: String, tag: String, parent: SpanId) -> Result<SpanId>;
 
-    // TODO More docs, e.g. parent is not checked, what this actually does (produce a trace)
-    /// End a span.
+    /// End a span. The span ID is not checked in any way. This produces a new execution trace event
+    /// of type SpanEnd.
     fn span_end(&mut self, id: SpanId);
 
     /// Returns whether debug mode is enabled.

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -38,6 +38,9 @@ use crate::gas::{Gas, GasTimer, PriceList};
 use crate::machine::limiter::MemoryLimiter;
 use crate::machine::Machine;
 
+// TODO Still not sure what the best place to define this is
+pub type SpanId = u64;
+
 pub struct SendResult {
     pub block_id: BlockId,
     pub block_stat: BlockStat,
@@ -350,6 +353,14 @@ pub trait RandomnessOps {
 pub trait DebugOps {
     /// Log a message.
     fn log(&self, msg: String);
+
+    // TODO More docs, e.g. parent is not checked, what this actually does (produce a trace)
+    /// Begin a new span.
+    fn span_begin(&mut self, label: String, tag: String, parent: SpanId) -> Result<SpanId>;
+
+    // TODO More docs, e.g. parent is not checked, what this actually does (produce a trace)
+    /// End a span.
+    fn span_end(&mut self, id: SpanId);
 
     /// Returns whether debug mode is enabled.
     fn debug_enabled(&self) -> bool;

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -68,6 +68,7 @@ mod test {
     use crate::externs::{Chain, Consensus, Externs, Rand};
     use crate::machine::{DefaultMachine, Manifest, NetworkConfig};
     use crate::state_tree::StateTree;
+    use crate::trace::TraceClock;
     use crate::{executor, DefaultKernel};
 
     struct DummyExterns;
@@ -118,6 +119,14 @@ mod test {
         }
     }
 
+    struct DummyTraceClock;
+
+    impl TraceClock for DummyTraceClock {
+        fn timestamp(&mut self) -> u64 {
+            0
+        }
+    }
+
     #[test]
     fn test_constructor() {
         let mut bs = MemoryBlockstore::default();
@@ -137,7 +146,7 @@ mod test {
             .override_actors(actors_cid)
             .for_epoch(0, 0, root);
 
-        let machine = DefaultMachine::new(&mc, bs, DummyExterns).unwrap();
+        let machine = DefaultMachine::new(&mc, bs, DummyExterns, DummyTraceClock).unwrap();
         let engine = EnginePool::new_default((&mc.network).into()).unwrap();
         let _ = executor::DefaultExecutor::<DefaultKernel<DefaultCallManager<_>>>::new(
             engine,

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -62,4 +62,9 @@ impl<M: Machine> Machine for Box<M> {
     fn new_limiter(&self) -> Self::Limiter {
         (**self).new_limiter()
     }
+
+    #[inline(always)]
+    fn next_span_id(&mut self) -> crate::kernel::SpanId {
+        (**self).next_span_id()
+    }
 }

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -5,6 +5,7 @@ use cid::Cid;
 use super::{Machine, MachineContext, Manifest};
 use crate::kernel::Result;
 use crate::state_tree::StateTree;
+use crate::trace::SpanId;
 
 type Type = MachineContext;
 
@@ -69,7 +70,7 @@ impl<M: Machine> Machine for Box<M> {
     }
 
     #[inline(always)]
-    fn next_span_id(&mut self) -> crate::kernel::SpanId {
+    fn next_span_id(&mut self) -> SpanId {
         (**self).next_span_id()
     }
 }

--- a/fvm/src/machine/boxed.rs
+++ b/fvm/src/machine/boxed.rs
@@ -12,6 +12,7 @@ impl<M: Machine> Machine for Box<M> {
     type Blockstore = M::Blockstore;
     type Externs = M::Externs;
     type Limiter = M::Limiter;
+    type TraceClock = M::TraceClock;
 
     #[inline(always)]
     fn blockstore(&self) -> &Self::Blockstore {
@@ -26,6 +27,10 @@ impl<M: Machine> Machine for Box<M> {
     #[inline(always)]
     fn externs(&self) -> &Self::Externs {
         (**self).externs()
+    }
+
+    fn trace_clock_mut(&mut self) -> &mut Self::TraceClock {
+        (**self).trace_clock_mut()
     }
 
     #[inline(always)]

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -13,7 +13,7 @@ use multihash::Code::Blake2b256;
 use super::{Machine, MachineContext};
 use crate::blockstore::BufferedBlockstore;
 use crate::externs::Externs;
-use crate::kernel::{ClassifyResult, Result};
+use crate::kernel::{ClassifyResult, Result, SpanId};
 use crate::machine::limiter::DefaultMemoryLimiter;
 use crate::machine::Manifest;
 use crate::state_tree::StateTree;
@@ -43,6 +43,7 @@ pub struct DefaultMachine<B, E> {
     /// Somewhat unique ID of the machine consisting of (epoch, randomness)
     /// randomness is generated with `initial_state_root`
     id: String,
+    span_id: SpanId,
 }
 
 impl<B, E> DefaultMachine<B, E>
@@ -123,6 +124,7 @@ where
                 context.epoch,
                 cid::multibase::encode(cid::multibase::Base::Base32Lower, randomness)
             ),
+            span_id: 0,
         })
     }
 }
@@ -181,6 +183,11 @@ where
 
     fn new_limiter(&self) -> Self::Limiter {
         DefaultMemoryLimiter::for_network(&self.context().network)
+    }
+
+    fn next_span_id(&mut self) -> SpanId {
+        self.span_id += 1;
+        self.span_id
     }
 }
 

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -13,11 +13,12 @@ use multihash::Code::Blake2b256;
 use super::{Machine, MachineContext, TraceClock};
 use crate::blockstore::BufferedBlockstore;
 use crate::externs::Externs;
-use crate::kernel::{ClassifyResult, Result, SpanId};
+use crate::kernel::{ClassifyResult, Result};
 use crate::machine::limiter::DefaultMemoryLimiter;
 use crate::machine::Manifest;
 use crate::state_tree::StateTree;
 use crate::system_actor::State as SystemActorState;
+use crate::trace::SpanId;
 use crate::EMPTY_ARR_CID;
 
 lazy_static::lazy_static! {
@@ -44,7 +45,7 @@ pub struct DefaultMachine<B, E, T> {
     /// Somewhat unique ID of the machine consisting of (epoch, randomness)
     /// randomness is generated with `initial_state_root`
     id: String,
-    span_id: SpanId,
+    span_counter: SpanId,
 }
 
 impl<B, E, T> DefaultMachine<B, E, T>
@@ -132,7 +133,7 @@ where
                 context.epoch,
                 cid::multibase::encode(cid::multibase::Base::Base32Lower, randomness)
             ),
-            span_id: 0,
+            span_counter: 0,
         })
     }
 }
@@ -200,8 +201,8 @@ where
     }
 
     fn next_span_id(&mut self) -> SpanId {
-        self.span_id += 1;
-        self.span_id
+        self.span_counter += 1;
+        self.span_counter
     }
 }
 

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -11,7 +11,7 @@ use num_traits::Zero;
 
 use crate::externs::Externs;
 use crate::gas::{price_list_by_network_version, PriceList};
-use crate::kernel::Result;
+use crate::kernel::{Result, SpanId};
 use crate::state_tree::StateTree;
 
 mod default;
@@ -33,6 +33,9 @@ pub const REWARD_ACTOR_ID: ActorID = 2;
 /// Distinguished Account actor that is the destination of all burnt funds.
 pub const BURNT_FUNDS_ACTOR_ID: ActorID = 99;
 
+// TODO Could add a Clock trait here, that will probably also need to be mocked, but let's get back
+// TODO How about TraceClock?
+// to that
 /// The Machine is the top-level object of the FVM.
 ///
 /// The Machine operates at a concrete network version and epoch, over an
@@ -81,6 +84,8 @@ pub trait Machine: 'static {
 
     /// Creates a new limiter to track the resources of a message execution.
     fn new_limiter(&self) -> Self::Limiter;
+
+    fn next_span_id(&mut self) -> SpanId;
 }
 
 /// Network-level settings. Except when testing locally, changing any of these likely requires a

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -13,6 +13,7 @@ use crate::externs::Externs;
 use crate::gas::{price_list_by_network_version, PriceList};
 use crate::kernel::{Result, SpanId};
 use crate::state_tree::StateTree;
+use crate::trace::TraceClock;
 
 mod default;
 
@@ -51,6 +52,7 @@ pub trait Machine: 'static {
     type Blockstore: Blockstore;
     type Externs: Externs;
     type Limiter: MemoryLimiter;
+    type TraceClock: TraceClock;
 
     /// Returns a reference to the machine's blockstore.
     fn blockstore(&self) -> &Self::Blockstore;
@@ -61,6 +63,8 @@ pub trait Machine: 'static {
 
     /// Returns a reference to all "node" supplied APIs.
     fn externs(&self) -> &Self::Externs;
+
+    fn trace_clock_mut(&mut self) -> &mut Self::TraceClock;
 
     /// Returns the builtin actor index.
     fn builtin_actors(&self) -> &Manifest;

--- a/fvm/src/machine/mod.rs
+++ b/fvm/src/machine/mod.rs
@@ -11,9 +11,9 @@ use num_traits::Zero;
 
 use crate::externs::Externs;
 use crate::gas::{price_list_by_network_version, PriceList};
-use crate::kernel::{Result, SpanId};
+use crate::kernel::Result;
 use crate::state_tree::StateTree;
-use crate::trace::TraceClock;
+use crate::trace::{SpanId, TraceClock};
 
 mod default;
 
@@ -34,9 +34,6 @@ pub const REWARD_ACTOR_ID: ActorID = 2;
 /// Distinguished Account actor that is the destination of all burnt funds.
 pub const BURNT_FUNDS_ACTOR_ID: ActorID = 99;
 
-// TODO Could add a Clock trait here, that will probably also need to be mocked, but let's get back
-// TODO How about TraceClock?
-// to that
 /// The Machine is the top-level object of the FVM.
 ///
 /// The Machine operates at a concrete network version and epoch, over an

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -1,7 +1,8 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use crate::kernel::{ClassifyResult, Result, SpanId};
+use crate::kernel::{ClassifyResult, Result};
 use crate::syscalls::context::Context;
+use crate::trace::SpanId;
 use crate::Kernel;
 
 pub fn log(context: Context<'_, impl Kernel>, msg_off: u32, msg_len: u32) -> Result<()> {

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -1,6 +1,6 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use crate::kernel::{ClassifyResult, Result};
+use crate::kernel::{ClassifyResult, Result, SpanId};
 use crate::syscalls::context::Context;
 use crate::Kernel;
 
@@ -13,6 +13,35 @@ pub fn log(context: Context<'_, impl Kernel>, msg_off: u32, msg_len: u32) -> Res
     let msg = context.memory.try_slice(msg_off, msg_len)?;
     let msg = String::from_utf8(msg.to_owned()).or_illegal_argument()?;
     context.kernel.log(msg);
+    Ok(())
+}
+
+pub fn span_begin(
+    context: Context<'_, impl Kernel>,
+    label_off: u32,
+    label_len: u32,
+    tag_off: u32,
+    tag_len: u32,
+    parent: SpanId,
+) -> Result<SpanId> {
+    // No-op if disabled.
+    if !context.kernel.debug_enabled() {
+        return Ok(0);
+    }
+
+    let label = context.memory.try_slice(label_off, label_len)?;
+    let label = String::from_utf8(label.to_owned()).or_illegal_argument()?;
+    let tag = context.memory.try_slice(tag_off, tag_len)?;
+    let tag = String::from_utf8(tag.to_owned()).or_illegal_argument()?;
+    context.kernel.span_begin(label, tag, parent)
+}
+
+pub fn span_end(context: Context<'_, impl Kernel>, span: SpanId) -> Result<()> {
+    // No-op if disabled.
+    if context.kernel.debug_enabled() {
+        context.kernel.span_end(span);
+    }
+
     Ok(())
 }
 

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -329,6 +329,8 @@ pub fn bind_syscalls(
     linker.bind("send", "send", send::send)?;
 
     linker.bind("debug", "log", debug::log)?;
+    linker.bind("debug", "span_begin", debug::span_begin)?;
+    linker.bind("debug", "span_end", debug::span_end)?;
     linker.bind("debug", "enabled", debug::enabled)?;
     linker.bind("debug", "store_artifact", debug::store_artifact)?;
 

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -1,3 +1,4 @@
+use cid::Cid;
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_ipld_encoding::ipld_block::IpldBlock;
@@ -7,7 +8,7 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::{ActorID, MethodNum};
 
 use crate::gas::GasCharge;
-use crate::kernel::SyscallError;
+use crate::kernel::{SpanId, SyscallError};
 
 /// Execution Trace, only for informational and debugging purposes.
 pub type ExecutionTrace = Vec<ExecutionEvent>;
@@ -16,6 +17,7 @@ pub type ExecutionTrace = Vec<ExecutionEvent>;
 ///
 /// This is marked as `non_exhaustive` so we can introduce additional event types later.
 #[derive(Clone, Debug)]
+// TODO This might be a mistake
 #[non_exhaustive]
 pub enum ExecutionEvent {
     GasCharge(GasCharge),
@@ -26,6 +28,32 @@ pub enum ExecutionEvent {
         params: Option<IpldBlock>,
         value: TokenAmount,
     },
+    SpanBegin(SpanBegin),
+    SpanEnd(SpanEnd),
     CallReturn(ExitCode, Option<IpldBlock>),
     CallError(SyscallError),
+}
+
+#[derive(Clone, Debug)]
+pub struct SpanBegin {
+    /// User-supplied label for this span.
+    pub label: String,
+    /// User-supplied tag for this span.
+    pub tag: String,
+    /// Parent span.
+    pub parent: SpanId,
+    /// CID of the currently executing method's code.
+    pub code: Cid,
+    /// Number of the currently executing method.
+    pub method: MethodNum,
+    /// The timestamp when this event ocurred, in nanoseconds.
+    pub timestamp: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct SpanEnd {
+    /// The ID of the span that is ending.
+    pub id: SpanId,
+    /// The timestamp when this event ocurred, in nanoseconds.
+    pub timestamp: u64,
 }

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -8,7 +8,10 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::{ActorID, MethodNum};
 
 use crate::gas::GasCharge;
-use crate::kernel::{SpanId, SyscallError};
+use crate::kernel::SyscallError;
+
+/// A unique identifier for a tracing span. The value zero is reserved for the global span.
+pub type SpanId = u64;
 
 /// Execution Trace, only for informational and debugging purposes.
 pub type ExecutionTrace = Vec<ExecutionEvent>;
@@ -17,7 +20,6 @@ pub type ExecutionTrace = Vec<ExecutionEvent>;
 ///
 /// This is marked as `non_exhaustive` so we can introduce additional event types later.
 #[derive(Clone, Debug)]
-// TODO This might be a mistake
 #[non_exhaustive]
 pub enum ExecutionEvent {
     GasCharge(GasCharge),

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -57,3 +57,28 @@ pub struct SpanEnd {
     /// The timestamp when this event ocurred, in nanoseconds.
     pub timestamp: u64,
 }
+
+/// A monotonic clock used for generating nanosecond timestamps during tracing.
+pub trait TraceClock {
+    fn timestamp(&mut self) -> u64;
+}
+
+pub struct DefaultTraceClock(std::time::Instant);
+
+impl DefaultTraceClock {
+    pub fn new() -> Self {
+        Self(std::time::Instant::now())
+    }
+}
+
+impl Default for DefaultTraceClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TraceClock for DefaultTraceClock {
+    fn timestamp(&mut self) -> u64 {
+        self.0.elapsed().as_nanos() as u64
+    }
+}

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -10,6 +10,7 @@ use fvm::call_manager::{Backtrace, CallManager, FinishRet, InvocationResult};
 use fvm::engine::Engine;
 use fvm::externs::{Chain, Consensus, Externs, Rand};
 use fvm::gas::{Gas, GasCharge, GasTimer, GasTracker};
+use fvm::kernel::SpanId;
 use fvm::machine::limiter::MemoryLimiter;
 use fvm::machine::{Machine, MachineContext, Manifest, NetworkConfig};
 use fvm::state_tree::StateTree;
@@ -105,6 +106,7 @@ pub struct DummyMachine {
     pub state_tree: StateTree<MemoryBlockstore>,
     pub ctx: MachineContext,
     pub builtin_actors: Manifest,
+    span_id: SpanId,
 }
 
 impl DummyMachine {
@@ -141,6 +143,7 @@ impl DummyMachine {
             ctx,
             state_tree,
             builtin_actors: manifest,
+            span_id: 0,
         })
     }
 }
@@ -184,6 +187,11 @@ impl Machine for DummyMachine {
 
     fn new_limiter(&self) -> Self::Limiter {
         DummyLimiter::default()
+    }
+
+    fn next_span_id(&mut self) -> SpanId {
+        self.span_id += 1;
+        self.span_id
     }
 }
 
@@ -404,4 +412,8 @@ impl CallManager for DummyCallManager {
     ) -> fvm::kernel::Result<()> {
         todo!()
     }
+
+    fn trace_span_begin(&mut self, _begin: fvm::trace::SpanBegin) {}
+
+    fn trace_span_end(&mut self, _end: fvm::trace::SpanEnd) {}
 }

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -10,11 +10,10 @@ use fvm::call_manager::{Backtrace, CallManager, FinishRet, InvocationResult};
 use fvm::engine::Engine;
 use fvm::externs::{Chain, Consensus, Externs, Rand};
 use fvm::gas::{Gas, GasCharge, GasTimer, GasTracker};
-use fvm::kernel::SpanId;
 use fvm::machine::limiter::MemoryLimiter;
 use fvm::machine::{Machine, MachineContext, Manifest, NetworkConfig};
 use fvm::state_tree::StateTree;
-use fvm::trace::TraceClock;
+use fvm::trace::{SpanId, TraceClock};
 use fvm::{kernel, Kernel};
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::{CborStore, DAG_CBOR};
@@ -116,8 +115,8 @@ pub struct DummyMachine {
     pub state_tree: StateTree<MemoryBlockstore>,
     pub ctx: MachineContext,
     pub builtin_actors: Manifest,
-    trace_clock: DummyTraceClock,
-    span_id: SpanId,
+    pub trace_clock: DummyTraceClock,
+    pub span_counter: SpanId,
 }
 
 impl DummyMachine {
@@ -155,7 +154,7 @@ impl DummyMachine {
             state_tree,
             builtin_actors: manifest,
             trace_clock: DummyTraceClock,
-            span_id: 0,
+            span_counter: 0,
         })
     }
 }
@@ -207,8 +206,8 @@ impl Machine for DummyMachine {
     }
 
     fn next_span_id(&mut self) -> SpanId {
-        self.span_id += 1;
-        self.span_id
+        self.span_counter += 1;
+        self.span_counter
     }
 }
 

--- a/sdk/src/debug.rs
+++ b/sdk/src/debug.rs
@@ -12,7 +12,8 @@ lazy_static! {
 
 /// Logs a message on the node.
 #[inline]
-pub fn log(msg: String) {
+pub fn log(msg: impl AsRef<str>) {
+    let msg = msg.as_ref();
     unsafe {
         sys::debug::log(msg.as_ptr(), msg.len() as u32).unwrap();
     }
@@ -24,6 +25,27 @@ pub fn init_logging() {
         log::set_logger(&Logger).expect("failed to enable logging");
         log::set_max_level(LevelFilter::Trace);
     }
+}
+
+// TODO Docs
+pub fn span_begin(label: impl AsRef<str>, tag: impl AsRef<str>, parent: u64) -> u64 {
+    let label = label.as_ref();
+    let tag = tag.as_ref();
+    unsafe {
+        sys::debug::span_begin(
+            label.as_ptr(),
+            label.len() as u32,
+            tag.as_ptr(),
+            tag.len() as u32,
+            parent,
+        )
+        .unwrap()
+    }
+}
+
+// TODO Docs
+pub fn span_end(id: u64) {
+    unsafe { sys::debug::span_end(id).unwrap() }
 }
 
 /// Saves an artifact to the host env. New artifacts with the same name will overwrite old ones

--- a/sdk/src/debug.rs
+++ b/sdk/src/debug.rs
@@ -27,7 +27,10 @@ pub fn init_logging() {
     }
 }
 
-// TODO Docs
+/// Begins a new tracing span. Tracing spans are used for debugging. The label and tag are user
+/// supplied and can be used by humans to identify the span. The parent is the id of the parent span.
+/// The value 0 is reserved for the global span, and should be passed if the span has no explicit parent.
+/// Returns the id of the newly created span.
 pub fn span_begin(label: impl AsRef<str>, tag: impl AsRef<str>, parent: u64) -> u64 {
     let label = label.as_ref();
     let tag = tag.as_ref();
@@ -43,7 +46,7 @@ pub fn span_begin(label: impl AsRef<str>, tag: impl AsRef<str>, parent: u64) -> 
     }
 }
 
-// TODO Docs
+/// Ends a tracing span previously created with [`span_begin`].
 pub fn span_end(id: u64) {
     unsafe { sys::debug::span_end(id).unwrap() }
 }

--- a/sdk/src/sys/debug.rs
+++ b/sdk/src/sys/debug.rs
@@ -12,10 +12,10 @@ super::fvm_syscalls! {
     /// Logs a message on the node.
     pub fn log(message: *const u8, message_len: u32) -> Result<()>;
 
-    // TODO Docs
+    /// Begin a span.
     pub fn span_begin(label: *const u8, label_len: u32, tag: *const u8, tag_len: u32, parent: u64) -> Result<u64>;
 
-    // TODO Docs
+    /// End a span.
     pub fn span_end(parent: u64) -> Result<()>;
 
     /// Save data as a debug artifact on the node.

--- a/sdk/src/sys/debug.rs
+++ b/sdk/src/sys/debug.rs
@@ -12,6 +12,12 @@ super::fvm_syscalls! {
     /// Logs a message on the node.
     pub fn log(message: *const u8, message_len: u32) -> Result<()>;
 
+    // TODO Docs
+    pub fn span_begin(label: *const u8, label_len: u32, tag: *const u8, tag_len: u32, parent: u64) -> Result<u64>;
+
+    // TODO Docs
+    pub fn span_end(parent: u64) -> Result<()>;
+
     /// Save data as a debug artifact on the node.
     pub fn store_artifact(name_off: *const u8, name_len: u32, data_off: *const u8, data_len: u32) -> Result<()>;
 }

--- a/testing/conformance/src/tracing.rs
+++ b/testing/conformance/src/tracing.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use fvm::executor::ApplyRet;
-use fvm::trace::ExecutionEvent;
+use fvm::trace::{ExecutionEvent, TraceClock};
 use serde::{Deserialize, Serialize};
 
 /// Timing and result of a message execution.
@@ -155,3 +155,12 @@ impl TestTraceExporter {
 }
 
 pub type TestTraceExporterRef = Option<Arc<TestTraceExporter>>;
+
+#[derive(Debug, Default)]
+pub struct TestTraceClock;
+
+impl TraceClock for TestTraceClock {
+    fn timestamp(&mut self) -> u64 {
+        0
+    }
+}

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;
 use cid::Cid;
+use fvm::trace::SpanId;
 use multihash::MultihashGeneric;
 
 use fvm::call_manager::{CallManager, DefaultCallManager};

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -73,6 +73,7 @@ pub struct TestMachine<M = Box<DefaultMachine<MemoryBlockstore, TestExterns>>> {
     pub machine: M,
     pub data: TestData,
     stats: TestStatsRef,
+    span_id: SpanId,
 }
 
 impl TestMachine<Box<DefaultMachine<MemoryBlockstore, TestExterns>>> {
@@ -121,6 +122,7 @@ impl TestMachine<Box<DefaultMachine<MemoryBlockstore, TestExterns>>> {
                 price_list,
             },
             stats,
+            span_id: 0,
         };
 
         Ok(machine)
@@ -177,6 +179,11 @@ where
             global_stats: self.stats.clone(),
             local_stats: TestStats::default(),
         }
+    }
+
+    fn next_span_id(&mut self) -> SpanId {
+        self.span_id += 1;
+        self.span_id
     }
 }
 
@@ -438,6 +445,12 @@ where
     fn log(&self, msg: String) {
         self.0.log(msg)
     }
+
+    fn span_begin(&mut self, _label: String, _tag: String, _parent: SpanId) -> Result<SpanId> {
+        Ok(0)
+    }
+
+    fn span_end(&mut self, _id: SpanId) {}
 
     fn debug_enabled(&self) -> bool {
         self.0.debug_enabled()

--- a/testing/integration/examples/integration.rs
+++ b/testing/integration/examples/integration.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use fvm::executor::{ApplyKind, Executor};
 use fvm_integration_tests::bundle;
-use fvm_integration_tests::dummy::DummyExterns;
+use fvm_integration_tests::dummy::{DummyExterns, DummyTraceClock};
 use fvm_integration_tests::tester::{Account, Tester};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
@@ -51,7 +51,9 @@ pub fn main() {
         .unwrap();
 
     // Instantiate machine
-    tester.instantiate_machine(DummyExterns).unwrap();
+    tester
+        .instantiate_machine(DummyExterns, DummyTraceClock::default())
+        .unwrap();
 
     // Send message
     let message = Message {

--- a/testing/integration/src/dummy.rs
+++ b/testing/integration/src/dummy.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
 use fvm::externs::{Chain, Consensus, Externs, Rand};
+use fvm::trace::TraceClock;
 use fvm_ipld_encoding::DAG_CBOR;
 use fvm_shared::IDENTITY_HASH;
 use multihash::Multihash;
@@ -60,5 +61,15 @@ impl Chain for DummyExterns {
             DAG_CBOR,
             Multihash::wrap(IDENTITY_HASH, &epoch.to_be_bytes()).unwrap(),
         ))
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DummyTraceClock(u64);
+
+impl TraceClock for DummyTraceClock {
+    fn timestamp(&mut self) -> u64 {
+        self.0 += 1;
+        self.0
     }
 }

--- a/testing/integration/tests/address_test.rs
+++ b/testing/integration/tests/address_test.rs
@@ -3,7 +3,7 @@
 mod bundles;
 use bundles::*;
 use fvm::executor::{ApplyKind, Executor};
-use fvm_integration_tests::dummy::DummyExterns;
+use fvm_integration_tests::dummy::{DummyExterns, DummyTraceClock};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
@@ -39,7 +39,9 @@ fn basic_address_tests() {
         .unwrap();
 
     // Instantiate machine
-    tester.instantiate_machine(DummyExterns).unwrap();
+    tester
+        .instantiate_machine(DummyExterns, DummyTraceClock::default())
+        .unwrap();
 
     let executor = tester.executor.as_mut().unwrap();
 

--- a/testing/integration/tests/basic_send_test.rs
+++ b/testing/integration/tests/basic_send_test.rs
@@ -7,7 +7,7 @@ use bundles::*;
 use fvm::executor::{ApplyKind, Executor};
 use fvm::gas::GasCharge;
 use fvm::machine::Machine;
-use fvm_integration_tests::dummy::DummyExterns;
+use fvm_integration_tests::dummy::{DummyExterns, DummyTraceClock};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
@@ -30,7 +30,9 @@ fn basic_send() {
     // Send to an f4 to create a placeholder. Otherwise, we end up invoking a constructor.
     let receiver = Address::new_delegated(10, b"foobar").expect("failed to construct f4 address");
 
-    tester.instantiate_machine(DummyExterns).unwrap();
+    tester
+        .instantiate_machine(DummyExterns, DummyTraceClock::default())
+        .unwrap();
     let executor = tester.executor.as_mut().unwrap();
 
     struct Case {

--- a/testing/integration/tests/bundles/mod.rs
+++ b/testing/integration/tests/bundles/mod.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use anyhow::Context;
 use fvm::externs::Externs;
+use fvm::trace::TraceClock;
 use fvm_integration_tests::bundle;
 use fvm_integration_tests::tester::{BasicTester, ExecutionOptions, Tester};
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
@@ -19,11 +20,11 @@ lazy_static! {
 }
 
 #[allow(dead_code)]
-pub fn new_tester<B: Blockstore, E: Externs>(
+pub fn new_tester<B: Blockstore, E: Externs, T: TraceClock>(
     nv: NetworkVersion,
     stv: StateTreeVersion,
     blockstore: B,
-) -> anyhow::Result<Tester<B, E>> {
+) -> anyhow::Result<Tester<B, E, T>> {
     let bundle = BUNDLES
         .get(&nv)
         .with_context(|| format!("unsupported network version {nv}"))?;

--- a/testing/integration/tests/calibration/mod.rs
+++ b/testing/integration/tests/calibration/mod.rs
@@ -9,7 +9,7 @@ use fvm::executor::{ApplyKind, ApplyRet, Executor};
 use fvm::gas::Gas;
 use fvm::trace::ExecutionEvent;
 use fvm_integration_tests::bundle;
-use fvm_integration_tests::dummy::DummyExterns;
+use fvm_integration_tests::dummy::{DummyExterns, DummyTraceClock};
 use fvm_integration_tests::tester::{Account, Tester};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
@@ -34,7 +34,7 @@ pub struct State {
 }
 
 pub struct TestEnv {
-    pub tester: Tester<MemoryBlockstore, DummyExterns>,
+    pub tester: Tester<MemoryBlockstore, DummyExterns, DummyTraceClock>,
     pub sender: Account,
     pub actor_address: Address,
     pub actor_sequence: u64,
@@ -153,6 +153,7 @@ pub fn instantiate_tester() -> TestEnv {
     tester
         .instantiate_machine_with_config(
             DummyExterns,
+            DummyTraceClock::default(),
             |_| (),
             |mc| {
                 mc.enable_tracing();

--- a/testing/integration/tests/embryo_sender_test.rs
+++ b/testing/integration/tests/embryo_sender_test.rs
@@ -1,3 +1,5 @@
+use fvm_integration_tests::dummy::DummyTraceClock;
+
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 mod bundles;
@@ -36,7 +38,9 @@ fn placeholder_as_sender() {
         .expect("failed to instantiate placeholder");
 
     // Instantiate machine
-    tester.instantiate_machine(DummyExterns).unwrap();
+    tester
+        .instantiate_machine(DummyExterns, DummyTraceClock::default())
+        .unwrap();
 
     let executor = tester.executor.as_mut().unwrap();
 

--- a/testing/integration/tests/events_test.rs
+++ b/testing/integration/tests/events_test.rs
@@ -4,7 +4,7 @@ mod bundles;
 use bundles::*;
 use fvm::executor::{ApplyKind, Executor};
 use fvm::machine::Machine;
-use fvm_integration_tests::dummy::DummyExterns;
+use fvm_integration_tests::dummy::{DummyExterns, DummyTraceClock};
 use fvm_integration_tests::tester::IntegrationExecutor;
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::to_vec;
@@ -120,7 +120,7 @@ fn events_test() {
 }
 
 fn setup() -> (
-    IntegrationExecutor<MemoryBlockstore, DummyExterns>,
+    IntegrationExecutor<MemoryBlockstore, DummyExterns, DummyTraceClock>,
     Address,
     Address,
 ) {
@@ -148,7 +148,9 @@ fn setup() -> (
         .unwrap();
 
     // Instantiate machine
-    tester.instantiate_machine(DummyExterns).unwrap();
+    tester
+        .instantiate_machine(DummyExterns, DummyTraceClock::default())
+        .unwrap();
 
     let executor = tester.executor.unwrap();
     (executor, sender, actor)

--- a/testing/integration/tests/fil_integer_overflow.rs
+++ b/testing/integration/tests/fil_integer_overflow.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use fvm::executor::{ApplyKind, Executor};
-use fvm_integration_tests::dummy::DummyExterns;
+use fvm_integration_tests::dummy::{DummyExterns, DummyTraceClock};
 use fvm_integration_tests::tester::{Account, Tester};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
@@ -24,7 +24,11 @@ pub struct State {
 }
 
 // Utility function to instantiation integration tester
-fn instantiate_tester() -> (Account, Tester<MemoryBlockstore, DummyExterns>, Address) {
+fn instantiate_tester() -> (
+    Account,
+    Tester<MemoryBlockstore, DummyExterns, DummyTraceClock>,
+    Address,
+) {
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,
@@ -58,7 +62,9 @@ fn integer_overflow() {
     let (sender, mut tester, actor_address) = instantiate_tester();
 
     // Instantiate machine
-    tester.instantiate_machine(DummyExterns).unwrap();
+    tester
+        .instantiate_machine(DummyExterns, DummyTraceClock::default())
+        .unwrap();
 
     // Params setup
     let x: i64 = 10000000000;

--- a/testing/integration/tests/fil_syscall.rs
+++ b/testing/integration/tests/fil_syscall.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use fvm::call_manager::backtrace::Cause;
 use fvm::executor::{ApplyFailure, ApplyKind, Executor};
-use fvm_integration_tests::dummy::DummyExterns;
+use fvm_integration_tests::dummy::{DummyExterns, DummyTraceClock};
 use fvm_integration_tests::tester::{Account, Tester};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
@@ -41,7 +41,11 @@ pub struct State {
 // Utility function to instantiation integration tester
 fn instantiate_tester(
     wasm_bin: &[u8],
-) -> (Account, Tester<MemoryBlockstore, DummyExterns>, Address) {
+) -> (
+    Account,
+    Tester<MemoryBlockstore, DummyExterns, DummyTraceClock>,
+    Address,
+) {
     // Instantiate tester
     let mut tester = new_tester(
         NetworkVersion::V18,
@@ -75,7 +79,9 @@ fn non_existing_syscall() {
     let (sender, mut tester, actor_address) = instantiate_tester(&wasm_bin);
 
     // Instantiate machine
-    tester.instantiate_machine(DummyExterns).unwrap();
+    tester
+        .instantiate_machine(DummyExterns, DummyTraceClock::default())
+        .unwrap();
 
     // Params setup
     let params = RawBytes::new(Vec::<u8>::new());
@@ -131,7 +137,9 @@ fn malformed_syscall_parameter() {
     let (sender, mut tester, actor_address) = instantiate_tester(wasm_bin);
 
     // Instantiate machine
-    tester.instantiate_machine(DummyExterns).unwrap();
+    tester
+        .instantiate_machine(DummyExterns, DummyTraceClock::default())
+        .unwrap();
 
     // Params setup
     let params = RawBytes::new(Vec::<u8>::new());

--- a/testing/integration/tests/gaslimit_test.rs
+++ b/testing/integration/tests/gaslimit_test.rs
@@ -3,7 +3,7 @@
 use bundles::*;
 use fvm::executor::{ApplyKind, Executor};
 use fvm::machine::Machine;
-use fvm_integration_tests::dummy::DummyExterns;
+use fvm_integration_tests::dummy::{DummyExterns, DummyTraceClock};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::to_vec;
 use fvm_shared::address::Address;
@@ -44,7 +44,9 @@ fn gaslimit_test() {
     };
 
     // Instantiate machine
-    tester.instantiate_machine(DummyExterns).unwrap();
+    tester
+        .instantiate_machine(DummyExterns, DummyTraceClock::default())
+        .unwrap();
 
     let executor = tester.executor.as_mut().unwrap();
 

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -564,10 +564,10 @@ fn native_stack_overflow() {
         )
         .unwrap();
 
-    let exec_test = |exec: &mut ThreadedExecutor<
+    type Exec<'a> = &'a mut ThreadedExecutor<
         IntegrationExecutor<MemoryBlockstore, DummyExterns, DummyTraceClock>,
-    >,
-                     method| {
+    >;
+    let exec_test = |exec: Exec<'_>, method| {
         // Send message
         let message = Message {
             from: sender[0].1,

--- a/testing/integration/tests/readonly_test.rs
+++ b/testing/integration/tests/readonly_test.rs
@@ -3,7 +3,7 @@
 mod bundles;
 use bundles::*;
 use fvm::executor::{ApplyKind, Executor};
-use fvm_integration_tests::dummy::DummyExterns;
+use fvm_integration_tests::dummy::{DummyExterns, DummyTraceClock};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
@@ -39,7 +39,9 @@ fn readonly_actor_tests() {
         .unwrap();
 
     // Instantiate machine
-    tester.instantiate_machine(DummyExterns).unwrap();
+    tester
+        .instantiate_machine(DummyExterns, DummyTraceClock::default())
+        .unwrap();
 
     let executor = tester.executor.as_mut().unwrap();
 

--- a/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
@@ -40,6 +40,7 @@ pub fn invoke(_: u32) -> u32 {
     test_message_context();
     test_balance();
     test_unaligned();
+    test_spans();
 
     #[cfg(coverage)]
     sdk::debug::store_artifact("syscall_actor.profraw", minicov::capture_coverage());
@@ -376,4 +377,12 @@ fn test_unaligned() {
         let expected = context().unwrap();
         assert_eq!(expected, actual);
     }
+}
+
+/// Test that span debug syscalls can be made.
+fn test_spans() {
+    let parent = sdk::debug::span_begin("parent label", "parent tag", 0);
+    let child = sdk::debug::span_begin("child label", "child tag", parent);
+    sdk::debug::span_end(child);
+    sdk::debug::span_end(parent);
 }


### PR DESCRIPTION
Part of https://github.com/filecoin-project/ref-fvm/issues/1566. Implements new syscalls for beginning and ending spans, and exposes them through the SDK. Adds new execution events for spans. Implements a new `TraceClock` abstraction to obtain nanosecond timestamps from the `Machine`, which can later be used to add timestamps to all `ExecutionEvent`s for tracing.

Tests the added functionality in an integration test.

What's not included in this PR:
- Emitting span events whenever a method call happens.
- Including timestamps on all execution events.

I felt like the PR was already quite large, so I decided to leave these for separate PRs.