### PR TITLE
chore: remove an unnecessary event copy

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -928,7 +928,7 @@ impl EventsAccumulator {
             let root = Amt::new_from_iter_with_bit_width(
                 DiscardBlockstore,
                 EVENTS_AMT_BITWIDTH,
-                self.events.iter().cloned(),
+                self.events.iter(),
             )
             .context("failed to construct events AMT")
             .or_fatal()?;


### PR DESCRIPTION
This came up when reviewing the gas costs: we don't need this copy.