### PR TITLE
chore: release fvm, fvm_shared, and HAMT crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,7 +1454,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1487,7 +1487,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "log",
  "num-derive",
  "num-traits",
@@ -1506,8 +1506,8 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.7.0",
+ "fvm_shared 3.4.0",
  "lazy_static",
  "log",
  "num-derive",
@@ -1526,7 +1526,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "hex-literal",
  "log",
  "multihash 0.18.1",
@@ -1545,7 +1545,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "hex-literal",
  "num-derive",
  "num-traits",
@@ -1565,7 +1565,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_kamt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "hex",
  "hex-literal",
  "log",
@@ -1587,8 +1587,8 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.7.0",
+ "fvm_shared 3.4.0",
  "log",
  "num-derive",
  "num-traits",
@@ -1608,8 +1608,8 @@ dependencies = [
  "fvm_ipld_bitfield 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.7.0",
+ "fvm_shared 3.4.0",
  "integer-encoding",
  "libipld-core 0.13.1",
  "log",
@@ -1632,8 +1632,8 @@ dependencies = [
  "fvm_ipld_bitfield 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.7.0",
+ "fvm_shared 3.4.0",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -1655,8 +1655,8 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.7.0",
+ "fvm_shared 3.4.0",
  "indexmap",
  "integer-encoding",
  "num-derive",
@@ -1675,7 +1675,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1697,8 +1697,8 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.7.0",
+ "fvm_shared 3.4.0",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -1716,7 +1716,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "lazy_static",
  "log",
  "num-derive",
@@ -1734,7 +1734,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1753,8 +1753,8 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.7.0",
+ "fvm_shared 3.4.0",
  "lazy_static",
  "log",
  "num-derive",
@@ -1769,7 +1769,7 @@ source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#f
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "hex",
  "serde",
  "uint",
@@ -1788,9 +1788,9 @@ dependencies = [
  "fvm_ipld_bitfield 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.7.0",
  "fvm_sdk 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "integer-encoding",
  "itertools 0.10.5",
  "log",
@@ -1814,7 +1814,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
 ]
 
 [[package]]
@@ -1851,7 +1851,7 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
 ]
 
 [[package]]
@@ -1860,7 +1860,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
  "serde",
  "serde_tuple",
 ]
@@ -1871,7 +1871,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
 ]
 
 [[package]]
@@ -1883,7 +1883,7 @@ dependencies = [
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1895,7 +1895,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
  "log",
  "serde",
  "serde_tuple",
@@ -1906,7 +1906,7 @@ name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
 ]
 
 [[package]]
@@ -1918,7 +1918,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
  "serde",
  "serde_tuple",
 ]
@@ -1929,7 +1929,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
  "minicov",
 ]
 
@@ -1938,7 +1938,7 @@ name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
 ]
 
 [[package]]
@@ -1946,7 +1946,7 @@ name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
 ]
 
 [[package]]
@@ -1972,7 +1972,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
 ]
 
 [[package]]
@@ -1982,7 +1982,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
 ]
 
 [[package]]
@@ -1990,7 +1990,7 @@ name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
 ]
 
 [[package]]
@@ -2000,7 +2000,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 3.3.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -2149,7 +2149,7 @@ dependencies = [
  "frc42_macros",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_sdk 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "thiserror",
 ]
 
@@ -2160,7 +2160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f72dabfe1b958b3588138f9d15ade5f485b79aca6f1e8f307f5dd09d0694d350"
 dependencies = [
  "fvm_sdk 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "thiserror",
 ]
 
