### PR TITLE
feat(hamt): implement external iteration

### DIFF
--- a/ipld/hamt/src/error.rs
+++ b/ipld/hamt/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     /// Cid not found in store error
     #[error("Cid ({0}) did not match any in database")]
     CidNotFound(String),
+    #[error("Iteration starting key not found in HAMT")]
+    StartKeyNotFound,
     /// Dynamic error for when the error needs to be forwarded as is.
     #[error("{0}")]
     Dynamic(anyhow::Error),

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -458,10 +458,40 @@ where
     Ver: Version,
     BS: Blockstore,
 {
+    /// Iterate over the HAMT. Alternatively, you can directly iterate over the HAMT without calling
+    /// this method:
+    ///
+    /// ```rust
+    /// use hamt::Hamt;
+    ///
+    /// let hamt = Hamt::new_with_bit_width(5);
+    ///
+    /// // ...
+    ///
+    /// for kv in &my_hamt {
+    ///     let (k, v) = kv?;
+    ///     println!("{k}: {v}");
+    /// }
+    /// ```
     pub fn iter(&self) -> IterImpl<BS, V, K, H, Ver> {
         IterImpl::new(&self.store, &self.root)
     }
 
+    /// Iterate over the HAMT starting at the given key. This can be used to implement "ranged"
+    /// iteration:
+    ///
+    /// ```rust
+    /// use hamt::Hamt;
+    ///
+    /// let hamt = Hamt::new_with_bit_width(5);
+    ///
+    /// // ...
+    ///
+    /// for kv in my_hamt.iter_from("start_key").take(5) {
+    ///     let (k, v) = kv?;
+    ///     println!("{k}: {v}");
+    /// }
+    /// ```
     pub fn iter_from<Q: ?Sized>(&self, key: &Q) -> Result<IterImpl<BS, V, K, H, Ver>, Error>
     where
         H: HashAlgorithm,

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -497,7 +497,6 @@ where
         H: HashAlgorithm,
         K: Borrow<Q>,
         Q: Hash + Eq,
-        K: PartialEq,
     {
         IterImpl::new_from(&self.store, &self.root, key, &self.conf)
     }

--- a/ipld/hamt/src/iter.rs
+++ b/ipld/hamt/src/iter.rs
@@ -3,7 +3,6 @@
 use std::borrow::Borrow;
 use std::iter::FusedIterator;
 
-use anyhow::anyhow;
 use forest_hash_utils::BytesKey;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::de::DeserializeOwned;
@@ -91,7 +90,7 @@ where
                                 stack,
                                 current: values[offset..].iter(),
                             }),
-                            None => Err(anyhow!("key not found").into()),
+                            None => Err(Error::StartKeyNotFound),
                         }
                     }
                 },

--- a/ipld/hamt/src/iter.rs
+++ b/ipld/hamt/src/iter.rs
@@ -52,7 +52,6 @@ where
         H: HashAlgorithm,
         K: Borrow<Q>,
         Q: Hash + Eq,
