### PR TITLE
fix(fevm-bench): don't give contracts endowments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,6 +2365,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 4.3.9",
+ "env_logger 0.10.0",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
  "fvm_shared 3.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,6 +2366,7 @@ dependencies = [
  "anyhow",
  "clap 4.3.9",
  "env_logger 0.10.0",
+ "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
  "fvm_shared 3.5.0",

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -366,7 +366,7 @@ impl BasicTester {
             };
 
         let mut tester = Tester::new(
-            NetworkVersion::V18,
+            NetworkVersion::V20,
             StateTreeVersion::V5,
             bundle_cid,
             blockstore,

--- a/testing/integration/src/testkit/fevm.rs
+++ b/testing/integration/src/testkit/fevm.rs
@@ -10,7 +10,7 @@ use fvm_shared::message::Message;
 use fvm_shared::{ActorID, METHOD_CONSTRUCTOR};
 use num_traits::Zero;
 
-use crate::tester::{BasicAccount, BasicTester, INITIAL_ACCOUNT_BALANCE};
+use crate::tester::{BasicAccount, BasicTester};
 
 pub const EAM_ADDRESS: Address = Address::new_id(10);
 pub const DEFAULT_GAS: u64 = 10_000_000_000;

--- a/testing/integration/src/testkit/fevm.rs
+++ b/testing/integration/src/testkit/fevm.rs
@@ -8,6 +8,7 @@ use fvm_ipld_encoding::{strict_bytes, BytesSer, RawBytes};
 use fvm_shared::address::Address;
 use fvm_shared::message::Message;
 use fvm_shared::{ActorID, METHOD_CONSTRUCTOR};
+use num_traits::Zero;
 
 use crate::tester::{BasicAccount, BasicTester, INITIAL_ACCOUNT_BALANCE};
 
@@ -25,7 +26,7 @@ pub fn create_contract(
         gas_limit: DEFAULT_GAS,
         method_num: EAMMethod::CreateExternal as u64,
         params: RawBytes::serialize(BytesSer(contract)).unwrap(),
-        value: INITIAL_ACCOUNT_BALANCE.clone(),
+        value: Zero::zero(),
         sequence: owner.seqno,
         ..Message::default()
     };

--- a/tools/fvm-bench/Cargo.toml
+++ b/tools/fvm-bench/Cargo.toml
@@ -11,3 +11,4 @@ anyhow = "1.0.71"
 clap = { version = "4.3.9", features = ["derive"] }
 hex = "0.4.3"
 env_logger = "0.10.0"
+fvm = { path = "../../fvm", default-features = false }

--- a/tools/fvm-bench/Cargo.toml
+++ b/tools/fvm-bench/Cargo.toml
@@ -10,3 +10,4 @@ fvm_shared = { path = "../../shared" }
 anyhow = "1.0.71"
 clap = { version = "4.3.9", features = ["derive"] }
 hex = "0.4.3"
+env_logger = "0.10.0"

--- a/tools/fvm-bench/src/main.rs
+++ b/tools/fvm-bench/src/main.rs
@@ -48,6 +48,7 @@ struct Args {
 }
 
 fn run() -> anyhow::Result<()> {
+    env_logger::init();
     let args = Args::parse();
     let options = tester::ExecutionOptions {
         debug: args.debug,


### PR DESCRIPTION
1. We were giving endowments to contracts by default, which fails with no helpful error when the contracts constructor isn't "payable".
2. Include other misc fixes/improvements found while debugging the first issue.