### PR TITLE
remove go-interop from amt

### DIFF
--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -17,9 +17,6 @@ anyhow = "1.0.71"
 fvm_ipld_blockstore = { version = "0.2", path = "../blockstore" }
 fvm_ipld_encoding = { version = "0.4", path = "../encoding" }
 
-[features]
-go-interop = []
-
 [dev-dependencies]
 criterion = "0.5.1"
 quickcheck = "1"

--- a/ipld/amt/src/value_mut.rs
+++ b/ipld/amt/src/value_mut.rs
@@ -22,13 +22,6 @@ impl<'a, V> ValueMut<'a, V> {
     pub fn value_changed(&self) -> bool {
         self.value_mutated
     }
-
-    /// Marks guard as unchanged. This should only be used when the value was updated but it is
-    /// intended to remove it. Otherwise, this function would give unexpected behaviour on flush.
-    #[cfg(feature = "go-interop")]
-    pub fn mark_unchanged(&mut self) {
-        self.value_mutated = false;
-    }
 }
 
 impl<V> Deref for ValueMut<'_, V> {

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -381,9 +381,7 @@ fn for_each() {
         .unwrap();
     assert_eq!(x, indexes.len());
 
-    // Iteration again will be read diff with go-interop, since they do not cache
     new_amt.for_each(|_, _: &BytesDe| Ok(())).unwrap();
-
     assert_eq!(
         c.to_string().as_str(),
         "bafy2bzaceanqxtbsuyhqgxubiq6vshtbhktmzp2if4g6kxzttxmzkdxmtipcm"


### PR DESCRIPTION
Remove the `go-interop` feature based on the discussion in the linked issue.

Closes https://github.com/filecoin-project/ref-fvm/issues/1856