-        K: PartialEq,
     {
         let hashed_key = H::hash(key);
         let mut hash = HashBits::new(&hashed_key);

--- a/ipld/hamt/src/iter.rs
+++ b/ipld/hamt/src/iter.rs
@@ -1,0 +1,157 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use std::borrow::Borrow;
+use std::iter::FusedIterator;
+
+use anyhow::anyhow;
+use forest_hash_utils::BytesKey;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::de::DeserializeOwned;
+use fvm_ipld_encoding::CborStore;
+
+use crate::hash_bits::HashBits;
+use crate::node::Node;
+use crate::pointer::version::Version;
+use crate::pointer::{version, Pointer};
+use crate::{Config, Error, Hash, HashAlgorithm, KeyValuePair, Sha256};
+
+#[doc(hidden)]
+pub struct IterImpl<'a, BS, V, K = BytesKey, H = Sha256, Ver = version::V3> {
+    store: &'a BS,
+    stack: Vec<std::slice::Iter<'a, Pointer<K, V, H, Ver>>>,
+    current: std::slice::Iter<'a, KeyValuePair<K, V>>,
+}
+
+pub type Iterv0<'a, BS, V, K = BytesKey, H = Sha256> = IterImpl<'a, BS, V, K, H, version::V0>;
+pub type Iter<'a, BS, V, K = BytesKey, H = Sha256> = IterImpl<'a, BS, V, K, H, version::V3>;
+
+impl<'a, K, V, BS, H, Ver> IterImpl<'a, BS, V, K, H, Ver>
+where
+    K: DeserializeOwned,
+    V: DeserializeOwned,
+    Ver: Version,
+    BS: Blockstore,
+{
+    pub(crate) fn new(store: &'a BS, root: &'a Node<K, V, H, Ver>) -> Self {
+        Self {
+            store,
+            stack: vec![root.pointers.iter()],
+            current: [].iter(),
+        }
+    }
+
+    pub(crate) fn new_from<Q: ?Sized>(
+        store: &'a BS,
+        root: &'a Node<K, V, H, Ver>,
+        key: &Q,
+        conf: &Config,
+    ) -> Result<Self, Error>
+    where
+        H: HashAlgorithm,
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+        K: PartialEq,
+    {
+        let hashed_key = H::hash(key);
+        let mut hash = HashBits::new(&hashed_key);
+        let mut node = root;
+        let mut stack = Vec::new();
+        loop {
+            let idx = hash.next(conf.bit_width)?;
+            stack.push(node.pointers[node.index_for_bit_pos(idx)..].iter());
+            node = match stack.last_mut().unwrap().next() {
+                Some(p) => match p {
+                    Pointer::Link { cid, cache } => {
+                        if let Some(cached_node) = cache.get() {
+                            cached_node
+                        } else {
+                            let node =
+                                if let Some(node) = store.get_cbor::<Node<K, V, H, Ver>>(cid)? {
+                                    node
+                                } else {
+                                    #[cfg(not(feature = "ignore-dead-links"))]
+                                    return Err(Error::CidNotFound(cid.to_string()));
+
+                                    #[cfg(feature = "ignore-dead-links")]
+                                    continue;
+                                };
+
+                            // Ignore error intentionally, the cache value will always be the same
+                            cache.get_or_init(|| Box::new(node))
+                        }
+                    }
+                    Pointer::Dirty(node) => node,
+                    Pointer::Values(values) => {
+                        return match values.iter().position(|kv| kv.key().borrow() == key) {
+                            Some(offset) => Ok(Self {
+                                store,
+                                stack,
+                                current: values[offset..].iter(),
+                            }),
+                            None => Err(anyhow!("key not found").into()),
+                        }
+                    }
+                },
+                None => continue,
+            };
+        }
+    }
+}
+
+impl<'a, K, V, BS, H, Ver> Iterator for IterImpl<'a, BS, V, K, H, Ver>
+where
+    BS: Blockstore,
+    Ver: Version,
+    K: DeserializeOwned,
+    V: DeserializeOwned,
+{
+    type Item = Result<(&'a K, &'a V), Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(v) = self.current.next() {
+            return Some(Ok((v.key(), v.value())));
+        }
+        loop {
+            if let Some(next) = self.stack.last_mut()?.next() {
+                match next {
+                    Pointer::Link { cid, cache } => {
+                        let node = if let Some(cached_node) = cache.get() {
+                            cached_node
+                        } else {
+                            let node = match self.store.get_cbor::<Node<K, V, H, Ver>>(cid) {
+                                Ok(Some(node)) => node,
+                                #[cfg(not(feature = "ignore-dead-links"))]
+                                Ok(None) => return Some(Err(Error::CidNotFound(cid.to_string()))),
+                                #[cfg(feature = "ignore-dead-links")]
+                                Ok(None) => continue,
+                                Err(err) => return Some(Err(err.into())),
+                            };
+
+                            // Ignore error intentionally, the cache value will always be the same
+                            cache.get_or_init(|| Box::new(node))
+                        };
+                        self.stack.push(node.pointers.iter())
+                    }
+                    Pointer::Dirty(node) => self.stack.push(node.pointers.iter()),
+                    Pointer::Values(kvs) => {
+                        self.current = kvs.iter();
+                        if let Some(v) = self.current.next() {
+                            return Some(Ok((v.key(), v.value())));
+                        }
+                    }
+                }
+            } else {
+                self.stack.pop();
+            }
+        }
+    }
+}
+
+impl<'a, K, V, BS, H, Ver> FusedIterator for IterImpl<'a, BS, V, K, H, Ver>
+where
+    K: DeserializeOwned,
+    V: DeserializeOwned,
+    Ver: Version,
+    BS: Blockstore,
+{
+}

