### PR TITLE
feat: perform randomness hashing in the kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,6 +2326,8 @@ version = "3.5.0"
 dependencies = [
  "anyhow",
  "arbitrary",
+ "blake2b_simd",
+ "byteorder",
  "cid 0.10.1",
  "derive_more",
  "filecoin-proofs-api",

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -38,6 +38,8 @@ rand = "0.8.5"
 quickcheck = { version = "1", optional = true }
 once_cell = "1.18"
 minstant = "0.1.2"
+blake2b_simd = "1.0.0"
+byteorder = "1.4.3"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/fvm/src/externs/mod.rs
+++ b/fvm/src/externs/mod.rs
@@ -23,21 +23,11 @@ pub trait Consensus {
 pub trait Rand {
     /// Gets 32 bytes of randomness for ChainRand paramaterized by the DomainSeparationTag,
     /// ChainEpoch, Entropy from the ticket chain.
-    fn get_chain_randomness(
-        &self,
-        pers: i64,
-        round: ChainEpoch,
-        entropy: &[u8],
-    ) -> anyhow::Result<[u8; 32]>;
+    fn get_chain_randomness(&self, round: ChainEpoch) -> anyhow::Result<[u8; 32]>;
 
     /// Gets 32 bytes of randomness for ChainRand paramaterized by the DomainSeparationTag,
     /// ChainEpoch, Entropy from the latest beacon entry.
-    fn get_beacon_randomness(
-        &self,
-        pers: i64,
-        round: ChainEpoch,
-        entropy: &[u8],
-    ) -> anyhow::Result<[u8; 32]>;
+    fn get_beacon_randomness(&self, round: ChainEpoch) -> anyhow::Result<[u8; 32]>;
 }
 
 /// Chain information provider.

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -759,9 +759,11 @@ fn draw_randomness(
     state.write_all(rbase)?;
     state.write_i64::<byteorder::BigEndian>(round)?;
     state.write_all(entropy)?;
-    let mut ret = [0u8; 32];
-    ret.clone_from_slice(state.finalize().as_bytes());
-    Ok(ret)
+    state
+        .finalize()
+        .as_bytes()
+        .try_into()
+        .map_err(anyhow::Error::from)
 }
 
 impl<C> RandomnessOps for DefaultKernel<C>

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -77,9 +77,7 @@ mod test {
     impl Rand for DummyExterns {
         fn get_chain_randomness(
             &self,
-            _pers: i64,
             _round: fvm_shared::clock::ChainEpoch,
-            _entropy: &[u8],
         ) -> anyhow::Result<[u8; 32]> {
             let msg = "mel was here".as_bytes();
             let mut out = [0u8; 32];
@@ -89,9 +87,7 @@ mod test {
 
         fn get_beacon_randomness(
             &self,
-            _pers: i64,
             _round: fvm_shared::clock::ChainEpoch,
-            _entropy: &[u8],
         ) -> anyhow::Result<[u8; 32]> {
             todo!()
         }

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -35,18 +35,14 @@ impl Externs for DummyExterns {}
 impl Rand for DummyExterns {
     fn get_chain_randomness(
         &self,
-        _pers: i64,
         _round: fvm_shared::clock::ChainEpoch,
-        _entropy: &[u8],
     ) -> anyhow::Result<[u8; 32]> {
         todo!()
     }
 
     fn get_beacon_randomness(
         &self,
-        _pers: i64,
         _round: fvm_shared::clock::ChainEpoch,
-        _entropy: &[u8],
     ) -> anyhow::Result<[u8; 32]> {
         todo!()
     }

--- a/testing/conformance/src/externs.rs
+++ b/testing/conformance/src/externs.rs
@@ -25,22 +25,12 @@ impl TestExterns {
 impl Externs for TestExterns {}
 
 impl Rand for TestExterns {
-    fn get_chain_randomness(
-        &self,
-        pers: i64,
-        round: ChainEpoch,
-        entropy: &[u8],
-    ) -> anyhow::Result<[u8; 32]> {
-        self.rand.get_chain_randomness(pers, round, entropy)
+    fn get_chain_randomness(&self, round: ChainEpoch) -> anyhow::Result<[u8; 32]> {
+        self.rand.get_chain_randomness(round)
     }
 
-    fn get_beacon_randomness(
-        &self,
-        pers: i64,
-        round: ChainEpoch,
-        entropy: &[u8],
-    ) -> anyhow::Result<[u8; 32]> {
-        self.rand.get_beacon_randomness(pers, round, entropy)
+    fn get_beacon_randomness(&self, round: ChainEpoch) -> anyhow::Result<[u8; 32]> {
+        self.rand.get_beacon_randomness(round)
     }
 }
 

--- a/testing/conformance/src/rand.rs
+++ b/testing/conformance/src/rand.rs
@@ -20,11 +20,11 @@ pub struct ReplayingRand {
 pub struct TestFallbackRand;
 
 impl Rand for TestFallbackRand {
-    fn get_chain_randomness(&self, _: i64, _: ChainEpoch, _: &[u8]) -> anyhow::Result<[u8; 32]> {
+    fn get_chain_randomness(&self, _: ChainEpoch) -> anyhow::Result<[u8; 32]> {
         Ok(*b"i_am_random_____i_am_random_____")
     }
 
-    fn get_beacon_randomness(&self, _: i64, _: ChainEpoch, _: &[u8]) -> anyhow::Result<[u8; 32]> {
+    fn get_beacon_randomness(&self, _: ChainEpoch) -> anyhow::Result<[u8; 32]> {
         Ok(*b"i_am_random_____i_am_random_____")
     }
 }
@@ -50,40 +50,26 @@ impl ReplayingRand {
 }
 
 impl Rand for ReplayingRand {
-    fn get_chain_randomness(
-        &self,
-        dst: i64,
-        epoch: ChainEpoch,
-        entropy: &[u8],
-    ) -> anyhow::Result<[u8; 32]> {
+    fn get_chain_randomness(&self, epoch: ChainEpoch) -> anyhow::Result<[u8; 32]> {
         let rule = RandomnessRule {
             kind: RandomnessKind::Chain,
-            dst,
             epoch,
-            entropy: entropy.to_vec(),
         };
         if let Some(bz) = self.matches(rule) {
             Ok(bz)
         } else {
-            self.fallback.get_chain_randomness(dst, epoch, entropy)
+            self.fallback.get_chain_randomness(epoch)
         }
     }
-    fn get_beacon_randomness(
-        &self,
-        dst: i64,
-        epoch: ChainEpoch,
-        entropy: &[u8],
-    ) -> anyhow::Result<[u8; 32]> {
+    fn get_beacon_randomness(&self, epoch: ChainEpoch) -> anyhow::Result<[u8; 32]> {
         let rule = RandomnessRule {
             kind: RandomnessKind::Beacon,
-            dst,
             epoch,
-            entropy: entropy.to_vec(),
         };
         if let Some(bz) = self.matches(rule) {
             Ok(bz)
         } else {
-            self.fallback.get_beacon_randomness(dst, epoch, entropy)
+            self.fallback.get_beacon_randomness(epoch)
         }
     }
 }

--- a/testing/conformance/src/vector.rs
+++ b/testing/conformance/src/vector.rs
@@ -117,10 +117,7 @@ pub enum RandomnessKind {
 #[derive(Debug, Deserialize_tuple, PartialEq, Eq, Clone)]
 pub struct RandomnessRule {
     pub kind: RandomnessKind,
-    pub dst: i64,
     pub epoch: ChainEpoch,
-    #[serde(with = "base64_bytes")]
-    pub entropy: Vec<u8>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/testing/integration/src/dummy.rs
+++ b/testing/integration/src/dummy.rs
@@ -14,9 +14,7 @@ impl Externs for DummyExterns {}
 impl Rand for DummyExterns {
     fn get_chain_randomness(
         &self,
-        _pers: i64,
         _round: fvm_shared::clock::ChainEpoch,
-        _entropy: &[u8],
     ) -> anyhow::Result<[u8; 32]> {
         let rng: String = thread_rng()
             .sample_iter(&Alphanumeric)
@@ -29,9 +27,7 @@ impl Rand for DummyExterns {
 
     fn get_beacon_randomness(
         &self,
-        _pers: i64,
         _round: fvm_shared::clock::ChainEpoch,
-        _entropy: &[u8],
     ) -> anyhow::Result<[u8; 32]> {
         let rng: String = thread_rng()
             .sample_iter(&Alphanumeric)


### PR DESCRIPTION
Fixes #1277 

We currently rely on clients like Lotus to do the hashing required for drawing randomness. This PR pulls that into the kernel.

We should eventually push the work of hashing into the actor directly, which can request it over syscalls.