### PR TITLE
feat: add syscall for bls aggregate signature verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,7 +1446,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_account"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "fil_actors_runtime",
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_cron"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_datacap"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "cid 0.10.1",
  "fil_actors_runtime",
@@ -1518,7 +1518,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_eam"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1539,7 +1539,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_ethaccount"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
@@ -1555,7 +1555,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_evm"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1579,7 +1579,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_init"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1598,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_market"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1621,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_miner"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1646,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_multisig"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_paych"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1684,12 +1684,12 @@ dependencies = [
 [[package]]
 name = "fil_actor_placeholder"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 
 [[package]]
 name = "fil_actor_power"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1711,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_reward"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1727,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_system"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_verifreg"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1765,7 +1765,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_evm_shared"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1778,7 +1778,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1820,7 +1820,7 @@ dependencies = [
 [[package]]
 name = "fil_builtin_actors_bundle"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "cid 0.10.1",
  "clap 3.2.25",
@@ -4791,7 +4791,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vm_api"
 version = "1.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f46d4dc4cbd631a506ef70a5a198275f1d96339d"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#c0599c4c219d83a6f57ee1ac02475964b5076b68"
 dependencies = [
  "anyhow",
  "cid 0.10.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,6 +2350,7 @@ dependencies = [
  "replace_with",
  "serde",
  "serde_tuple",
+ "static_assertions",
  "thiserror",
  "wasmtime",
  "wasmtime-environ",
@@ -2738,6 +2739,7 @@ dependencies = [
 name = "fvm_sdk"
 version = "3.3.0"
 dependencies = [
+ "byteorder",
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_shared 3.4.0",

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -38,6 +38,7 @@ rand = "0.8.5"
 quickcheck = { version = "1", optional = true }
 once_cell = "1.18"
 minstant = "0.1.2"
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -584,6 +584,9 @@ impl PriceList {
 
     /// Returns gas required for BLS aggregate signature verification.
     pub fn on_verify_aggregate_signature(&self, num_sigs: usize) -> GasCharge {
+        // TODO: the gas cost calculated below is only an estimate; its actual value is yet to be
+        // benchmarked.
+
         // When `num_sigs` BLS signatures are aggregated into a single signature, the aggregate
         // signature verifier must perform `num_sigs + 1` expensive pairing operations (one
         // pairing on the aggregate signature, and one pairing for each signed plaintext's digest).

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -7,7 +7,6 @@ use std::ops::Mul;
 
 use anyhow::Context;
 use fvm_shared::crypto::signature::SignatureType;
-use fvm_shared::event::{ActorEvent, Flags};
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredPoStProof, RegisteredSealProof, ReplicaUpdateInfo,
@@ -26,6 +25,21 @@ use crate::kernel::SupportedHashes;
 // Each element reserves a `usize` in the table, so we charge 8 bytes per pointer.
 // https://docs.rs/wasmtime/2.0.2/wasmtime/struct.InstanceLimits.html#structfield.table_elements
 const TABLE_ELEMENT_SIZE: u32 = 8;
+
+// The maximum overhead (in bytes) of a single event when encoded into CBOR.
+//
+// 1: CBOR tuple with 2 fields (StampedEvent)
+//   9: Emitter ID
+//   2: Entry array overhead (max size 255)
+const EVENT_OVERHEAD: u64 = 12;
+// The maximum overhead (in bytes) of a single event entry when encoded into CBOR.
+//
+// 1: CBOR tuple with 4 fields
+//   1: Flags (will adjust as more flags are added)
+//   2: Key major type + length (up to 255 bytes)
+//   2: Codec major type + value (codec should be <= 255)
+//   3: Value major type + length (up to 8192 bytes)
+const EVENT_ENTRY_OVERHEAD: u64 = 9;
 
 /// Create a mapping from enum items to values in a way that guarantees at compile
 /// time that we did not miss any member, in any of the prices, even if the enum
@@ -293,26 +307,15 @@ lazy_static! {
             memory_fill_per_byte_cost: Gas::from_milligas(400),
         },
 
-        // These parameters are specifically sized for EVM events. They will need
-        // to be revisited before Wasm actors are able to emit arbitrary events.
-        //
-        // Validation costs are dependent on encoded length, but also
-        // co-dependent on the number of entries. The latter is a chicken-and-egg
-        // situation because we can only learn how many entries were emitted once we
-        // decode the CBOR event.
-        //
-        // We will likely need to revisit the ABI of emit_event to remove CBOR
-        // as the exchange format.
-        event_validation_cost: ScalingCost {
+        // TODO(#1817): Per-entry event validation cost. These parameters were benchmarked for the
+        // EVM but haven't been revisited since revising the API.
+        event_per_entry: ScalingCost {
             flat: Gas::new(1750),
             scale: Gas::new(25),
         },
 
-        // The protocol does not currently mandate indexing work, so these are
-        // left at zero. Once we start populating and committing indexing data
-        // structures, these costs will need to reflect the computation and
-        // storage costs of such actions.
-        event_accept_per_index_element: ScalingCost {
+        // TODO(#1817): Cost of validating utf8 (used in event parsing).
+        utf8_validation: ScalingCost {
             flat: Zero::zero(),
             scale: Zero::zero(),
         },
@@ -468,13 +471,13 @@ pub struct PriceList {
 
     /// Gas cost to validate an ActorEvent as soon as it's received from the actor, and prior
     /// to it being parsed.
-    pub(crate) event_validation_cost: ScalingCost,
-
-    /// Gas cost of every indexed element, scaling per number of bytes indexed.
-    pub(crate) event_accept_per_index_element: ScalingCost,
+    pub(crate) event_per_entry: ScalingCost,
 
     /// Gas cost of doing lookups in the builtin actor mappings.
     pub(crate) builtin_actor_manifest_lookup: Gas,
+
+    /// Gas cost of utf8 parsing.
+    pub(crate) utf8_validation: ScalingCost,
 
     /// Gas cost of accessing the network context.
     pub(crate) network_context: Gas,
@@ -921,59 +924,33 @@ impl PriceList {
     }
 
     #[inline]
-    pub fn on_actor_event_validate(&self, data_size: usize) -> GasCharge {
-        let memcpy = self.block_memcpy.apply(data_size);
-        let alloc = self.block_allocate.apply(data_size);
-        let validate = self.event_validation_cost.apply(data_size);
+    pub fn on_actor_event(&self, entries: usize, keysize: usize, valuesize: usize) -> GasCharge {
+        // Here we estimate per-event overhead given the constraints on event values.
 
-        GasCharge::new(
-            "OnActorEventValidate",
-            memcpy + alloc + validate,
-            Zero::zero(),
-        )
-    }
+        let validate_entries = self.event_per_entry.apply(entries);
+        let validate_utf8 = self.utf8_validation.apply(keysize);
 
-    #[inline]
-    pub fn on_actor_event_accept(&self, evt: &ActorEvent, serialized_len: usize) -> GasCharge {
-        let (mut indexed_bytes, mut indexed_elements) = (0usize, 0u32);
-        for evt in evt.entries.iter() {
-            if evt.flags.contains(Flags::FLAG_INDEXED_KEY) {
-                indexed_bytes += evt.key.len();
-                indexed_elements += 1;
-            }
-            if evt.flags.contains(Flags::FLAG_INDEXED_VALUE) {
-                indexed_bytes += evt.value.len();
-                indexed_elements += 1;
-            }
-        }
+        // Estimate the size, saturating at max-u64. Given how we calculate gas, this will saturate
+        // the gas maximum at max-u64 milligas.
+        let estimated_size = EVENT_OVERHEAD
+            .saturating_add(EVENT_ENTRY_OVERHEAD.saturating_mul(entries as u64))
+            .saturating_add(keysize as u64)
+            .saturating_add(valuesize as u64);
 
-        // The estimated size of the serialized StampedEvent event, which
-        // includes the ActorEvent + 8 bytes for the actor ID + some bytes
-        // for CBOR framing.
-        const STAMP_EXTRA_SIZE: usize = 12;
-        let stamped_event_size = serialized_len + STAMP_EXTRA_SIZE;
-
-        // Charge for 3 memory copy operations.
-        // This includes the cost of forming a StampedEvent, copying into the
-        // AMT's buffer on finish, and returning to the client.
-        let memcpy = self.block_memcpy.apply(stamped_event_size);
-
-        // Charge for 2 memory allocations.
-        // This includes the cost of retaining the StampedEvent in the call manager,
-        // and allocaing into the AMT's buffer on finish.
-        let alloc = self.block_allocate.apply(stamped_event_size);
+        // Calculate the cost per copy (one memcpy + one allocation).
+        let mem =
+            self.block_memcpy.apply(estimated_size) + self.block_allocate.apply(estimated_size);
 
         // Charge for the hashing on AMT insertion.
-        let hash = self.hashing_cost[&SupportedHashes::Blake2b256].apply(stamped_event_size);
+        let hash = self.hashing_cost[&SupportedHashes::Blake2b256].apply(estimated_size);
 
         GasCharge::new(
-            "OnActorEventAccept",
-            memcpy + alloc,
-            self.event_accept_per_index_element.flat * indexed_elements
-                + self.event_accept_per_index_element.scale * indexed_bytes
-                + memcpy * 2u32 // deferred cost, placing here to hide from benchmark
-                + alloc // deferred cost, placing here to hide from benchmark
-                + hash, // deferred cost, placing here to hide from benchmark
+            "OnActorEvent",
+            // Charge for validation/storing events.
+            mem + validate_entries + validate_utf8,
+            // Charge for forming the AMT and returning the events to the client.
+            // one copy into the AMT, one copy to the client.
+            hash + (mem * 2u32),
         )
     }
 }

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -14,7 +14,7 @@ use fvm_shared::address::Payload;
 use fvm_shared::bigint::Zero;
 use fvm_shared::chainid::ChainID;
 use fvm_shared::consensus::ConsensusFault;
-use fvm_shared::crypto::signature;
+use fvm_shared::crypto::signature::{self, Signature};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::event::{ActorEvent, Entry, Flags};
@@ -34,7 +34,7 @@ use super::hash::SupportedHashes;
 use super::*;
 use crate::call_manager::{CallManager, InvocationResult, NO_DATA_BLOCK_ID};
 use crate::externs::{Chain, Consensus, Rand};
-use crate::gas::GasTimer;
+use crate::gas::{GasCharge, GasTimer};
 use crate::init_actor::INIT_ACTOR_ID;
 use crate::machine::{MachineContext, NetworkConfig};
 use crate::state_tree::ActorState;
@@ -464,6 +464,37 @@ where
         t.record(catch_and_log_panic("verifying signature", || {
             Ok(signature::verify(sig_type, signature, plaintext, &signing_addr).is_ok())
         }))
+    }
+
+    fn verify_bls_aggregate(
+        &self,
+        aggregate_signature: &[u8; BLS_SIG_LEN],
+        pub_keys: &[[u8; BLS_PUB_LEN]],
+        digests: &[[u8; BLS_DIGEST_LEN]],
+    ) -> Result<bool> {
+        let sig = Signature::new_bls(aggregate_signature.to_vec());
+        let pub_keys: Vec<&[u8]> = pub_keys.iter().map(AsRef::as_ref).collect();
+        let digests: Vec<&[u8]> = digests.iter().map(AsRef::as_ref).collect();
+
+        let gas_required = {
+            let gas_two_pairings = self.call_manager.price_list().sig_cost[&SignatureType::BLS]
+                .flat
+                .as_milligas();
+            let gas_one_pairing = gas_two_pairings / 2;
+            let num_pairings = digests.len() as u64 + 1;
+            let gas_required = Gas::from_milligas(num_pairings * gas_one_pairing);
+            GasCharge::new("OnVerifySignature", gas_required, Zero::zero())
+        };
+
+        let t = self.call_manager.charge_gas(gas_required)?;
+        t.record(catch_and_log_panic(
+            "verifying bls aggregate signature",
+            || {
+                Ok(signature::ops::verify_bls_aggregate(
+                    &digests, &pub_keys, &sig,
+                ))
+            },
+        ))
     }
 
     fn recover_secp_public_key(

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -438,24 +438,27 @@ where
     fn verify_bls_aggregate(
         &self,
         aggregate_sig: &[u8; BLS_SIG_LEN],
-        pub_keys: &[&[u8; BLS_PUB_LEN]],
-        digests: &[&[u8; BLS_DIGEST_LEN]],
+        pub_keys: &[[u8; BLS_PUB_LEN]],
+        digests: &[[u8; BLS_DIGEST_LEN]],
     ) -> Result<bool> {
+        let num_signers = pub_keys.len();
+
+        if num_signers != digests.len() {
+            return Err(syscall_error!(
+                IllegalArgument;
+                "unequal numbers of bls public keys and digests"
+            )
+            .into());
+        }
+
         let t = self.call_manager.charge_gas(
             self.call_manager
                 .price_list()
-                .on_verify_aggregate_signature(pub_keys.len()),
+                .on_verify_aggregate_signature(num_signers),
         )?;
 
         t.record(
-            signature::ops::verify_bls_aggregate(aggregate_sig, pub_keys, digests).map_err(|e| {
-                syscall_error!(
-                    IllegalArgument;
-                    "bls signature verification failed: {}",
-                    e
-                )
-                .into()
-            }),
+            signature::ops::verify_bls_aggregate(aggregate_sig, pub_keys, digests).or(Ok(false)),
         )
     }
 

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -10,11 +10,10 @@ use cid::Cid;
 use filecoin_proofs_api::{self as proofs, ProverId, PublicReplicaInfo, SectorId};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{bytes_32, IPLD_RAW};
-use fvm_shared::address::Payload;
 use fvm_shared::bigint::Zero;
 use fvm_shared::chainid::ChainID;
 use fvm_shared::consensus::ConsensusFault;
-use fvm_shared::crypto::signature::{self, Signature};
+use fvm_shared::crypto::signature;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::event::{ActorEvent, Entry, Flags};
@@ -34,7 +33,7 @@ use super::hash::SupportedHashes;
 use super::*;
 use crate::call_manager::{CallManager, InvocationResult, NO_DATA_BLOCK_ID};
 use crate::externs::{Chain, Consensus, Rand};
-use crate::gas::{GasCharge, GasTimer};
+use crate::gas::GasTimer;
 use crate::init_actor::INIT_ACTOR_ID;
 use crate::machine::{MachineContext, NetworkConfig};
 use crate::state_tree::ActorState;
@@ -436,65 +435,28 @@ impl<C> CryptoOps for DefaultKernel<C>
 where
     C: CallManager,
 {
-    fn verify_signature(
+    fn verify_bls_aggregate(
         &self,
-        sig_type: SignatureType,
-        signature: &[u8],
-        signer: &Address,
-        plaintext: &[u8],
+        aggregate_sig: &[u8; BLS_SIG_LEN],
+        pub_keys: &[&[u8; BLS_PUB_LEN]],
+        digests: &[&[u8; BLS_DIGEST_LEN]],
     ) -> Result<bool> {
         let t = self.call_manager.charge_gas(
             self.call_manager
                 .price_list()
-                .on_verify_signature(sig_type, plaintext.len()),
+                .on_verify_aggregate_signature(pub_keys.len()),
         )?;
 
-        // We only support key addresses (f1/f3). This change does not require a FIP, because no
-        // actors invoke this method with non-key addresses.
-        let signing_addr = match signer.payload() {
-            Payload::BLS(_) | Payload::Secp256k1(_) => *signer,
-            // Not a key address.
-            _ => {
-                return Err(syscall_error!(IllegalArgument; "address protocol {} not supported", signer.protocol()).into());
-            }
-        };
-
-        // Verify signature, catching errors. Signature verification can include some complicated
-        // math.
-        t.record(catch_and_log_panic("verifying signature", || {
-            Ok(signature::verify(sig_type, signature, plaintext, &signing_addr).is_ok())
-        }))
-    }
-
-    fn verify_bls_aggregate(
-        &self,
-        aggregate_signature: &[u8; BLS_SIG_LEN],
-        pub_keys: &[[u8; BLS_PUB_LEN]],
-        digests: &[[u8; BLS_DIGEST_LEN]],
-    ) -> Result<bool> {
-        let sig = Signature::new_bls(aggregate_signature.to_vec());
-        let pub_keys: Vec<&[u8]> = pub_keys.iter().map(AsRef::as_ref).collect();
-        let digests: Vec<&[u8]> = digests.iter().map(AsRef::as_ref).collect();
-
-        let gas_required = {
-            let gas_two_pairings = self.call_manager.price_list().sig_cost[&SignatureType::BLS]
-                .flat
-                .as_milligas();
-            let gas_one_pairing = gas_two_pairings / 2;
-            let num_pairings = digests.len() as u64 + 1;
-            let gas_required = Gas::from_milligas(num_pairings * gas_one_pairing);
-            GasCharge::new("OnVerifySignature", gas_required, Zero::zero())
-        };
-
-        let t = self.call_manager.charge_gas(gas_required)?;
-        t.record(catch_and_log_panic(
-            "verifying bls aggregate signature",
-            || {
-                Ok(signature::ops::verify_bls_aggregate(
-                    &digests, &pub_keys, &sig,
-                ))
-            },
-        ))
+        t.record(
+            signature::ops::verify_bls_aggregate(aggregate_sig, pub_keys, digests).map_err(|e| {
+                syscall_error!(
+                    IllegalArgument;
+                    "bls signature verification failed: {}",
+                    e
+                )
+                .into()
+            }),
+        )
     }
 
     fn recover_secp_public_key(

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -6,8 +6,7 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::signature::{
-    BLS_DIGEST_LEN, BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN,
-    SECP_SIG_MESSAGE_HASH_SIZE,
+    BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
 };
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -262,13 +261,14 @@ pub trait CryptoOps {
     ///
     /// Returns:
     /// - `Ok(true)` on a valid signature.
-    /// - `Ok(false)` on an invalid signature or if any arguments represent an invalid curve point.
-    /// - `Err(IllegalArgument)` if `pub_keys.len() != digests.len()`.
+    /// - `Ok(false)` on an invalid signature or if the signature or public keys' bytes represent an
+    ///    invalid curve point.
+    /// - `Err(IllegalArgument)` if `pub_keys.len() != plaintexts.len()`.
     fn verify_bls_aggregate(
         &self,
         aggregate_sig: &[u8; BLS_SIG_LEN],
         pub_keys: &[[u8; BLS_PUB_LEN]],
-        digests: &[[u8; BLS_DIGEST_LEN]],
+        plaintexts: &[&[u8]],
     ) -> Result<bool>;
 
     /// Given a message hash and its signature, recovers the public key of the signer.

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -257,11 +257,18 @@ pub trait GasOps {
 
 /// Cryptographic primitives provided by the kernel.
 pub trait CryptoOps {
+    /// Verifies a BLS aggregate signature. In the case where there is one signer/signed plaintext,
+    /// this is equivalent to verifying a non-aggregated BLS signature.
+    ///
+    /// Returns:
+    /// - `Ok(true)` on a valid signature.
+    /// - `Ok(false)` on an invalid signature or if any arguments represent an invalid curve point.
+    /// - `Err(IllegalArgument)` if `pub_keys.len() != digests.len()`.
     fn verify_bls_aggregate(
         &self,
         aggregate_sig: &[u8; BLS_SIG_LEN],
-        pub_keys: &[&[u8; BLS_PUB_LEN]],
-        digests: &[&[u8; BLS_DIGEST_LEN]],
+        pub_keys: &[[u8; BLS_PUB_LEN]],
+        digests: &[[u8; BLS_DIGEST_LEN]],
     ) -> Result<bool>;
 
     /// Given a message hash and its signature, recovers the public key of the signer.

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -6,7 +6,8 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::signature::{
-    SignatureType, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
+    SignatureType, BLS_DIGEST_LEN, BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN,
+    SECP_SIG_MESSAGE_HASH_SIZE,
 };
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -263,6 +264,13 @@ pub trait CryptoOps {
         signature: &[u8],
         signer: &Address,
         plaintext: &[u8],
+    ) -> Result<bool>;
+
+    fn verify_bls_aggregate(
+        &self,
+        aggregate_signature: &[u8; BLS_SIG_LEN],
+        pub_keys: &[[u8; BLS_PUB_LEN]],
+        digests: &[[u8; BLS_DIGEST_LEN]],
     ) -> Result<bool>;
 
     /// Given a message hash and its signature, recovers the public key of the signer.

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -6,7 +6,7 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::signature::{
-    SignatureType, BLS_DIGEST_LEN, BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN,
+    BLS_DIGEST_LEN, BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN,
     SECP_SIG_MESSAGE_HASH_SIZE,
 };
 use fvm_shared::econ::TokenAmount;
@@ -257,20 +257,11 @@ pub trait GasOps {
 
 /// Cryptographic primitives provided by the kernel.
 pub trait CryptoOps {
-    /// Verifies that a signature is valid for an address and plaintext.
-    fn verify_signature(
-        &self,
-        sig_type: SignatureType,
-        signature: &[u8],
-        signer: &Address,
-        plaintext: &[u8],
-    ) -> Result<bool>;
-
     fn verify_bls_aggregate(
         &self,
-        aggregate_signature: &[u8; BLS_SIG_LEN],
-        pub_keys: &[[u8; BLS_PUB_LEN]],
-        digests: &[[u8; BLS_DIGEST_LEN]],
+        aggregate_sig: &[u8; BLS_SIG_LEN],
+        pub_keys: &[&[u8; BLS_PUB_LEN]],
+        digests: &[&[u8; BLS_DIGEST_LEN]],
     ) -> Result<bool>;
 
     /// Given a message hash and its signature, recovers the public key of the signer.

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -373,5 +373,10 @@ pub trait LimiterOps {
 /// Eventing APIs.
 pub trait EventOps {
     /// Records an event emitted throughout execution.
-    fn emit_event(&mut self, raw_evt: &[u8]) -> Result<()>;
+    fn emit_event(
+        &mut self,
+        event_headers: &[fvm_shared::sys::EventEntry],
+        raw_key: &[u8],
+        raw_val: &[u8],
+    ) -> Result<()>;
 }

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -268,7 +268,8 @@ pub trait CryptoOps {
         &self,
         aggregate_sig: &[u8; BLS_SIG_LEN],
         pub_keys: &[[u8; BLS_PUB_LEN]],
-        plaintexts: &[&[u8]],
+        plaintexts_concat: &[u8],
+        plaintext_lens: &[u32],
     ) -> Result<bool>;
 
     /// Given a message hash and its signature, recovers the public key of the signer.

--- a/fvm/src/syscalls/event.rs
+++ b/fvm/src/syscalls/event.rs
@@ -1,12 +1,23 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use anyhow::Context as _;
+
 use super::Context;
-use crate::kernel::Result;
+use crate::kernel::{ClassifyResult, Result};
 use crate::Kernel;
 
-/// Emits an actor event. It takes an DAG-CBOR encoded ActorEvent that has been
-/// written to Wasm memory, as an offset and length tuple.
+/// Emits an actor event. The event is split into three raw byte buffers that have
+/// been written to Wasm memory. This is done so that the FVM can accurately charge
+/// for gas without needing to parse anything inside the FVM.
+/// The buffers are serialized as follows:
+///  - event_off/event_len: The offset and length tuple of all the event entries
+///       flags:u64,key_len:u32,codec:u64,value_len:u32)
+///  - key_off/key_len: The offset and length tuple of all entry keys in the event
+///  - val_off/val_len: The offset and length tuple of all entry values in the event
+///
+/// During deserialization, the key_len/value_len stored in each entry will be used
+/// to parse the keys and values from the key/value buffers.
 ///
 /// The FVM validates the structural, syntatic, and semantic correctness of the
 /// supplied event, and errors with `IllegalArgument` if the payload was invalid.
@@ -15,9 +26,28 @@ use crate::Kernel;
 /// if such condition arises.
 pub fn emit_event(
     context: Context<'_, impl Kernel>,
-    event_off: u32, // ActorEvent
+    event_off: u32,
     event_len: u32,
+    key_off: u32,
+    key_len: u32,
+    val_off: u32,
+    val_len: u32,
 ) -> Result<()> {
-    let raw = context.memory.try_slice(event_off, event_len)?;
-    context.kernel.emit_event(raw)
+    let event_headers = unsafe {
+        const EVENT_SIZE: u32 = std::mem::size_of::<fvm_shared::sys::EventEntry>() as u32;
+        // assert the alignment so we can safely cast from a byte-slice
+        static_assertions::assert_eq_align!(fvm_shared::sys::EventEntry, u8);
+        let size = event_len
+            .checked_mul(EVENT_SIZE)
+            .context("events index out of bounds")
+            .or_illegal_argument()?;
+        let buf = context.memory.try_slice(event_off, size)?;
+        std::slice::from_raw_parts(
+            buf.as_ptr() as *const fvm_shared::sys::EventEntry,
+            event_len as usize,
+        )
+    };
+    let raw_key = context.memory.try_slice(key_off, key_len)?;
+    let raw_val = context.memory.try_slice(val_off, val_len)?;
+    context.kernel.emit_event(event_headers, raw_key, raw_val)
 }

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -286,7 +286,6 @@ pub fn bind_syscalls(
     #[cfg(feature = "m2-native")]
     linker.bind("actor", "install_actor", actor::install_actor)?;
 
-    linker.bind("crypto", "verify_signature", crypto::verify_signature)?;
     linker.bind(
         "crypto",
         "verify_bls_aggregate",

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -289,6 +289,11 @@ pub fn bind_syscalls(
     linker.bind("crypto", "verify_signature", crypto::verify_signature)?;
     linker.bind(
         "crypto",
+        "verify_bls_aggregate",
+        crypto::verify_bls_aggregate,
+    )?;
+    linker.bind(
+        "crypto",
         "recover_secp_public_key",
         crypto::recover_secp_public_key,
     )?;

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -19,6 +19,7 @@ lazy_static = { version = "1.4.0" }
 log = "0.4.19"
 thiserror = "1.0.40"
 fvm_ipld_encoding = { version = "0.4", path = "../ipld/encoding" }
+byteorder = "1.4.3"
 
 [features]
 default = []

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -98,10 +98,10 @@ pub fn verify_bls_aggregate(
     unsafe {
         sys::crypto::verify_bls_aggregate(
             num_signers,
-            sig.as_ptr() as *const u8,
-            pub_keys.as_ptr() as *const u8,
-            plaintext_lens.as_ptr() as *const u8,
-            plaintexts_concat.as_ptr() as *const u8,
+            sig.as_ptr(),
+            pub_keys.as_ptr(),
+            plaintexts_concat.as_ptr(),
+            plaintext_lens.as_ptr(),
         )
         .map(status_code_to_bool)
     }

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -6,7 +6,8 @@ use fvm_shared::address::Address;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::hash::SupportedHashes;
 use fvm_shared::crypto::signature::{
-    Signature, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
+    Signature, BLS_DIGEST_LEN, BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN,
+    SECP_SIG_MESSAGE_HASH_SIZE,
 };
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::{
@@ -38,6 +39,22 @@ pub fn verify_signature(
             signer.len() as u32,
             plaintext.as_ptr(),
             plaintext.len() as u32,
+        )
+        .map(status_code_to_bool)
+    }
+}
+
+pub fn verify_bls_aggregate(
+    sig: &[u8; BLS_SIG_LEN],
+    pub_keys: &[[u8; BLS_PUB_LEN]],
+    digests: &[[u8; BLS_DIGEST_LEN]],
+) -> SyscallResult<bool> {
+    unsafe {
+        sys::crypto::verify_bls_aggregate(
+            pub_keys.len() as u32,
+            sig.as_ptr() as *const u8,
+            pub_keys.as_ptr() as *const u8,
+            digests.as_ptr() as *const u8,
         )
         .map(status_code_to_bool)
     }

--- a/sdk/src/event.rs
+++ b/sdk/src/event.rs
@@ -1,12 +1,47 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
+use crate::{sys, SyscallResult};
 use fvm_shared::event::ActorEvent;
 
-use crate::{sys, SyscallResult};
-
 pub fn emit_event(evt: &ActorEvent) -> SyscallResult<()> {
-    let encoded = fvm_ipld_encoding::to_vec(evt).expect("failed to marshal actor event");
-    let entries = encoded.as_slice();
+    // we manually serialize the ActorEvent (not using CBOR) into three byte arrays so
+    // we can accurately charge gas without needing to parse anything inside the FVM
+    let mut total_key_len: usize = 0;
+    let mut total_val_len: usize = 0;
 
-    unsafe { sys::event::emit_event(entries.as_ptr(), entries.len() as u32) }
+    let mut fixed_entries = Vec::with_capacity(evt.entries.len());
+    for i in 0..evt.entries.len() {
+        let e = &evt.entries[i];
+
+        fixed_entries.push(fvm_shared::sys::EventEntry {
+            flags: e.flags,
+            codec: e.codec,
+            key_len: e.key.len() as u32,
+            val_len: e.value.len() as u32,
+        });
+
+        total_key_len += e.key.len();
+        total_val_len += e.value.len();
+    }
+
+    let mut keys = Vec::with_capacity(total_key_len);
+    for i in 0..evt.entries.len() {
+        keys.extend_from_slice(evt.entries[i].key.as_bytes());
+    }
+
+    let mut values = Vec::with_capacity(total_val_len);
+    for i in 0..evt.entries.len() {
+        values.extend_from_slice(evt.entries[i].value.as_slice());
+    }
+
+    unsafe {
+        sys::event::emit_event(
+            fixed_entries.as_ptr(),
+            fixed_entries.len() as u32,
+            keys.as_ptr(),
+            keys.len() as u32,
+            values.as_ptr(),
+            values.len() as u32,
+        )
+    }
 }

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -23,18 +23,20 @@ super::fvm_syscalls! {
     /// - `num_signers` the number of signatures aggregated.
     /// - `sig_off` specifies the location of the aggregate signature.
     /// - `pub_keys_off` specifies the location of the signers' BLS public keys.
-    /// - `digests_off` specifies the location of the digests of the data that were signed.
+    /// - `plaintext_lens_off` specifies the location of the plaintexts' lengths.
+    /// - `plaintexts_off` specifies the location of the concatenated plaintexts.
     ///
     /// # Errors
     ///
-    /// | Error               | Reason                                                 |
-    /// |---------------------|--------------------------------------------------------|
-    /// | [`IllegalArgument`] | signature, public keys, or digests buffers are invalid |
+    /// | Error               | Reason                                                    |
+    /// |---------------------|-----------------------------------------------------------|
+    /// | [`IllegalArgument`] | signature, public keys, or plaintexts buffers are invalid |
     pub fn verify_bls_aggregate(
         num_signers: u32,
         sig_off: *const u8,
         pub_keys_off: *const u8,
-        digests_off: *const u8,
+        plaintext_lens_off: *const u8,
+        plaintexts_off: *const u8,
     ) -> Result<i32>;
 
     /// Recovers the signer public key from a signed message hash and its signature.

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for cryptographic operations.
 
-use fvm_shared::crypto::signature::SECP_PUB_LEN;
+use fvm_shared::crypto::signature::{BLS_PUB_LEN, SECP_PUB_LEN};
 #[doc(inline)]
 pub use fvm_shared::sys::out::crypto::*;
 
@@ -34,9 +34,9 @@ super::fvm_syscalls! {
     pub fn verify_bls_aggregate(
         num_signers: u32,
         sig_off: *const u8,
-        pub_keys_off: *const u8,
-        plaintext_lens_off: *const u8,
+        pub_keys_off: *const [u8; BLS_PUB_LEN],
         plaintexts_off: *const u8,
+        plaintext_lens_off: *const u32,
     ) -> Result<i32>;
 
     /// Recovers the signer public key from a signed message hash and its signature.

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -13,31 +13,6 @@ use crate::sys::ErrorNumber::*;
 super::fvm_syscalls! {
     module = "crypto";
 
-    /// Verifies that a signature is valid for an f1 or f3 address and plaintext.
-    ///
-    /// Returns 0 on success, or -1 if the signature fails to validate.
-    ///
-    /// # Arguments
-    ///
-    /// - `sig_off` and `sig_len` specify location and length of the signature.
-    /// - `addr_off` and `addr_len` specify location and length of expected signer's address.
-    /// - `plaintext_off` and `plaintext_len` specify location and length of the signed data.
-    ///
-    /// # Errors
-    ///
-    /// | Error               | Reason                                               |
-    /// |---------------------|------------------------------------------------------|
-    /// | [`IllegalArgument`] | signature, address, or plaintext buffers are invalid |
-    pub fn verify_signature(
-        sig_type: u32,
-        sig_off: *const u8,
-        sig_len: u32,
-        addr_off: *const u8,
-        addr_len: u32,
-        plaintext_off: *const u8,
-        plaintext_len: u32,
-    ) -> Result<i32>;
-
     /// Verifies that a BLS aggregate signature is valid for a list of signers' BLS public keys and
     /// and the digest of each signer's plaintext.
     ///

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -38,6 +38,30 @@ super::fvm_syscalls! {
         plaintext_len: u32,
     ) -> Result<i32>;
 
+    /// Verifies that a BLS aggregate signature is valid for a list of signers' BLS public keys and
+    /// and the digest of each signer's plaintext.
+    ///
+    /// Returns 0 on success, or -1 if the signature fails to validate.
+    ///
+    /// # Arguments
+    ///
+    /// - `num_signers` the number of signatures aggregated.
+    /// - `sig_off` specifies the location of the aggregate signature.
+    /// - `pub_keys_off` specifies the location of the signers' BLS public keys.
+    /// - `digests_off` specifies the location of the digests of the data that were signed.
+    ///
+    /// # Errors
+    ///
+    /// | Error               | Reason                                                 |
+    /// |---------------------|--------------------------------------------------------|
+    /// | [`IllegalArgument`] | signature, public keys, or digests buffers are invalid |
+    pub fn verify_bls_aggregate(
+        num_signers: u32,
+        sig_off: *const u8,
+        pub_keys_off: *const u8,
+        digests_off: *const u8,
+    ) -> Result<i32>;
+
     /// Recovers the signer public key from a signed message hash and its signature.
     ///
     /// Returns the public key in uncompressed 65 bytes form.

--- a/sdk/src/sys/event.rs
+++ b/sdk/src/sys/event.rs
@@ -6,20 +6,27 @@
 #[cfg(doc)]
 use crate::sys::ErrorNumber::*;
 
+// For documentation
+#[doc(inline)]
+pub use fvm_shared::sys::EventEntry;
+
 super::fvm_syscalls! {
     module = "event";
 
     /// Emits an actor event to be recorded in the receipt.
-    ///
-    /// Expects a DAG-CBOR representation of the ActorEvent struct.
     ///
     /// # Errors
     ///
     /// | Error               | Reason                                                              |
     /// |---------------------|---------------------------------------------------------------------|
     /// | [`IllegalArgument`] | entries failed to validate due to improper encoding or invalid data |
+    /// | [`ReadOnly`]        | cannot send events while read-only                                  |
     pub fn emit_event(
-        evt_off: *const u8,
+        evt_off: *const EventEntry,
         evt_len: u32,
+        key_off: *const u8,
+        key_len: u32,
+        value_off: *const u8,
+        value_len: u32,
     ) -> Result<()>;
 }

--- a/shared/src/event/mod.rs
+++ b/shared/src/event/mod.rs
@@ -39,6 +39,7 @@ impl From<Vec<Entry>> for ActorEvent {
 bitflags! {
     /// Flags associated with an Event entry.
     #[derive(Deserialize, Serialize, Copy, Clone, Eq, PartialEq, Debug)]
+    #[repr(transparent)] // we pass this type through a syscall
     #[serde(transparent)]
     pub struct Flags: u64 {
         const FLAG_INDEXED_KEY      = 0b00000001;

--- a/shared/src/sys/mod.rs
+++ b/shared/src/sys/mod.rs
@@ -67,6 +67,16 @@ impl SendFlags {
     }
 }
 
+/// A fixed sized struct for serializing an [event `Entry`](crate::event::Entry) separately from the
+/// key/value bytes.
+#[repr(C, packed)]
+pub struct EventEntry {
+    pub flags: crate::event::Flags,
+    pub codec: u64,
+    pub key_len: u32,
+    pub val_len: u32,
+}
+
 /// An unsafe trait to mark "syscall safe" types. These types must be safe to memcpy to and from
 /// WASM. This means:
 ///

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -364,8 +364,8 @@ where
     fn verify_bls_aggregate(
         &self,
         aggregate_signature: &[u8; BLS_SIG_LEN],
-        pub_keys: &[&[u8; BLS_PUB_LEN]],
-        digests: &[&[u8; BLS_DIGEST_LEN]],
+        pub_keys: &[[u8; BLS_PUB_LEN]],
+        digests: &[[u8; BLS_DIGEST_LEN]],
     ) -> Result<bool> {
         self.0
             .verify_bls_aggregate(aggregate_signature, pub_keys, digests)

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -28,7 +28,7 @@ use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, ReplicaUpdateInfo, SealVerifyInfo,
     WindowPoStVerifyInfo,
 };
-use fvm_shared::sys::SendFlags;
+use fvm_shared::sys::{EventEntry, SendFlags};
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum, TOTAL_FILECOIN};
 
@@ -564,8 +564,13 @@ where
     C: CallManager<Machine = TestMachine<M>>,
     K: Kernel<CallManager = C>,
 {
-    fn emit_event(&mut self, raw_evt: &[u8]) -> Result<()> {
-        self.0.emit_event(raw_evt)
+    fn emit_event(
+        &mut self,
+        event_headers: &[EventEntry],
+        key_evt: &[u8],
+        val_evt: &[u8],
+    ) -> Result<()> {
+        self.0.emit_event(event_headers, key_evt, val_evt)
     }
 }
 

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -364,10 +364,15 @@ where
         &self,
         aggregate_signature: &[u8; BLS_SIG_LEN],
         pub_keys: &[[u8; BLS_PUB_LEN]],
-        plaintexts: &[&[u8]],
+        plaintexts_concat: &[u8],
+        plaintext_lens: &[u32],
     ) -> Result<bool> {
-        self.0
-            .verify_bls_aggregate(aggregate_signature, pub_keys, plaintexts)
+        self.0.verify_bls_aggregate(
+            aggregate_signature,
+            pub_keys,
+            plaintexts_concat,
+            plaintext_lens,
+        )
     }
 
     // forwarded

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -19,7 +19,8 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::signature::{
-    SignatureType, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
+    SignatureType, BLS_DIGEST_LEN, BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN,
+    SECP_SIG_MESSAGE_HASH_SIZE,
 };
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PieceInfo;
@@ -369,6 +370,17 @@ where
     ) -> Result<bool> {
         self.0
             .verify_signature(sig_type, signature, signer, plaintext)
+    }
+
+    // forwarded
+    fn verify_bls_aggregate(
+        &self,
+        aggregate_signature: &[u8; BLS_SIG_LEN],
+        pub_keys: &[[u8; BLS_PUB_LEN]],
+        digests: &[[u8; BLS_DIGEST_LEN]],
+    ) -> Result<bool> {
+        self.0
+            .verify_bls_aggregate(aggregate_signature, pub_keys, digests)
     }
 
     // forwarded

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -19,7 +19,7 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::signature::{
-    SignatureType, BLS_DIGEST_LEN, BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN,
+    BLS_DIGEST_LEN, BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN,
     SECP_SIG_MESSAGE_HASH_SIZE,
 };
 use fvm_shared::econ::TokenAmount;
@@ -361,23 +361,11 @@ where
     }
 
     // forwarded
-    fn verify_signature(
-        &self,
-        sig_type: SignatureType,
-        signature: &[u8],
-        signer: &Address,
-        plaintext: &[u8],
-    ) -> Result<bool> {
-        self.0
-            .verify_signature(sig_type, signature, signer, plaintext)
-    }
-
-    // forwarded
     fn verify_bls_aggregate(
         &self,
         aggregate_signature: &[u8; BLS_SIG_LEN],
-        pub_keys: &[[u8; BLS_PUB_LEN]],
-        digests: &[[u8; BLS_DIGEST_LEN]],
+        pub_keys: &[&[u8; BLS_PUB_LEN]],
+        digests: &[&[u8; BLS_DIGEST_LEN]],
     ) -> Result<bool> {
         self.0
             .verify_bls_aggregate(aggregate_signature, pub_keys, digests)

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -19,8 +19,7 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::signature::{
-    BLS_DIGEST_LEN, BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN,
-    SECP_SIG_MESSAGE_HASH_SIZE,
+    BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
 };
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PieceInfo;
@@ -365,10 +364,10 @@ where
         &self,
         aggregate_signature: &[u8; BLS_SIG_LEN],
         pub_keys: &[[u8; BLS_PUB_LEN]],
-        digests: &[[u8; BLS_DIGEST_LEN]],
+        plaintexts: &[&[u8]],
     ) -> Result<bool> {
         self.0
-            .verify_bls_aggregate(aggregate_signature, pub_keys, digests)
+            .verify_bls_aggregate(aggregate_signature, pub_keys, plaintexts)
     }
 
     // forwarded

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -33,7 +33,7 @@ default-features = false
 features = ["cranelift", "parallel-compilation"]
 
 [dev-dependencies]
-actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }
+actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
 fvm_test_actors = { path = "../test_actors" }
 fvm_gas_calibration_shared = { path = "../calibration/shared" }
 blake2b_simd = "1.0.1"

--- a/testing/integration/tests/events_test.rs
+++ b/testing/integration/tests/events_test.rs
@@ -36,7 +36,11 @@ fn events_test() {
         .execute_message(message.clone(), ApplyKind::Explicit, 100)
         .unwrap();
 
-    assert_eq!(ExitCode::OK, res.msg_receipt.exit_code);
+    assert!(
+        res.msg_receipt.exit_code.is_success(),
+        "{:?}",
+        res.failure_info
+    );
 
     let gas_used = res.msg_receipt.gas_used;
 

--- a/testing/integration/tests/gasfuzz.rs
+++ b/testing/integration/tests/gasfuzz.rs
@@ -88,7 +88,11 @@ fn gasfuzz_get_exec_trace() -> ExecutionTrace {
         .unwrap();
 
     let create_res = testkit::fevm::create_contract(&mut tester, &mut account, &contract).unwrap();
-    assert!(create_res.msg_receipt.exit_code.is_success());
+    assert!(
+        create_res.msg_receipt.exit_code.is_success(),
+        "{:?}",
+        create_res.failure_info
+    );
 
     let create_return: testkit::fevm::CreateReturn =
         create_res.msg_receipt.return_data.deserialize().unwrap();

--- a/testing/test_actors/actors/fil-create-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-create-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
 fvm_shared = { version = "3.4.0", path = "../../../../shared" }
-actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }
+actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-events-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-events-actor/src/actor.rs
@@ -50,12 +50,23 @@ pub fn invoke(params: u32) -> u32 {
             sdk::event::emit_event(&multi_entry.into()).unwrap();
         }
         EMIT_MALFORMED => unsafe {
-            // mangle an event.
-            let mut serialized = fvm_ipld_encoding::to_vec(&single_entry_evt).unwrap();
-            serialized[1] = 0xff;
-
+            // Trigger an out of bounds.
+            let entry = fvm_shared::sys::EventEntry {
+                flags: Flags::empty(),
+                codec: IPLD_RAW,
+                key_len: 5,
+                val_len: 0,
+            };
             assert!(
-                sdk::sys::event::emit_event(serialized.as_ptr(), serialized.len() as u32).is_err(),
+                sdk::sys::event::emit_event(
+                    &entry as *const fvm_shared::sys::EventEntry,
+                    1,
+                    0 as *const u8,
+                    4,
+                    0 as *const u8,
+                    0,
+                )
+                .is_err(),
                 "expected failed syscall"
             );
         },

--- a/testing/test_actors/actors/fil-events-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-events-actor/src/actor.rs
@@ -1,5 +1,7 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
+use std::ptr;
+
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::IPLD_RAW;
 use fvm_sdk as sdk;
@@ -61,9 +63,9 @@ pub fn invoke(params: u32) -> u32 {
                 sdk::sys::event::emit_event(
                     &entry as *const fvm_shared::sys::EventEntry,
                     1,
-                    0 as *const u8,
+                    ptr::null(),
                     4,
-                    0 as *const u8,
+                    ptr::null(),
                     0,
                 )
                 .is_err(),

--- a/testing/test_actors/actors/fil-gas-calibration-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-gas-calibration-actor/src/actor.rs
@@ -107,11 +107,11 @@ fn on_verify_signature(p: OnVerifySignatureParams) -> Result<()> {
         bytes: p.signature,
     };
 
-    let mut digest = random_bytes(p.size, p.seed);
+    let mut data = random_bytes(p.size, p.seed);
 
     for i in 0..p.iterations {
-        random_mutations(&mut digest, p.seed + i as u64, MUTATION_COUNT);
-        fvm_sdk::crypto::verify_signature(&sig, &p.signer, &digest)?;
+        random_mutations(&mut data, p.seed + i as u64, MUTATION_COUNT);
+        fvm_sdk::crypto::verify_signature(&sig, &p.signer, &data)?;
     }
 
     Ok(())

--- a/testing/test_actors/actors/fil-gas-calibration-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-gas-calibration-actor/src/actor.rs
@@ -107,11 +107,11 @@ fn on_verify_signature(p: OnVerifySignatureParams) -> Result<()> {
         bytes: p.signature,
     };
 
-    let mut data = random_bytes(p.size, p.seed);
+    let mut digest = random_bytes(p.size, p.seed);
 
     for i in 0..p.iterations {
-        random_mutations(&mut data, p.seed + i as u64, MUTATION_COUNT);
-        fvm_sdk::crypto::verify_signature(&sig, &p.signer, &data)?;
+        random_mutations(&mut digest, p.seed + i as u64, MUTATION_COUNT);
+        fvm_sdk::crypto::verify_signature(&sig, &[p.signer], &[&digest])?;
     }
 
     Ok(())

--- a/testing/test_actors/actors/fil-gas-calibration-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-gas-calibration-actor/src/actor.rs
@@ -111,7 +111,7 @@ fn on_verify_signature(p: OnVerifySignatureParams) -> Result<()> {
 
     for i in 0..p.iterations {
         random_mutations(&mut digest, p.seed + i as u64, MUTATION_COUNT);
-        fvm_sdk::crypto::verify_signature(&sig, &[p.signer], &[&digest])?;
+        fvm_sdk::crypto::verify_signature(&sig, &p.signer, &digest)?;
     }
 
     Ok(())

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -9,7 +9,7 @@ fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
 fvm_shared = { version = "3.4.0", path = "../../../../shared" }
 minicov = {version = "0.3", optional = true}
-actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }
+actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
 multihash = { workspace = true }
 
 [lib]

--- a/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
@@ -99,8 +99,8 @@ fn test_secp_signature() {
 
     // test we can recover the public key from the signature
     //
-    let sig: &[u8; SECP_SIG_LEN] = signature_bytes.as_slice().try_into().unwrap();
     let digest: &[u8; SECP_SIG_MESSAGE_HASH_SIZE] = digest.as_slice().try_into().unwrap();
+    let sig: &[u8; SECP_SIG_LEN] = signature_bytes.as_slice().try_into().unwrap();
     let res = sdk::crypto::recover_secp_public_key(digest, sig).unwrap();
     assert_eq!(res, pub_key_bytes.as_slice());
 
@@ -179,28 +179,24 @@ fn test_bls_aggregate() {
     };
     assert_eq!(res, Ok(true));
 
-    // Test SDK's bls aggregate signature validation syscall.
-    let pub_keys = [&pub_keys[0], &pub_keys[1], &pub_keys[2]];
-    let digests = [&digests[0], &digests[1], &digests[2]];
-
-    // Assert that signature validation syscall succeeds.
+    // Assert that bls validation syscall succeeds.
     let res = sdk::crypto::verify_bls_aggregate(&sig, &pub_keys, &digests);
     assert_eq!(res, Ok(true));
 
     // Both BLS signatures and digests are a G2 point, thus we can use a valid digest's bytes as the
     // G2 bytes for an incorrect signature (and vice versa).
     let invalid_sig = digests[0];
-    let invalid_digests = [&sig, digests[1], digests[2]];
+    let invalid_digests = [sig, digests[1], digests[2]];
 
-    // Assert that syscall validation fails for an invalid aggregate signature.
-    let res = sdk::crypto::verify_bls_aggregate(invalid_sig, &pub_keys, &digests);
+    // Assert that bls validation syscall fails for an invalid aggregate signature.
+    let res = sdk::crypto::verify_bls_aggregate(&invalid_sig, &pub_keys, &digests);
     assert_eq!(res, Ok(false));
 
-    // Assert that syscall validation fails for an invalid message digest.
+    // Assert that bls validation syscall fails for an invalid message digest.
     let res = sdk::crypto::verify_bls_aggregate(&sig, &pub_keys, &invalid_digests);
     assert_eq!(res, Ok(false));
 
-    // Assert that syscall validation fails for an invalid public key.
+    // Assert that bls validation syscall fails for an invalid public key.
     let invalid_pub_keys = [pub_keys[0], pub_keys[0], pub_keys[2]];
     let res = sdk::crypto::verify_bls_aggregate(&sig, &invalid_pub_keys, &digests);
     assert_eq!(res, Ok(false));

--- a/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
@@ -6,7 +6,7 @@ use fvm_shared::address::Address;
 use fvm_shared::chainid::ChainID;
 use fvm_shared::crypto::hash::SupportedHashes as SharedSupportedHashes;
 use fvm_shared::crypto::signature::{
-    Signature, BLS_DIGEST_LEN, BLS_PUB_LEN, BLS_SIG_LEN, SECP_SIG_LEN,
+    Signature, BLS_DIGEST_LEN, BLS_PUB_LEN, BLS_SIG_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
 };
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::sector::RegisteredSealProof;
@@ -34,7 +34,7 @@ pub enum SupportedHashes {
 pub fn invoke(_: u32) -> u32 {
     sdk::initialize();
 
-    test_signature();
+    test_secp_signature();
     test_bls_aggregate();
     test_expected_hash();
     test_hash_syscall();
@@ -49,7 +49,7 @@ pub fn invoke(_: u32) -> u32 {
     0
 }
 
-fn test_signature() {
+fn test_secp_signature() {
     // the following vectors represent a valid secp256k1 signatures for an address and plaintext message
     //
     let signature_bytes: Vec<u8> = vec![
@@ -65,12 +65,13 @@ fn test_signature() {
         194, 146, 27, 16, 114,
     ];
     let message: Vec<u8> = vec![3, 1, 4, 1, 5, 9, 2, 6, 5, 3];
+    let digest = sdk::crypto::hash_blake2b(&message);
 
     // test the happy path
     //
     let signature = Signature::new_secp256k1(signature_bytes.clone());
     let address = Address::new_secp256k1(&pub_key_bytes).unwrap();
-    let res = sdk::crypto::verify_signature(&signature, &address, message.as_slice());
+    let res = sdk::crypto::verify_signature(&signature, &[address], &[&digest]);
     assert_eq!(res, Ok(true));
 
     // test with invalid signature
@@ -78,7 +79,7 @@ fn test_signature() {
     let mut invalid_signature_bytes = signature_bytes.clone();
     invalid_signature_bytes[0] += 1;
     let invalid_signature = Signature::new_secp256k1(invalid_signature_bytes.clone());
-    let res = sdk::crypto::verify_signature(&invalid_signature, &address, message.as_slice());
+    let res = sdk::crypto::verify_signature(&invalid_signature, &[address], &[&digest]);
     assert_eq!(res, Ok(false));
 
     // test with invalid address
@@ -86,60 +87,28 @@ fn test_signature() {
     let mut invalid_pub_key_bytes = pub_key_bytes.clone();
     invalid_pub_key_bytes[0] += 1;
     let invalid_address = Address::new_secp256k1(&invalid_pub_key_bytes).unwrap();
-    let res = sdk::crypto::verify_signature(&signature, &invalid_address, message.as_slice());
+    let res = sdk::crypto::verify_signature(&signature, &[invalid_address], &[&digest]);
     assert_eq!(res, Ok(false));
 
-    // test with invalid message
+    // test with invalid digest
     //
-    let mut invalid_message = message.clone();
-    invalid_message[0] += 1;
-    let res = sdk::crypto::verify_signature(&signature, &address, invalid_message.as_slice());
+    let mut invalid_digest = digest;
+    invalid_digest[0] += 1;
+    let res = sdk::crypto::verify_signature(&signature, &[address], &[&invalid_digest]);
     assert_eq!(res, Ok(false));
-
-    // test that calling sdk::sys::crypto::verify_signature with invalid parameters result
-    // in correct error value
-    //
-    unsafe {
-        let sig_type = signature.signature_type();
-        let sig_bytes = signature.bytes();
-        let signer = address.to_bytes();
-
-        // test invalid signature type
-        let res = sdk::sys::crypto::verify_signature(
-            u32::MAX,
-            sig_bytes.as_ptr(),
-            sig_bytes.len() as u32,
-            signer.as_ptr(),
-            signer.len() as u32,
-            message.as_ptr(),
-            message.len() as u32,
-        );
-        assert_eq!(res, Err(ErrorNumber::IllegalArgument));
-
-        // test invalid signature ptr
-        let res = sdk::sys::crypto::verify_signature(
-            sig_type as u32,
-            sig_bytes.as_ptr(),
-            sig_bytes.len() as u32,
-            (u32::MAX) as *const u8,
-            signer.len() as u32,
-            message.as_ptr(),
-            message.len() as u32,
-        );
-        assert_eq!(res, Err(ErrorNumber::IllegalArgument));
-    }
 
     // test we can recover the public key from the signature
     //
-    let hash = sdk::crypto::hash_blake2b(&message);
-    let sig: [u8; SECP_SIG_LEN] = signature_bytes.try_into().unwrap();
-    let res = sdk::crypto::recover_secp_public_key(&hash, &sig).unwrap();
+    let sig: &[u8; SECP_SIG_LEN] = signature_bytes.as_slice().try_into().unwrap();
+    let digest: &[u8; SECP_SIG_MESSAGE_HASH_SIZE] = digest.as_slice().try_into().unwrap();
+    let res = sdk::crypto::recover_secp_public_key(digest, sig).unwrap();
     assert_eq!(res, pub_key_bytes.as_slice());
 
     // test that passing an invalid hash buffer results in IllegalArgument
     //
     unsafe {
-        let res = sdk::sys::crypto::recover_secp_public_key(hash.as_ptr(), (u32::MAX) as *const u8);
+        let res =
+            sdk::sys::crypto::recover_secp_public_key(digest.as_ptr(), (u32::MAX) as *const u8);
         assert_eq!(res, Err(ErrorNumber::IllegalArgument));
     }
 }
@@ -198,24 +167,40 @@ fn test_bls_aggregate() {
         255, 107, 98, 100, 207, 63, 75, 188, 34, 162, 170, 237, 188, 68, 170, 53, 11, 200, 124,
     ];
 
-    // Assert that signature validation succeeds.
+    // Assert that `sdk::crypto::verify_signature` succeeds for BLS signatures.
+    let res = {
+        let sig = Signature::new_bls(sig.to_vec());
+        let addrs: Vec<Address> = pub_keys
+            .iter()
+            .map(|pub_key| Address::new_bls(pub_key).unwrap())
+            .collect();
+        let digests: Vec<&[u8]> = digests.iter().map(|digest| digest.as_slice()).collect();
+        sdk::crypto::verify_signature(&sig, &addrs, &digests)
+    };
+    assert_eq!(res, Ok(true));
+
+    // Test SDK's bls aggregate signature validation syscall.
+    let pub_keys = [&pub_keys[0], &pub_keys[1], &pub_keys[2]];
+    let digests = [&digests[0], &digests[1], &digests[2]];
+
+    // Assert that signature validation syscall succeeds.
     let res = sdk::crypto::verify_bls_aggregate(&sig, &pub_keys, &digests);
     assert_eq!(res, Ok(true));
 
     // Both BLS signatures and digests are a G2 point, thus we can use a valid digest's bytes as the
-    // G2 bytes for an invalid signature (and vice versa).
+    // G2 bytes for an incorrect signature (and vice versa).
     let invalid_sig = digests[0];
-    let invalid_digests = [sig, digests[1], digests[2]];
+    let invalid_digests = [&sig, digests[1], digests[2]];
 
-    // Assert that validation fails for an invalid aggregate signature.
-    let res = sdk::crypto::verify_bls_aggregate(&invalid_sig, &pub_keys, &digests);
+    // Assert that syscall validation fails for an invalid aggregate signature.
+    let res = sdk::crypto::verify_bls_aggregate(invalid_sig, &pub_keys, &digests);
     assert_eq!(res, Ok(false));
 
-    // Assert that signature validation fails for an invalid message digest.
+    // Assert that syscall validation fails for an invalid message digest.
     let res = sdk::crypto::verify_bls_aggregate(&sig, &pub_keys, &invalid_digests);
     assert_eq!(res, Ok(false));
 
-    // Assert that signature validation fails for an invalid public key.
+    // Assert that syscall validation fails for an invalid public key.
     let invalid_pub_keys = [pub_keys[0], pub_keys[0], pub_keys[2]];
     let res = sdk::crypto::verify_bls_aggregate(&sig, &invalid_pub_keys, &digests);
     assert_eq!(res, Ok(false));

--- a/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
@@ -35,6 +35,7 @@ pub fn invoke(_: u32) -> u32 {
     sdk::initialize();
 
     test_secp_signature();
+    test_bls_signature();
     test_bls_aggregate();
     test_expected_hash();
     test_hash_syscall();
@@ -71,7 +72,7 @@ fn test_secp_signature() {
     //
     let signature = Signature::new_secp256k1(signature_bytes.clone());
     let address = Address::new_secp256k1(&pub_key_bytes).unwrap();
-    let res = sdk::crypto::verify_signature(&signature, &[address], &[&digest]);
+    let res = sdk::crypto::verify_signature(&signature, &address, &digest);
     assert_eq!(res, Ok(true));
 
     // test with invalid signature
@@ -79,7 +80,7 @@ fn test_secp_signature() {
     let mut invalid_signature_bytes = signature_bytes.clone();
     invalid_signature_bytes[0] += 1;
     let invalid_signature = Signature::new_secp256k1(invalid_signature_bytes.clone());
-    let res = sdk::crypto::verify_signature(&invalid_signature, &[address], &[&digest]);
+    let res = sdk::crypto::verify_signature(&invalid_signature, &address, &digest);
     assert_eq!(res, Ok(false));
 
     // test with invalid address
@@ -87,14 +88,14 @@ fn test_secp_signature() {
     let mut invalid_pub_key_bytes = pub_key_bytes.clone();
     invalid_pub_key_bytes[0] += 1;
     let invalid_address = Address::new_secp256k1(&invalid_pub_key_bytes).unwrap();
-    let res = sdk::crypto::verify_signature(&signature, &[invalid_address], &[&digest]);
+    let res = sdk::crypto::verify_signature(&signature, &invalid_address, &digest);
     assert_eq!(res, Ok(false));
 
     // test with invalid digest
     //
     let mut invalid_digest = digest;
     invalid_digest[0] += 1;
-    let res = sdk::crypto::verify_signature(&signature, &[address], &[&invalid_digest]);
+    let res = sdk::crypto::verify_signature(&signature, &address, &invalid_digest);
     assert_eq!(res, Ok(false));
 
     // test we can recover the public key from the signature
@@ -111,6 +112,59 @@ fn test_secp_signature() {
             sdk::sys::crypto::recover_secp_public_key(digest.as_ptr(), (u32::MAX) as *const u8);
         assert_eq!(res, Err(ErrorNumber::IllegalArgument));
     }
+}
+
+fn test_bls_signature() {
+    let sig_bytes = [
+        145, 231, 149, 78, 254, 149, 201, 48, 97, 56, 111, 8, 149, 59, 65, 138, 25, 255, 228, 114,
+        184, 70, 110, 94, 171, 206, 73, 47, 46, 58, 239, 16, 118, 245, 23, 102, 118, 204, 69, 109,
+        228, 168, 211, 62, 146, 247, 190, 10, 7, 73, 53, 221, 156, 16, 102, 140, 46, 34, 214, 246,
+        82, 183, 139, 195, 87, 71, 71, 219, 28, 234, 30, 110, 87, 238, 21, 167, 7, 228, 146, 9,
+        129, 128, 127, 126, 77, 187, 251, 16, 142, 44, 119, 214, 190, 227, 98, 25,
+    ];
+    let pub_key = [
+        173, 154, 145, 188, 114, 85, 101, 250, 129, 225, 3, 205, 128, 61, 161, 185, 210, 18, 147,
+        84, 160, 15, 233, 114, 178, 113, 115, 142, 4, 221, 81, 215, 188, 151, 11, 87, 4, 110, 23,
+        219, 125, 143, 122, 176, 207, 123, 66, 146,
+    ];
+    let digest = [
+        181, 145, 190, 167, 107, 236, 66, 69, 130, 119, 110, 13, 105, 74, 233, 196, 58, 174, 232,
+        116, 251, 63, 228, 253, 118, 124, 230, 212, 25, 41, 161, 93, 120, 26, 15, 93, 159, 43, 105,
+        48, 32, 195, 149, 33, 66, 253, 168, 14, 7, 137, 91, 110, 4, 218, 32, 88, 183, 199, 36, 184,
+        187, 119, 179, 254, 255, 158, 41, 181, 168, 22, 67, 175, 5, 101, 59, 86, 163, 23, 248, 34,
+        187, 94, 53, 226, 19, 210, 124, 67, 143, 68, 183, 199, 112, 240, 127, 98,
+    ];
+
+    // Assert that signature validation succeeds.
+    let sig = Signature::new_bls(sig_bytes.to_vec());
+    let addr = Address::new_bls(&pub_key).unwrap();
+    let res = sdk::crypto::verify_signature(&sig, &addr, &digest);
+    assert_eq!(res, Ok(true));
+
+    // BLS signatures and digests are each a G2 point, thus a digest's valid point representation
+    // can be used as an invalid signature (and vise-versa).
+    let invalid_sig = Signature::new_bls(digest.to_vec());
+    let invalid_digest = sig_bytes;
+
+    // The bytes of a valid G1 point.
+    let invalid_pub_key = [
+        177, 126, 78, 182, 93, 122, 198, 81, 5, 240, 226, 238, 241, 247, 37, 183, 171, 231, 237,
+        71, 215, 84, 120, 150, 238, 23, 45, 109, 96, 19, 169, 23, 115, 147, 70, 45, 36, 87, 177,
+        103, 43, 231, 60, 58, 127, 63, 232, 225,
+    ];
+
+    // Test invalid signature.
+    let res = sdk::crypto::verify_signature(&invalid_sig, &addr, &digest);
+    assert_eq!(res, Ok(false));
+
+    // Test invalid public key.
+    let invalid_addr = Address::new_bls(&invalid_pub_key).unwrap();
+    let res = sdk::crypto::verify_signature(&sig, &invalid_addr, &digest);
+    assert_eq!(res, Ok(false));
+
+    // Test invalid digest.
+    let res = sdk::crypto::verify_signature(&sig, &addr, &invalid_digest);
+    assert_eq!(res, Ok(false));
 }
 
 fn test_bls_aggregate() {
@@ -166,18 +220,6 @@ fn test_bls_aggregate() {
         169, 161, 204, 104, 192, 74, 124, 45, 91, 136, 11, 191, 53, 202, 210, 135, 41, 160, 199,
         255, 107, 98, 100, 207, 63, 75, 188, 34, 162, 170, 237, 188, 68, 170, 53, 11, 200, 124,
     ];
-
-    // Assert that `sdk::crypto::verify_signature` succeeds for BLS signatures.
-    let res = {
-        let sig = Signature::new_bls(sig.to_vec());
-        let addrs: Vec<Address> = pub_keys
-            .iter()
-            .map(|pub_key| Address::new_bls(pub_key).unwrap())
-            .collect();
-        let digests: Vec<&[u8]> = digests.iter().map(|digest| digest.as_slice()).collect();
-        sdk::crypto::verify_signature(&sig, &addrs, &digests)
-    };
-    assert_eq!(res, Ok(true));
 
     // Assert that bls validation syscall succeeds.
     let res = sdk::crypto::verify_bls_aggregate(&sig, &pub_keys, &digests);


### PR DESCRIPTION
This PR adds a syscall and associated kernel operation for BLS aggregate signature validation.

Work remaining for this draft PR:
- [x] Remove `verify_signature` syscall
- [ ] Calculate gas charge for bls aggregate signature validation (maybe remove `on_verify_signature` from `PriceList`)

Closes #1349