--- a/ipld/hamt/src/iter.rs
+++ b/ipld/hamt/src/iter.rs
@@ -22,7 +22,10 @@ pub struct IterImpl<'a, BS, V, K = BytesKey, H = Sha256, Ver = version::V3> {
     current: std::slice::Iter<'a, KeyValuePair<K, V>>,
 }
 
+/// Iterator over HAMT Key/Value tuples (hamt v0).
 pub type Iterv0<'a, BS, V, K = BytesKey, H = Sha256> = IterImpl<'a, BS, V, K, H, version::V0>;
+
+/// Iterator over HAMT Key/Value tuples.
 pub type Iter<'a, BS, V, K = BytesKey, H = Sha256> = IterImpl<'a, BS, V, K, H, version::V3>;
 
 impl<'a, K, V, BS, H, Ver> IterImpl<'a, BS, V, K, H, Ver>

--- a/ipld/hamt/src/lib.rs
+++ b/ipld/hamt/src/lib.rs
@@ -16,6 +16,7 @@ mod hamt;
 mod hash;
 mod hash_algorithm;
 mod hash_bits;
+mod iter;
 mod node;
 mod pointer;
 
@@ -26,6 +27,7 @@ pub use self::error::Error;
 pub use self::hamt::{Hamt, Hamtv0};
 pub use self::hash::*;
 pub use self::hash_algorithm::*;
+pub use self::iter::{Iter, Iterv0};
 
 /// Default bit width for indexing a hash at each depth level
 #[deprecated]

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -141,146 +141,6 @@ where
         self.pointers.is_empty()
     }
 
