### PR TITLE
feat: add new fields to message trace for supporting new trace api

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -186,6 +186,13 @@ where
                 method,
                 params: params.as_ref().map(Into::into),
                 value: value.clone(),
+                gas_limit: std::cmp::min(
+                    gas_limit
+                        .unwrap_or(Gas::from_milligas(u64::MAX))
+                        .as_milligas(),
+                    self.gas_tracker.gas_available().as_milligas(),
+                ),
+                read_only,
             });
         }
 

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -187,10 +187,8 @@ where
                 params: params.as_ref().map(Into::into),
                 value: value.clone(),
                 gas_limit: std::cmp::min(
-                    gas_limit
-                        .unwrap_or(Gas::from_milligas(u64::MAX))
-                        .as_milligas(),
-                    self.gas_tracker.gas_available().as_milligas(),
+                    gas_limit.unwrap_or(Gas::from_milligas(u64::MAX)).round_up(),
+                    self.gas_tracker.gas_available().round_up(),
                 ),
                 read_only,
             });

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -661,6 +661,10 @@ where
             .get_actor(to)?
             .ok_or_else(|| syscall_error!(NotFound; "actor does not exist: {}", to))?;
 
+        if self.machine.context().tracing {
+            self.trace(ExecutionEvent::InvokeActor(state.code));
+        }
+
         // Transfer, if necessary.
         if !value.is_zero() {
             let t = self.charge_gas(self.price_list().on_value_transfer())?;

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -25,6 +25,8 @@ pub enum ExecutionEvent {
         method: MethodNum,
         params: Option<IpldBlock>,
         value: TokenAmount,
+        gas_limit: u64,
+        read_only: bool,
     },
     CallReturn(ExitCode, Option<IpldBlock>),
     CallError(SyscallError),

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -31,5 +31,5 @@ pub enum ExecutionEvent {
     },
     CallReturn(ExitCode, Option<IpldBlock>),
     CallError(SyscallError),
-    Invoke(Cid),
+    InvokeActor(Cid),
 }

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -20,6 +20,8 @@ pub type ExecutionTrace = Vec<ExecutionEvent>;
 #[non_exhaustive]
 pub enum ExecutionEvent {
     GasCharge(GasCharge),
+    /// Emitted on each send call regardless whether we actually end up invoking the
+    /// actor or not (e.g. if we don't have enough gas or if the actor does not exist)
     Call {
         from: ActorID,
         to: Address,
@@ -31,5 +33,6 @@ pub enum ExecutionEvent {
     },
     CallReturn(ExitCode, Option<IpldBlock>),
     CallError(SyscallError),
+    /// Emitted every time we successfully invoke an actor
     InvokeActor(Cid),
 }

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -8,6 +8,7 @@ use fvm_shared::{ActorID, MethodNum};
 
 use crate::gas::GasCharge;
 use crate::kernel::SyscallError;
+use crate::Cid;
 
 /// Execution Trace, only for informational and debugging purposes.
 pub type ExecutionTrace = Vec<ExecutionEvent>;
@@ -30,4 +31,5 @@ pub enum ExecutionEvent {
     },
     CallReturn(ExitCode, Option<IpldBlock>),
     CallError(SyscallError),
+    Invoke(Cid),
 }


### PR DESCRIPTION
Related: https://github.com/filecoin-project/ref-fvm/issues/1793 and https://github.com/filecoin-project/fvm-pm/issues/613

This PR adds the following fields to `ExecutionEvent` which are required to confirm to the trace api [spec](https://docs.alchemy.com/reference/trace-api):
- `gas_limit`: The gas provided by the sender
- `read_only`: Whether the call is read only or not