### PR TITLE
chore: release fvm v2.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "2.6.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_conformance_tests"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "2.5.0"
+version = "2.4.0"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "2.6.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,16 +4,6 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
-## 2.6.0 (2023-08-16)
-
-Breaking Changes:
-- Perform randomness hashing in the kernel
-  - The FVM no longer supplies a DST and entropy to the client extern when requesting randomness
-  - It expects the client to return the "digest", from which the kernel then draws the randomness
-  - Clients integrating this change should:
-    - no longer expect the DST and entropy parameters for the `get_chain_randomness` and `get_beacon_randomness` externs
-    - omit the last step they currently perform when drawing randomness; that is, return the hashed digest after looking up the randomness source
-
 ## 2.5.0 (2023-06-28)
 
 Breaking Changes:

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,16 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 2.6.0 (2023-08-18)
+
+Breaking Changes:
+- Perform randomness hashing in the kernel
+  - The FVM no longer supplies a DST and entropy to the client extern when requesting randomness
+  - It expects the client to return the "digest", from which the kernel then draws the randomness
+  - Clients integrating this change should:
+    - no longer expect the DST and entropy parameters for the `get_chain_randomness` and `get_beacon_randomness` externs
+    - omit the last step they currently perform when drawing randomness; that is, return the hashed digest after looking up the randomness source
+
 ## 2.5.0 (2023-06-28)
 
 Breaking Changes:

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "2.5.0"
+version = "2.6.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "2.6.0"
+version = "2.5.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -19,7 +19,7 @@ derive_builder = "0.12.0"
 num-derive = "0.3.3"
 cid = { workspace = true, features = ["serde-codec"] }
 multihash = { workspace = true }
-fvm_shared = { version = "2.6.0", path = "../shared", features = ["crypto"] }
+fvm_shared = { version = "2.5.0", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "2.5.0"
+version = "2.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { workspace = true }
-fvm_shared = { version = "2.6.0", path = "../shared" }
+fvm_shared = { version = "2.5.0", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = { version = "1.4.0" }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "2.6.0"
+version = "2.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -51,7 +51,7 @@ tar = { version = "0.4.38", default-features = false }
 zstd = { version = "0.12.3", default-features = false }
 
 [dependencies.fvm]
-version = "2.5.0"
+version = "2.6.0"
 path = "../../fvm"
 default-features = false
 features = ["testing"]

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_conformance_tests"
 description = "Filecoin Virtual Machine conformance tests"
-version = "0.2.0"
+version = "0.1.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
 exclude = ["/test-vectors"]
@@ -9,7 +9,7 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "2.6.0", path = "../../shared" }
+fvm_shared = { version = "2.5.0", path = "../../shared" }
 fvm_ipld_hamt = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 fvm_ipld_car = { workspace = true }
@@ -51,7 +51,7 @@ tar = { version = "0.4.38", default-features = false }
 zstd = { version = "0.12.3", default-features = false }
 
 [dependencies.fvm]
-version = "2.6.0"
+version = "2.5.0"
 path = "../../fvm"
 default-features = false
 features = ["testing"]


### PR DESCRIPTION
Reverts #1845, which accidentally bumped versions on a couple more crates, and correctly only releases the fvm crate.