### PR TITLE
feat: remove the verify-seal syscall

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -520,17 +520,6 @@ where
         }))
     }
 
-    /// Verify seal proof for sectors. This proof verifies that a sector was sealed by the miner.
-    fn verify_seal(&self, vi: &SealVerifyInfo) -> Result<bool> {
-        let t = self
-            .call_manager
-            .charge_gas(self.call_manager.price_list().on_verify_seal(vi))?;
-
-        // It's probably _fine_ to just let these turn into fatal errors, but seal verification is
-        // pretty self contained, so catching panics here probably doesn't hurt.
-        t.record(catch_and_log_panic("verifying seal", || verify_seal(vi)))
-    }
-
     fn verify_post(&self, verify_info: &WindowPoStVerifyInfo) -> Result<bool> {
         let t = self
             .call_manager

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -285,9 +285,6 @@ pub trait CryptoOps {
         pieces: &[PieceInfo],
     ) -> Result<Cid>;
 
-    /// Verifies a sector seal proof.
-    fn verify_seal(&self, vi: &SealVerifyInfo) -> Result<bool>;
-
     /// Verifies a window proof of spacetime.
     fn verify_post(&self, verify_info: &WindowPoStVerifyInfo) -> Result<bool>;
 

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -124,25 +124,6 @@ pub fn compute_unsealed_sector_cid(
     context.memory.write_cid(&cid, cid_off, cid_len)
 }
 
-/// Verifies a sector seal proof.
-///
-/// The return i32 indicates the status code of the verification:
-///  - 0: verification ok.
-///  - -1: verification failed.
-pub fn verify_seal(
-    context: Context<'_, impl Kernel>,
-    info_off: u32, // SealVerifyInfo
-    info_len: u32,
-) -> Result<i32> {
-    let info = context
-        .memory
-        .read_cbor::<SealVerifyInfo>(info_off, info_len)?;
-    context
-        .kernel
-        .verify_seal(&info)
-        .map(|v| if v { 0 } else { -1 })
-}
-
 /// Verifies a window proof of spacetime.
 ///
 /// The return i32 indicates the status code of the verification:

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -292,7 +292,6 @@ pub fn bind_syscalls(
         crypto::recover_secp_public_key,
     )?;
     linker.bind("crypto", "hash", crypto::hash)?;
-    linker.bind("crypto", "verify_seal", crypto::verify_seal)?;
     linker.bind("crypto", "verify_post", crypto::verify_post)?;
     linker.bind(
         "crypto",

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -132,12 +132,6 @@ pub fn compute_unsealed_sector_cid(
     }
 }
 
-/// Verifies a sector seal proof.
-pub fn verify_seal(info: &SealVerifyInfo) -> SyscallResult<bool> {
-    let info = to_vec(info).expect("failed to marshal seal verification input");
-    unsafe { sys::crypto::verify_seal(info.as_ptr(), info.len() as u32).map(status_code_to_bool) }
-}
-
 /// Verifies a window proof of spacetime.
 pub fn verify_post(info: &WindowPoStVerifyInfo) -> SyscallResult<bool> {
     let info = to_vec(info).expect("failed to marshal PoSt verification input");

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -111,22 +111,6 @@ super::fvm_syscalls! {
         cid_len: u32,
     ) -> Result<u32>;
 
-    /// Verifies a sector seal proof.
-    ///
-    /// Returns 0 to indicate that the proof was valid, -1 otherwise.
-    ///
-    /// # Arguments
-    ///
-    /// `info_off` and `info_len` specify the location and length of a cbor-encoded
-    /// [`SealVerifyInfo`][fvm_shared::sector::SealVerifyInfo] in tuple representation.
-    ///
-    /// # Errors
-    ///
-    /// | Error               | Reason                   |
-    /// |---------------------|--------------------------|
-    /// | [`IllegalArgument`] | an argument is malformed |
-    pub fn verify_seal(info_off: *const u8, info_len: u32) -> Result<i32>;
-
     /// Verifies a window proof of spacetime.
     ///
     /// Returns 0 to indicate that the proof was valid, -1 otherwise.

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -386,13 +386,6 @@ where
     }
 
     // NOT forwarded
-    fn verify_seal(&self, vi: &SealVerifyInfo) -> Result<bool> {
-        let charge = self.1.price_list.on_verify_seal(vi);
-        let _ = self.0.charge_gas(&charge.name, charge.total())?;
-        Ok(true)
-    }
-
-    // NOT forwarded
     fn verify_post(&self, vi: &WindowPoStVerifyInfo) -> Result<bool> {
         let charge = self.1.price_list.on_verify_post(vi);
         let _ = self.0.charge_gas(&charge.name, charge.total())?;


### PR DESCRIPTION
This is unused in the builtin actors. No FIP necessary as it's unused and was restricted to the miner actor anyways.