### PR TITLE
fix(fvm): fix (and prevent) two bugs in out of gas handling.

### DIFF
--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -298,9 +298,9 @@ mod tests {
     #[allow(clippy::identity_op)]
     fn basic_gas_tracker() -> Result<()> {
         let t = GasTracker::new(Gas::new(20), Gas::new(10), false);
-        let _ = t.apply_charge(GasCharge::new("", Gas::new(5), Gas::zero()))?;
+        t.apply_charge(GasCharge::new("", Gas::new(5), Gas::zero()))?;
         assert_eq!(t.gas_used(), Gas::new(15));
-        let _ = t.apply_charge(GasCharge::new("", Gas::new(5), Gas::zero()))?;
+        t.apply_charge(GasCharge::new("", Gas::new(5), Gas::zero()))?;
         assert_eq!(t.gas_used(), Gas::new(20));
         assert!(t
             .apply_charge(GasCharge::new("", Gas::new(1), Gas::zero()))

--- a/fvm/src/gas/timer.rs
+++ b/fvm/src/gas/timer.rs
@@ -27,7 +27,6 @@ pub type GasInstant = Instant;
 
 /// A handle returned by `charge_gas` which must be used to mark the end of
 /// the execution associated with that gas.
-#[must_use]
 #[derive(Debug)]
 pub struct GasTimer(Option<GasTimerInner>);
 

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -267,8 +267,7 @@ where
     fn block_open(&mut self, cid: &Cid) -> Result<(BlockId, BlockStat)> {
         // TODO(M2): Check for reachability here.
 
-        let _ = self
-            .call_manager
+        self.call_manager
             .charge_gas(self.call_manager.price_list().on_block_open_base())?;
 
         let start = GasTimer::start();
@@ -740,9 +739,8 @@ where
             );
         }
 
-        let _ = self
-            .call_manager
-            .charge_gas(self.call_manager.price_list().on_tipset_cid(offset > 1));
+        self.call_manager
+            .charge_gas(self.call_manager.price_list().on_tipset_cid(offset > 1))?;
 
         self.call_manager.externs().get_tipset_cid(epoch).or_fatal()
     }

--- a/fvm/src/syscalls/bind.rs
+++ b/fvm/src/syscalls/bind.rs
@@ -97,7 +97,7 @@ fn memory_and_data<'a, K: Kernel>(
 macro_rules! charge_syscall_gas {
     ($kernel:expr) => {
         let charge = $kernel.price_list().on_syscall();
-        let _ = $kernel
+        $kernel
             .charge_gas(&charge.name, charge.compute_gas)
             .map_err(Abort::from_error_as_fatal)?;
     };

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -151,8 +151,7 @@ pub fn charge_for_exec<K: Kernel>(
         // Only recording time for the execution, not for the memory part, which is unknown. But we
         // could perform stomething like a multi-variate linear regression to see if the amount of
         // memory explains any of the exectuion time.
-        let _ = data
-            .kernel
+        data.kernel
             .charge_gas("wasm_memory_grow", memory_gas_charge)
             .map_err(Abort::from_error_as_fatal)?;
     }
@@ -179,7 +178,7 @@ pub fn charge_for_init<K: Kernel>(
 
     if let Some(min_table_elements) = min_table_elements(module) {
         let table_gas = data.kernel.price_list().init_table_gas(min_table_elements);
-        let _ = data.kernel.charge_gas("wasm_table_init", table_gas)?;
+        data.kernel.charge_gas("wasm_table_init", table_gas)?;
     }
 
     data.kernel.charge_gas("wasm_memory_init", memory_gas)


### PR DESCRIPTION
My last commit introduced a bug where I ignored the error from a call to `CallManager::charge_gas` when we _meant_ to simply ignore the gas timer, not the entire error. This bug was in the charge for `on_method_return`.

So I decided to remove the `must_use` marker from gas timers _in general_ so we didn't have to explicitly ignore the results. We generally don't care about these timers anyways.

While doing that, I found another bug in the `tipset_cid` syscall where we made the same mistake. this issue is tricker because this code is already deployed to mainnet, but we should be able to fix it without any consensus issues. Basically, right now:

1. We won't detect the out of gas condition when we should.
2. We'll fetch the requested tipset CID from state.
3. We'll return it to the user.
4. The actor (the EVM) will try to charge a bit of gas when handling the return value from the syscall.
5. The actor will run out of gas and abort with an OutOfGas.

Now, we'll just abort with an OutOfGas error immediately.