@@ -2190,9 +2190,9 @@ dependencies = [
  "fvm_ipld_amt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.7.0",
  "fvm_sdk 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "integer-encoding",
  "num-traits",
  "serde",
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2336,8 +2336,8 @@ dependencies = [
  "fvm_ipld_amt 0.6.1",
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_ipld_hamt 0.7.0",
- "fvm_shared 3.4.0",
+ "fvm_ipld_hamt 0.8.0",
+ "fvm_shared 3.5.0",
  "lazy_static",
  "log",
  "minstant",
@@ -2367,7 +2367,7 @@ dependencies = [
  "clap 4.3.9",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
  "hex",
 ]
 
@@ -2395,7 +2395,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_sdk 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -2420,7 +2420,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_car 0.7.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
  "itertools 0.11.0",
  "ittapi-rs",
  "lazy_static",
@@ -2442,7 +2442,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -2464,7 +2464,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_car 0.7.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2655,6 +2655,26 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f01c65915bd7ab95ff973bb0bb7e03e8d43a43642c8f4b15407e42e4ffcc0d98"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "cid 0.10.1",
+ "forest_hash_utils",
+ "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libipld-core 0.16.0",
+ "multihash 0.18.1",
+ "once_cell",
+ "serde",
+ "sha2 0.10.7",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_ipld_hamt"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2674,26 +2694,6 @@ dependencies = [
  "sha2 0.10.7",
  "thiserror",
  "unsigned-varint",
-]
-
-[[package]]
-name = "fvm_ipld_hamt"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c65915bd7ab95ff973bb0bb7e03e8d43a43642c8f4b15407e42e4ffcc0d98"
-dependencies = [
- "anyhow",
- "byteorder",
- "cid 0.10.1",
- "forest_hash_utils",
- "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libipld-core 0.16.0",
- "multihash 0.18.1",
- "once_cell",
- "serde",
- "sha2 0.10.7",
- "thiserror",
 ]
 
 [[package]]
@@ -2742,7 +2742,7 @@ version = "3.3.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.4.0",
+ "fvm_shared 3.5.0",
  "lazy_static",
  "log",
  "num-traits",
@@ -2757,44 +2757,11 @@ checksum = "6c855aead9219cacd48450a4d9d5f57d13dbe4dbbe2d8538d350212792854f5d"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 3.4.0",
  "lazy_static",
  "log",
  "num-traits",
  "thiserror",
-]
-
-[[package]]
-name = "fvm_shared"
-version = "3.4.0"
-dependencies = [
- "anyhow",
- "arbitrary",
- "bitflags 2.3.3",
- "blake2b_simd",
- "bls-signatures",
- "cid 0.10.1",
- "data-encoding",
- "data-encoding-macro",
- "filecoin-proofs-api",
- "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.4.0",
- "lazy_static",
- "libsecp256k1",
- "multihash 0.18.1",
- "num-bigint",
- "num-derive",
- "num-integer",
- "num-traits",
- "quickcheck",
- "quickcheck_macros",
- "rand",
- "rand_chacha",
- "serde",
- "serde_json",
- "serde_tuple",
- "thiserror",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -2817,6 +2784,39 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+ "serde_tuple",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "fvm_shared"
+version = "3.5.0"
+dependencies = [
+ "anyhow",
+ "arbitrary",
+ "bitflags 2.3.3",
+ "blake2b_simd",
+ "bls-signatures",
+ "cid 0.10.1",
+ "data-encoding",
+ "data-encoding-macro",
+ "filecoin-proofs-api",
+ "fvm_ipld_encoding 0.4.0",
+ "fvm_shared 3.5.0",
+ "lazy_static",
+ "libsecp256k1",
+ "multihash 0.18.1",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "quickcheck",
+ "quickcheck_macros",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "serde_json",
  "serde_tuple",
  "thiserror",
  "unsigned-varint",
@@ -4799,8 +4799,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.7.0",
+ "fvm_shared 3.4.0",
  "num-derive",
  "num-traits",
  "rand",

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,46 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 3.6.0 [2023-08-18]
+
+Breaking Changes:
+- Perform randomness hashing in the kernel
+  - The FVM no longer supplies a DST and entropy to the client extern when requesting randomness
+  - It expects the client to return the "digest", from which the kernel then draws the randomness
+  - Clients integrating this change should:
+    - no longer expect the DST and entropy parameters for the `get_chain_randomness` and `get_beacon_randomness` externs
+    - omit the last step they currently perform when drawing randomness; that is, return the hashed digest after looking up the randomness source
+- Drop deprecated `hyperspace` feature
+
+Other Changes:
+- Add support for nv21 behind the `nv21-dev` feature flag
+  - Note: We do NOT expect to support nv21 on FVM3, this only facilitates the development of nv21 before FVM4 is ready
+  - We use the Hygge pricelist as-is for nv21 if the `nv21-dev` feature flag is enabled
+- Refactor: remove `with_transaction` and move the "return" gas charge
+  - transaction logic is now entirely in `CallManager::send`
+- Syscalls: fix: Do not assume return pointers are aligned
+- Buffered Blockstore: fixup IPLD flush logic 
+  - Make it less generic (performance).
+  - Remove blocks from the write buffer as we write them to avoid
+    duplicate writes.
+  - Simplify some of the checks around what is allowed. For example, I'm
+    now allowing CBOR + Identity hash which should have been allowed
+    previously but wasn't (we don't use it but still, it should have been
+    allowed).
+  - Remove the explicit 100 byte CID length check. The `Cid` type already
+    validates that the digest can be no longer than 64 bytes.
+  - Be less strict on DagCBOR validation. Counter-intuitively, being
+    overly strict here is dangerous as it gives us more points where
+    implementations can disagree and fork. Instead, we enforce the
+    following rules for DAG_CBOR:
+    1. Blocks must have a valid CBOR structure, but _values_ aren't
+       validated. E.g., no utf-8 validation, no float validation, no
+       minimum encoding requirements, no canonical ordering requirements,
+       etc.
+    2. All CBOR values tagged with 42 must be valid CIDs. I.e., a CBOR
+       byte string starting with a 0x0 byte followed by a valid CID with
+       at most a 64 byte digest.
+
 ## 3.5.0 [2023-06-27]
 
 Breaking Changes:

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "3.5.0"
+version = "3.6.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -17,8 +17,8 @@ thiserror = "1.0.40"
 num-traits = "0.2"
 cid = { workspace = true, features = ["serde-codec"] }
 multihash = { workspace = true }
-fvm_shared = { version = "3.4.0", path = "../shared", features = ["crypto"] }
-fvm_ipld_hamt = { version = "0.7.0", path = "../ipld/hamt" }
+fvm_shared = { version = "3.5.0", path = "../shared", features = ["crypto"] }
+fvm_ipld_hamt = { version = "0.8.0", path = "../ipld/hamt" }
 fvm_ipld_amt = { version = "0.6.1", path = "../ipld/amt" }
 fvm_ipld_blockstore = { version = "0.2.0", path = "../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../ipld/encoding" }

--- a/ipld/hamt/CHANGELOG.md
+++ b/ipld/hamt/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+Changes to the reference FVM's HAMT implementation.
+
+## [Unreleased]
+
+## 0.8.0 [2023-08-18)
+
+Breaking Changes:
+
+- Deprecate default bitwidths in the HAMT
+  - Users must now always specify the bitwidth
+- TODO: Something about #1808?
+
 ## 0.7.0 [2023-06-28)
 
 Breaking Changes:

--- a/ipld/hamt/CHANGELOG.md
+++ b/ipld/hamt/CHANGELOG.md
@@ -10,7 +10,7 @@ Breaking Changes:
 
 - Deprecate default bitwidths in the HAMT
   - Users must now always specify the bitwidth
-- TODO: Something about #1808?
+- Add support for the Hamt version 0 datastructure, for historical purposes.
 
 ## 0.7.0 [2023-06-28)
 

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_hamt"
 description = "Sharded IPLD HashMap implementation."
-version = "0.7.0"
+version = "0.8.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { workspace = true }
-fvm_shared = { version = "3.4.0", path = "../shared" }
+fvm_shared = { version = "3.5.0", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.15", default-features = false }
 lazy_static = { version = "1.4.0" }

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+TODO: Can this be a patch release?
+## 3.5.0 [2023-08-18]
+
+- Add the V21 network version constant
+
 ## 3.4.0 [2023-06-27]
 
 Breaking Changes:

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [Unreleased]
 
-TODO: Can this be a patch release?
 ## 3.5.0 [2023-08-18]
 
 - Add the V21 network version constant

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "3.4.0"
+version = "3.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/testing/calibration/shared/Cargo.toml
+++ b/testing/calibration/shared/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Protocol Labs", "Filecoin Core Devs"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "3.4.0", path = "../../../shared", features = ["testing"] }
+fvm_shared = { version = "3.5.0", path = "../../../shared", features = ["testing"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 num-traits = "0.2"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "3.4.0", path = "../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../shared" }
 fvm_ipld_car = { version = "0.7.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.2.0", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../ipld/encoding" }
@@ -39,7 +39,7 @@ tar = { version = "0.4.38", default-features = false }
 zstd = { version = "0.12.3", default-features = false }
 
 [dependencies.fvm]
-version = "3.5.0"
+version = "3.6.0"
 path = "../../fvm"
 default-features = false
 features = ["testing"]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Protocol Labs", "Filecoin Core Devs", "Polyphene"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "3.5.0", path = "../../fvm", default-features = false, features = ["testing"] }
-fvm_shared = { version = "3.4.0", path = "../../shared", features = ["testing"] }
+fvm = { version = "3.6.0", path = "../../fvm", default-features = false, features = ["testing"] }
+fvm_shared = { version = "3.5.0", path = "../../shared", features = ["testing"] }
 fvm_ipld_car = { version = "0.7.0", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.2.0", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../ipld/encoding" }

--- a/testing/test_actors/actors/fil-address-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-address-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-create-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-create-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }
 
 [lib]

--- a/testing/test_actors/actors/fil-events-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-events-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 serde = {version = "1.0.164", features = ["derive"] }
 serde_tuple = "0.5.0"
 

--- a/testing/test_actors/actors/fil-exit-data-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-exit-data-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 
 [lib]

--- a/testing/test_actors/actors/fil-gas-calibration-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-gas-calibration-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 fvm_gas_calibration_shared = { path = "../../../calibration/shared" }
 

--- a/testing/test_actors/actors/fil-gaslimit-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-gaslimit-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 serde = {version = "1.0.164", features = ["derive"] }
 serde_tuple = "0.5.0"
 log = "0.4.19"

--- a/testing/test_actors/actors/fil-hello-world-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-hello-world-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 fvm_ipld_blockstore = { version = "0.2.0", path = "../../../../ipld/blockstore" }
 

--- a/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 
 [target.'cfg(coverage)'.dependencies]
 minicov = "0.3"

--- a/testing/test_actors/actors/fil-malformed-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-malformed-syscall-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
 
 [lib]

--- a/testing/test_actors/actors/fil-oom-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-oom-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-readonly-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-readonly-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 cid = { workspace = true }
 

--- a/testing/test_actors/actors/fil-sself-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-sself-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 cid = { workspace = true }
 

--- a/testing/test_actors/actors/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-stack-overflow-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.4.0", path = "../../../../shared" }
+fvm_shared = { version = "3.5.0", path = "../../../../shared" }
 minicov = {version = "0.3", optional = true}
 actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }
 multihash = { workspace = true }


### PR DESCRIPTION
As in the title, I intend to use these releases to support nv21 development in Lotus.