### PR TITLE
refactor: remove `with_transaction` and move "return" gas charge

### DIFF
--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -74,12 +74,6 @@ pub trait CallManager: 'static {
         read_only: bool,
     ) -> Result<InvocationResult>;
 
-    /// Execute some operation (usually a send) within a transaction.
-    fn with_transaction(
-        &mut self,
-        f: impl FnOnce(&mut Self) -> Result<InvocationResult>,
-    ) -> Result<InvocationResult>;
-
     /// Finishes execution, returning the gas used, machine, and exec trace if requested.
     fn finish(self) -> (Result<FinishRet>, Self::Machine);
 

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -139,29 +139,17 @@ where
                 )
             });
 
-            let result = cm.with_transaction(|cm| {
-                // Invoke the message.
-                let ret = cm.send::<K>(
-                    sender_id,
-                    msg.to,
-                    msg.method_num,
-                    params,
-                    &msg.value,
-                    None,
-                    false,
-                )?;
-
-                // Charge for including the result (before we end the transaction).
-                if let Some(value) = &ret.value {
-                    let _ = cm.charge_gas(
-                        cm.context()
-                            .price_list
-                            .on_chain_return_value(value.size() as usize),
-                    )?;
-                }
-
-                Ok(ret)
-            });
+            // Invoke the message. We charge for the return value internally if the call-stack depth
+            // is 1.
+            let result = cm.send::<K>(
+                sender_id,
+                msg.to,
+                msg.method_num,
+                params,
+                &msg.value,
+                None,
+                false,
+            );
 
             let (res, machine) = match cm.finish() {
                 (Ok(res), machine) => (res, machine),

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -525,16 +525,6 @@ impl PriceList {
         )
     }
 
-    /// Returns the gas required for storing the response of a message in the chain.
-    #[inline]
-    pub fn on_chain_return_value(&self, data_size: usize) -> GasCharge {
-        GasCharge::new(
-            "OnChainReturnValue",
-            self.on_chain_return_compute.apply(data_size),
-            self.on_chain_return_storage.apply(data_size),
-        )
-    }
-
     /// Returns the gas required when invoking a method.
     #[inline]
     pub fn on_value_transfer(&self) -> GasCharge {
@@ -545,6 +535,18 @@ impl PriceList {
     #[inline]
     pub fn on_method_invocation(&self) -> GasCharge {
         GasCharge::new("OnMethodInvocation", self.send_invoke_method, Zero::zero())
+    }
+
+    /// Returns the gas required for storing the response of a message in the chain.
+    #[inline]
+    pub fn on_method_return(&self, call_depth: u32, data_size: u32) -> Option<GasCharge> {
+        (call_depth == 1).then(|| {
+            GasCharge::new(
+                "OnChainReturnValue",
+                self.on_chain_return_compute.apply(data_size),
+                self.on_chain_return_storage.apply(data_size),
+            )
+        })
     }
 
     /// Returns the gas cost to be applied on a syscall.

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -141,11 +141,9 @@ where
         }
 
         // Send.
-        let result = self.call_manager.with_transaction(|cm| {
-            cm.send::<K>(
-                from, *recipient, method, params, value, gas_limit, read_only,
-            )
-        })?;
+        let result = self.call_manager.send::<K>(
+            from, *recipient, method, params, value, gas_limit, read_only,
+        )?;
 
         // Store result and return.
         Ok(match result {

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -292,14 +292,6 @@ impl CallManager for DummyCallManager {
         todo!()
     }
 
-    fn with_transaction(
-        &mut self,
-        _f: impl FnOnce(&mut Self) -> kernel::Result<InvocationResult>,
-    ) -> kernel::Result<InvocationResult> {
-        // Ok(InvocationResult::Return(None))
-        todo!()
-    }
-
     fn finish(self) -> (kernel::Result<FinishRet>, Self::Machine) {
         (
             Ok(FinishRet {


### PR DESCRIPTION
(ipld reachability pre-factor)

In #1824, we'll need to charge for tracking reachable links on return. However, we'd _like_ to apply the gas limit specified by the caller so the callee can't "go over" their gas limit. That means we need a return-value charge inside the call manager instead of inside the caller (executor/kernel).

So, I figured I'd just apply a refactor that's been a long-time coming and remove the `with_transaction` dance. Instead, I put _all_ of the transaction logic into `CallManager::send`. This makes the function a bit heftier but, IMO, it's easier to reason about this way. It also removes an implementation detail (`with_transaction`) from the `CallManager` trait.