-    pub(crate) fn for_each<S, F>(&self, store: &S, f: &mut F) -> Result<(), Error>
-    where
-        F: FnMut(&K, &V) -> anyhow::Result<()>,
-        S: Blockstore,
-    {
-        for p in &self.pointers {
-            match p {
-                Pointer::Link { cid, cache } => {
-                    if let Some(cached_node) = cache.get() {
-                        cached_node.for_each(store, f)?
-                    } else {
-                        let node = if let Some(node) = store.get_cbor(cid)? {
-                            node
-                        } else {
-                            #[cfg(not(feature = "ignore-dead-links"))]
-                            return Err(Error::CidNotFound(cid.to_string()));
-
-                            #[cfg(feature = "ignore-dead-links")]
-                            continue;
-                        };
-
-                        // Ignore error intentionally, the cache value will always be the same
-                        let cache_node = cache.get_or_init(|| node);
-                        cache_node.for_each(store, f)?
-                    }
-                }
-                Pointer::Dirty(node) => node.for_each(store, f)?,
-                Pointer::Values(kvs) => {
-                    for kv in kvs {
-                        f(kv.0.borrow(), kv.1.borrow())?;
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    pub(crate) fn for_each_ranged<Q: ?Sized, S, F>(
-        &self,
-        store: &S,
-        conf: &Config,
-        mut starting_cursor: Option<(HashBits, &Q)>,
-        limit: Option<usize>,
-        f: &mut F,
-    ) -> Result<(usize, Option<K>), Error>
-    where
-        K: Borrow<Q> + Clone,
-        Q: Eq + Hash,
-        F: FnMut(&K, &V) -> anyhow::Result<()>,
-        S: Blockstore,
-    {
-        // determine which subtree the starting_cursor is in
-        let cindex = match starting_cursor {
-            Some((ref mut bits, _)) => {
-                let idx = bits.next(conf.bit_width)?;
-                self.index_for_bit_pos(idx)
-            }
-            None => 0,
-        };
-
-        let mut traversed_count = 0;
-
-        // skip exploration of subtrees that are before the subtree which contains the cursor
-        for p in &self.pointers[cindex..] {
-            match p {
-                Pointer::Link { cid, cache } => {
-                    if let Some(cached_node) = cache.get() {
-                        let (traversed, key) = cached_node.for_each_ranged(
-                            store,
-                            conf,
-                            starting_cursor.take(),
-                            limit.map(|l| l.checked_sub(traversed_count).unwrap()),
-                            f,
-                        )?;
-                        traversed_count += traversed;
-                        if limit.map_or(false, |l| traversed_count >= l) && key.is_some() {
-                            return Ok((traversed_count, key));
-                        }
-                    } else {
-                        let node = if let Some(node) = store.get_cbor(cid)? {
-                            node
-                        } else {
-                            #[cfg(not(feature = "ignore-dead-links"))]
-                            return Err(Error::CidNotFound(cid.to_string()));
-
-                            #[cfg(feature = "ignore-dead-links")]
-                            continue;
-                        };
-
-                        // Ignore error intentionally, the cache value will always be the same
-                        let cache_node = cache.get_or_init(|| node);
-                        let (traversed, key) = cache_node.for_each_ranged(
-                            store,
-                            conf,
-                            starting_cursor.take(),
-                            limit.map(|l| l.checked_sub(traversed_count).unwrap()),
-                            f,
-                        )?;
-                        traversed_count += traversed;
-                        if limit.map_or(false, |l| traversed_count >= l) && key.is_some() {
-                            return Ok((traversed_count, key));
-                        }
-                    }
-                }
-                Pointer::Dirty(node) => {
-                    let (traversed, key) = node.for_each_ranged(
-                        store,
-                        conf,
-                        starting_cursor.take(),
-                        limit.map(|l| l.checked_sub(traversed_count).unwrap()),
-                        f,
-                    )?;
-                    traversed_count += traversed;
-                    if limit.map_or(false, |l| traversed_count >= l) && key.is_some() {
-                        return Ok((traversed_count, key));
-                    }
-                }
-                Pointer::Values(kvs) => {
-                    for kv in kvs {
-                        if limit.map_or(false, |l| traversed_count == l) {
-                            // we have already found all requested items, return the key of the next item
-                            return Ok((traversed_count, Some(kv.0.clone())));
-                        } else if starting_cursor.map_or(false, |(_, key)| key.eq(kv.0.borrow())) {
-                            // mark that we have arrived at the starting cursor
-                            starting_cursor = None
-                        }
-
-                        if starting_cursor.is_none() {
-                            // have already passed the start cursor
-                            f(&kv.0, kv.1.borrow())?;
-                            traversed_count += 1;
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok((traversed_count, None))
-    }
-
     /// Search for a key.
     fn search<Q: ?Sized, S: Blockstore>(
         &self,
@@ -589,12 +449,6 @@ where
         self.pointers.insert(i, Pointer::Dirty(node))
     }
 
-    fn index_for_bit_pos(&self, bp: u32) -> usize {
-        let mask = Bitfield::zero().set_bits_le(bp);
-        assert_eq!(mask.count_ones(), bp as usize);
-        mask.and(&self.bitfield).count_ones()
-    }
-
     fn get_child_mut(&mut self, i: usize) -> &mut Pointer<K, V, H, Ver> {
         &mut self.pointers[i]
     }
@@ -613,5 +467,13 @@ where
             Err(Error::ZeroPointers) if depth < conf.min_data_depth => Ok(true),
             Err(err) => Err(err),
         }
+    }
+}
+
+impl<K, V, H, Ver> Node<K, V, H, Ver> {
+    pub(crate) fn index_for_bit_pos(&self, bp: u32) -> usize {
+        let mask = Bitfield::zero().set_bits_le(bp);
+        assert_eq!(mask.count_ones(), bp as usize);
+        mask.and(&self.bitfield).count_ones()
     }
 }

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -113,6 +113,10 @@ impl CidChecker {
 
 impl Drop for CidChecker {
     fn drop(&mut self) {
+        if std::thread::panicking() {
+            // Already failed, don't double-panic.
+            return;
+        }
         if let Some(cids) = &self.cids {
             assert_eq!(self.checked, cids.len())
         }

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -23,6 +23,9 @@ use serde::Serialize;
 // Redeclaring max array size of Hamt to avoid exposing value
 const BUCKET_SIZE: usize = 3;
 
+// Sizes at which we run variable-sized tests.
+const SIZE_FACTORS: &[usize] = &[1, 5, 19, 71, 104, 200, 983];
+
 /// Help reuse tests with different HAMT configurations.
 #[derive(Default)]
 struct HamtFactory {
@@ -301,32 +304,37 @@ fn reload_empty(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidCheck
     }
 }
 
-fn set_delete_many(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidChecker) {
+fn set_delete_many(
+    size_factor: usize,
+    factory: HamtFactory,
+    stats: Option<BSStats>,
+    mut cids: CidChecker,
+) {
     let mem = MemoryBlockstore::default();
     let store = TrackingBlockstore::new(&mem);
 
     // Test vectors setup specifically for bit width of 5
     let mut hamt: Hamt<_, BytesKey> = factory.new_with_bit_width(&store, 5);
 
-    for i in 0..200 {
+    for i in 0..size_factor {
         hamt.set(tstring(i), tstring(i)).unwrap();
     }
 
     let c1 = hamt.flush().unwrap();
     cids.check_next(c1);
 
-    for i in 200..400 {
+    for i in size_factor..(size_factor * 2) {
         hamt.set(tstring(i), tstring(i)).unwrap();
     }
 
     let cid_all = hamt.flush().unwrap();
     cids.check_next(cid_all);
 
-    for i in 200..400 {
+    for i in size_factor..(size_factor * 2) {
         assert!(hamt.delete(&tstring(i)).unwrap().is_some());
     }
-    // Ensure first 200 keys still exist
-    for i in 0..200 {
+    // Ensure first size_factor keys still exist
+    for i in 0..size_factor {
         assert_eq!(hamt.get(&tstring(i)).unwrap(), Some(&tstring(i)));
     }
 
@@ -337,13 +345,18 @@ fn set_delete_many(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidCh
     }
 }
 
-fn for_each(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidChecker) {
+fn for_each(
+    size_factor: usize,
+    factory: HamtFactory,
+    stats: Option<BSStats>,
+    mut cids: CidChecker,
+) {
     let mem = MemoryBlockstore::default();
     let store = TrackingBlockstore::new(&mem);
 
     let mut hamt: Hamt<_, BytesKey> = factory.new_with_bit_width(&store, 5);
 
-    for i in 0..200 {
+    for i in 0..size_factor {
         hamt.set(tstring(i), tstring(i)).unwrap();
     }
 
@@ -355,7 +368,7 @@ fn for_each(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidChecker) 
         Ok(())
     })
     .unwrap();
-    assert_eq!(count, 200);
+    assert_eq!(count, size_factor);
 
     let c = hamt.flush().unwrap();
     cids.check_next(c);
@@ -370,7 +383,7 @@ fn for_each(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidChecker) 
         Ok(())
     })
     .unwrap();
-    assert_eq!(count, 200);
+    assert_eq!(count, size_factor);
 
     // Iterating through hamt with cached nodes.
     let mut count = 0;
@@ -380,7 +393,7 @@ fn for_each(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidChecker) 
         Ok(())
     })
     .unwrap();
-    assert_eq!(count, 200);
+    assert_eq!(count, size_factor);
 
     let c = hamt.flush().unwrap();
     cids.check_next(c);
@@ -390,14 +403,18 @@ fn for_each(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidChecker) 
     }
 }
 
-fn for_each_ranged(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidChecker) {
+fn for_each_ranged(
+    size_factor: usize,
+    factory: HamtFactory,
+    stats: Option<BSStats>,
+    mut cids: CidChecker,
+) {
     let mem = MemoryBlockstore::default();
     let store = TrackingBlockstore::new(&mem);
 
     let mut hamt: Hamt<_, usize> = factory.new_with_bit_width(&store, 5);
 
-    const RANGE: usize = 200;
-    for i in 0..RANGE {
+    for i in 0..size_factor {
         hamt.set(tstring(i), i).unwrap();
     }
 
@@ -411,7 +428,7 @@ fn for_each_ranged(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidCh
     .unwrap();
 
     // Iterate through the array, requesting pages of different sizes
-    for page_size in 0..RANGE {
+    for page_size in 0..size_factor {
         let mut kvs_variable_page = Vec::new();
         let (num_traversed, next_key) = hamt
             .for_each_ranged::<BytesKey, _>(None, Some(page_size), |k, v| {
@@ -430,13 +447,13 @@ fn for_each_ranged(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidCh
 
     // Iterate through the array, requesting more items than are remaining
     let (num_traversed, next_key) = hamt
-        .for_each_ranged::<BytesKey, _>(None, Some(RANGE + 10), |_k, _v| Ok(()))
+        .for_each_ranged::<BytesKey, _>(None, Some(size_factor + 10), |_k, _v| Ok(()))
         .unwrap();
-    assert_eq!(num_traversed, RANGE);
+    assert_eq!(num_traversed, size_factor);
     assert_eq!(next_key, None);
 
     // Iterate through it again starting at a certain key
-    for start_at in 0..RANGE {
+    for start_at in 0..size_factor {
         let mut kvs_variable_start = Vec::new();
         let (num_traversed, next_key) = hamt
             .for_each_ranged(Some(&kvs[start_at].0), None, |k, v| {
@@ -462,31 +479,33 @@ fn for_each_ranged(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidCh
         let mut iterations = 0;
         let mut cursor: Option<BytesKey> = None;
 
-        // Request all items in pages of 20 items each
-        const PAGE_SIZE: usize = 20;
+        // Request all items in pages of N items each
+        let page_size: usize = (size_factor / 10).max(1);
         loop {
-            let (page_size, next) = match cursor {
+            let (count, next) = match cursor {
                 Some(ref start) => hamt
-                    .for_each_ranged::<BytesKey, _>(Some(start), Some(PAGE_SIZE), |k, v| {
+                    .for_each_ranged::<BytesKey, _>(Some(start), Some(page_size), |k, v| {
                         kvs_paginated_requests.push((k.clone(), *v));
                         Ok(())
                     })
                     .unwrap(),
                 None => hamt
-                    .for_each_ranged::<BytesKey, _>(None, Some(PAGE_SIZE), |k, v| {
+                    .for_each_ranged::<BytesKey, _>(None, Some(page_size), |k, v| {
                         kvs_paginated_requests.push((k.clone(), *v));
                         Ok(())
                     })
                     .unwrap(),
             };
+            let total_count = iterations * page_size + count;
+            assert_eq!(kvs_paginated_requests.len(), total_count);
             iterations += 1;
-            assert_eq!(page_size, PAGE_SIZE);
-            assert_eq!(kvs_paginated_requests.len(), iterations * PAGE_SIZE);
 
             if next.is_none() {
+                assert_eq!(total_count, size_factor);
                 break;
             } else {
-                assert_eq!(next.clone().unwrap(), kvs[iterations * PAGE_SIZE].0);
+                assert_eq!(count, page_size);
+                assert_eq!(next.clone().unwrap(), kvs[iterations * page_size].0);
                 cursor = next;
             }
         }
@@ -495,7 +514,10 @@ fn for_each_ranged(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidCh
         assert_eq!(kvs_paginated_requests.len(), kvs.len(), "{}", iterations);
         assert_eq!(kvs_paginated_requests, kvs);
         // should have used the expected number of iterations
-        assert_eq!(iterations, RANGE / PAGE_SIZE);
+        assert_eq!(
+            iterations,
+            (size_factor / page_size) + ((size_factor % page_size) > 0) as usize
+        );
     }
 
     let c = hamt.flush().unwrap();
@@ -509,30 +531,32 @@ fn for_each_ranged(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidCh
         let mut cursor: Option<BytesKey> = None;
 
         // Request all items in pages of 20 items each
-        const PAGE_SIZE: usize = 20;
+        let page_size: usize = (size_factor / 10).max(1);
         loop {
-            let (page_size, next) = match cursor {
+            let (count, next) = match cursor {
                 Some(ref start) => hamt
-                    .for_each_ranged::<BytesKey, _>(Some(start), Some(PAGE_SIZE), |k, v| {
+                    .for_each_ranged::<BytesKey, _>(Some(start), Some(page_size), |k, v| {
                         kvs_paginated_requests.push((k.clone(), *v));
                         Ok(())
                     })
                     .unwrap(),
                 None => hamt
-                    .for_each_ranged::<BytesKey, _>(None, Some(PAGE_SIZE), |k, v| {
+                    .for_each_ranged::<BytesKey, _>(None, Some(page_size), |k, v| {
                         kvs_paginated_requests.push((k.clone(), *v));
                         Ok(())
                     })
                     .unwrap(),
             };
+            let total_count = iterations * page_size + count;
+            assert_eq!(kvs_paginated_requests.len(), total_count);
             iterations += 1;
-            assert_eq!(page_size, PAGE_SIZE);
-            assert_eq!(kvs_paginated_requests.len(), iterations * PAGE_SIZE);
 
             if next.is_none() {
+                assert_eq!(total_count, size_factor);
                 break;
             } else {
-                assert_eq!(next.clone().unwrap(), kvs[iterations * PAGE_SIZE].0);
+                assert_eq!(count, page_size);
+                assert_eq!(next.clone().unwrap(), kvs[iterations * page_size].0);
                 cursor = next;
             }
         }
@@ -541,7 +565,10 @@ fn for_each_ranged(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidCh
         assert_eq!(kvs_paginated_requests.len(), kvs.len(), "{}", iterations);
         assert_eq!(kvs_paginated_requests, kvs);
         // should have used the expected number of iterations
-        assert_eq!(iterations, RANGE / PAGE_SIZE);
+        assert_eq!(
+            iterations,
+            (size_factor / page_size) + ((size_factor % page_size) > 0) as usize
+        );
     }
 
     let c = hamt.flush().unwrap();
@@ -976,29 +1003,29 @@ mod test_default {
             "bafy2bzacecxcp736xkl2mcyjlors3tug6vdlbispbzxvb75xlrhthiw2xwxvw",
             "bafy2bzaceczhz54xmmz3xqnbmvxfbaty3qprr6dq7xh5vzwqbirlsnbd36z7a",
         ]);
-        super::set_delete_many(HamtFactory::default(), Some(stats), cids);
+        super::set_delete_many(200, HamtFactory::default(), Some(stats), cids);
     }
 
     #[test]
     fn for_each() {
         #[rustfmt::skip]
-        let stats = BSStats {r: 30, w: 30, br: 3209, bw: 3209};
+            let stats = BSStats {r: 30, w: 30, br: 3209, bw: 3209};
         let cids = CidChecker::new(vec![
             "bafy2bzaceczhz54xmmz3xqnbmvxfbaty3qprr6dq7xh5vzwqbirlsnbd36z7a",
             "bafy2bzaceczhz54xmmz3xqnbmvxfbaty3qprr6dq7xh5vzwqbirlsnbd36z7a",
         ]);
-        super::for_each(HamtFactory::default(), Some(stats), cids);
+        super::for_each(200, HamtFactory::default(), Some(stats), cids);
     }
 
     #[test]
     fn for_each_ranged() {
         #[rustfmt::skip]
-        let stats = BSStats {r: 30, w: 30, br: 2895, bw: 2895};
+            let stats = BSStats {r: 30, w: 30, br: 2895, bw: 2895};
         let cids = CidChecker::new(vec![
             "bafy2bzacedy4ypl2vedhdqep3llnwko6vrtfiys5flciz2f3c55pl4whlhlqm",
             "bafy2bzacedy4ypl2vedhdqep3llnwko6vrtfiys5flciz2f3c55pl4whlhlqm",
         ]);
-        super::for_each_ranged(HamtFactory::default(), Some(stats), cids);
+        super::for_each_ranged(200, HamtFactory::default(), Some(stats), cids);
     }
 
     #[test]
@@ -1098,12 +1125,23 @@ macro_rules! test_hamt_mod {
 
             #[test]
             fn set_delete_many() {
-                super::set_delete_many($factory, None, CidChecker::empty())
+                for s in super::SIZE_FACTORS {
+                    super::set_delete_many(*s, $factory, None, CidChecker::empty())
+                }
             }
 
             #[test]
             fn for_each() {
-                super::for_each($factory, None, CidChecker::empty())
+                for s in super::SIZE_FACTORS {
+                    super::for_each(*s, $factory, None, CidChecker::empty())
+                }
+            }
+
+            #[test]
+            fn for_each_ranged() {
+                for s in super::SIZE_FACTORS {
+                    super::for_each_ranged(*s, $factory, None, CidChecker::empty())
+                }
             }
 
             #[test]


### PR DESCRIPTION
Previously, we only supported "internal" iteration with a callback. This switches to an external iterator which:

1. Allows us to make the APIs a little more composable.
2. Allows HAMT iterators to be used in rust for loops.
3. Avoids the awkward error wrapping when bubbling up errors from `for_each` calls.

Usage:

```rust
let mut hamt = Hamt::new_with_bit_width(&bs, 4);

// ...

for item in &hamt {
    let (k, v) = item?; // error handling is a bit annoying.
}

// ranged iteration
for item in hamt.iter_from(start_key).take(50) {
    // ...
}

```

part of https://github.com/filecoin-project/ref-fvm/issues/286