### PR TITLE
chore(hamt): move the version parameter to the end

### DIFF
--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -34,14 +34,14 @@ use crate::{pointer::version, Config, Error, Hash, HashAlgorithm, Sha256};
 /// assert_eq!(map.get::<_>(&1).unwrap(), None);
 /// let cid = map.flush().unwrap();
 /// ```
-pub type Hamt<BS, V, K = BytesKey, H = Sha256> = HamtImpl<BS, V, version::V3, K, H>;
+pub type Hamt<BS, V, K = BytesKey, H = Sha256> = HamtImpl<BS, V, K, H, version::V3>;
 /// Legacy amt V0
-pub type Hamtv0<BS, V, K = BytesKey, H = Sha256> = HamtImpl<BS, V, version::V0, K, H>;
+pub type Hamtv0<BS, V, K = BytesKey, H = Sha256> = HamtImpl<BS, V, K, H, version::V0>;
 
 #[derive(Debug)]
 #[doc(hidden)]
-pub struct HamtImpl<BS, V, Ver, K = BytesKey, H = Sha256> {
-    root: Node<K, V, Ver, H>,
+pub struct HamtImpl<BS, V, K = BytesKey, H = Sha256, Ver = version::V3> {
+    root: Node<K, V, H, Ver>,
     store: BS,
     conf: Config,
     hash: PhantomData<H>,
@@ -49,7 +49,7 @@ pub struct HamtImpl<BS, V, Ver, K = BytesKey, H = Sha256> {
     flushed_cid: Option<Cid>,
 }
 
-impl<BS, V, Ver, K, H> Serialize for HamtImpl<BS, V, Ver, K, H>
+impl<BS, V, K, H, Ver> Serialize for HamtImpl<BS, V, K, H, Ver>
 where
     K: Serialize,
     V: Serialize,
@@ -65,14 +65,14 @@ where
 }
 
 impl<K: PartialEq, V: PartialEq, S: Blockstore, H: HashAlgorithm, Ver> PartialEq
-    for HamtImpl<S, V, Ver, K, H>
+    for HamtImpl<S, V, K, H, Ver>
 {
     fn eq(&self, other: &Self) -> bool {
         self.root == other.root
     }
 }
 
-impl<BS, V, Ver, K, H> HamtImpl<BS, V, Ver, K, H>
+impl<BS, V, K, H, Ver> HamtImpl<BS, V, K, H, Ver>
 where
     K: Hash + Eq + PartialOrd + Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -37,13 +37,13 @@ pub mod version {
 
 /// Pointer to index values or a link to another child node.
 #[derive(Debug)]
-pub(crate) enum Pointer<K, V, Ver, H> {
+pub(crate) enum Pointer<K, V, H, Ver = version::V3> {
     Values(Vec<KeyValuePair<K, V>>),
     Link {
         cid: Cid,
-        cache: OnceCell<Box<Node<K, V, Ver, H>>>,
+        cache: OnceCell<Box<Node<K, V, H, Ver>>>,
     },
-    Dirty(Box<Node<K, V, Ver, H>>),
+    Dirty(Box<Node<K, V, H, Ver>>),
 }
 
 impl<K: PartialEq, V: PartialEq, H, Ver> PartialEq for Pointer<K, V, H, Ver> {
@@ -81,10 +81,10 @@ mod pointer_v0 {
         Vals(Vec<KeyValuePair<K, V>>),
     }
 
-    impl<'a, K, V, Ver, H> TryFrom<&'a Pointer<K, V, Ver, H>> for PointerSer<'a, K, V> {
+    impl<'a, K, V, H, Ver> TryFrom<&'a Pointer<K, V, H, Ver>> for PointerSer<'a, K, V> {
         type Error = &'static str;
 
-        fn try_from(pointer: &'a Pointer<K, V, Ver, H>) -> Result<Self, Self::Error> {
+        fn try_from(pointer: &'a Pointer<K, V, H, Ver>) -> Result<Self, Self::Error> {
             match pointer {
                 Pointer::Values(vals) => Ok(PointerSer::Vals(vals.as_ref())),
                 Pointer::Link { cid, .. } => Ok(PointerSer::Link(cid)),
@@ -93,7 +93,7 @@ mod pointer_v0 {
         }
     }
 
-    impl<K, V, Ver, H> From<PointerDe<K, V>> for Pointer<K, V, Ver, H> {
+    impl<K, V, H, Ver> From<PointerDe<K, V>> for Pointer<K, V, H, Ver> {
         fn from(pointer: PointerDe<K, V>) -> Self {
             match pointer {
                 PointerDe::Link(cid) => Pointer::Link {
@@ -107,7 +107,7 @@ mod pointer_v0 {
 }
 
 /// Serialize the Pointer like an untagged enum.
-impl<K, V, Ver, H> Serialize for Pointer<K, V, Ver, H>
+impl<K, V, H, Ver> Serialize for Pointer<K, V, H, Ver>
 where
     K: Serialize,
     V: Serialize,
@@ -130,7 +130,7 @@ where
     }
 }
 
-impl<K, V, Ver, H> TryFrom<Ipld> for Pointer<K, V, Ver, H>
+impl<K, V, H, Ver> TryFrom<Ipld> for Pointer<K, V, H, Ver>
 where
     K: DeserializeOwned,
     V: DeserializeOwned,
@@ -156,7 +156,7 @@ where
 }
 
 /// Deserialize the Pointer like an untagged enum.
-impl<'de, K, V, Ver, H> Deserialize<'de> for Pointer<K, V, Ver, H>
+impl<'de, K, V, H, Ver> Deserialize<'de> for Pointer<K, V, H, Ver>
 where
     K: DeserializeOwned,
     V: DeserializeOwned,
@@ -184,7 +184,7 @@ impl<K, V, H, Ver> Default for Pointer<K, V, H, Ver> {
     }
 }
 
-impl<K, V, Ver, H> Pointer<K, V, Ver, H>
+impl<K, V, H, Ver> Pointer<K, V, H, Ver>
 where
     K: Serialize + DeserializeOwned + Hash + PartialOrd,
     V: Serialize + DeserializeOwned,


### PR DESCRIPTION
And "default" it to V3. Neither of these changes really matter, but I was getting thrown by the somewhat inconsistent type parameter order.

The parameter order isn't fully consistent (K/V in some cases, V/K in others) but that's a whole different issue and unrelated to recent changes.