### PR TITLE
feat: hamt: paranoid validation when reading nodes

### DIFF
--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -23,8 +23,6 @@ fvm_ipld_blockstore = { version = "0.2", path = "../blockstore" }
 
 [features]
 identity = []
-# This feature should just be used for testing (ignoring links that don't exist in store)
-ignore-dead-links = []
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -115,7 +115,7 @@ where
     /// Lazily instantiate a hamt from this root Cid with a specified parameters.
     pub fn load_with_config(cid: &Cid, store: BS, conf: Config) -> Result<Self, Error> {
         Ok(Self {
-            root: Node::load(&conf, &store, cid)?,
+            root: Node::load(&conf, &store, cid, 0)?,
             store,
             conf,
             hash: Default::default(),
@@ -136,7 +136,7 @@ where
 
     /// Sets the root based on the Cid of the root node using the Hamt store
     pub fn set_root(&mut self, cid: &Cid) -> Result<(), Error> {
-        self.root = Node::load(&self.conf, &self.store, cid)?;
+        self.root = Node::load(&self.conf, &self.store, cid, 0)?;
         self.flushed_cid = Some(*cid);
 
         Ok(())

--- a/ipld/hamt/src/iter.rs
+++ b/ipld/hamt/src/iter.rs
@@ -6,7 +6,6 @@ use std::iter::FusedIterator;
 use forest_hash_utils::BytesKey;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::de::DeserializeOwned;
-use fvm_ipld_encoding::CborStore;
 
 use crate::hash_bits::HashBits;
 use crate::node::Node;
@@ -17,6 +16,7 @@ use crate::{Config, Error, Hash, HashAlgorithm, KeyValuePair, Sha256};
 #[doc(hidden)]
 pub struct IterImpl<'a, BS, V, K = BytesKey, H = Sha256, Ver = version::V3> {
     store: &'a BS,
+    conf: &'a Config,
     stack: Vec<std::slice::Iter<'a, Pointer<K, V, H, Ver>>>,
     current: std::slice::Iter<'a, KeyValuePair<K, V>>,
 }
@@ -34,8 +34,9 @@ where
     Ver: Version,
     BS: Blockstore,
 {
-    pub(crate) fn new(store: &'a BS, root: &'a Node<K, V, H, Ver>) -> Self {
+    pub(crate) fn new(store: &'a BS, root: &'a Node<K, V, H, Ver>, conf: &'a Config) -> Self {
         Self {
+            conf,
             store,
             stack: vec![root.pointers.iter()],
             current: [].iter(),
@@ -46,11 +47,11 @@ where
         store: &'a BS,
         root: &'a Node<K, V, H, Ver>,
         key: &Q,
-        conf: &Config,
+        conf: &'a Config,
     ) -> Result<Self, Error>
     where
         H: HashAlgorithm,
-        K: Borrow<Q>,
+        K: Borrow<Q> + PartialOrd,
         Q: Hash + Eq,
     {
         let hashed_key = H::hash(key);
@@ -63,28 +64,13 @@ where
             node = match stack.last_mut().unwrap().next() {
                 Some(p) => match p {
                     Pointer::Link { cid, cache } => {
-                        if let Some(cached_node) = cache.get() {
-                            cached_node
-                        } else {
-                            let node =
-                                if let Some(node) = store.get_cbor::<Node<K, V, H, Ver>>(cid)? {
-                                    node
-                                } else {
-                                    #[cfg(not(feature = "ignore-dead-links"))]
-                                    return Err(Error::CidNotFound(cid.to_string()));
-
-                                    #[cfg(feature = "ignore-dead-links")]
-                                    continue;
-                                };
-
-                            // Ignore error intentionally, the cache value will always be the same
-                            cache.get_or_init(|| Box::new(node))
-                        }
+                        cache.get_or_try_init(|| Node::load(conf, store, cid).map(Box::new))?
                     }
                     Pointer::Dirty(node) => node,
                     Pointer::Values(values) => {
                         return match values.iter().position(|kv| kv.key().borrow() == key) {
                             Some(offset) => Ok(Self {
+                                conf,
                                 store,
                                 stack,
                                 current: values[offset..].iter(),
@@ -103,7 +89,7 @@ impl<'a, K, V, BS, H, Ver> Iterator for IterImpl<'a, BS, V, K, H, Ver>
 where
     BS: Blockstore,
     Ver: Version,
-    K: DeserializeOwned,
+    K: DeserializeOwned + PartialOrd,
     V: DeserializeOwned,
 {
     type Item = Result<(&'a K, &'a V), Error>;
@@ -119,20 +105,11 @@ where
             };
             match next {
                 Pointer::Link { cid, cache } => {
-                    let node = if let Some(cached_node) = cache.get() {
-                        cached_node
-                    } else {
-                        let node = match self.store.get_cbor::<Node<K, V, H, Ver>>(cid) {
-                            Ok(Some(node)) => node,
-                            #[cfg(not(feature = "ignore-dead-links"))]
-                            Ok(None) => return Some(Err(Error::CidNotFound(cid.to_string()))),
-                            #[cfg(feature = "ignore-dead-links")]
-                            Ok(None) => continue,
-                            Err(err) => return Some(Err(err.into())),
-                        };
-
-                        // Ignore error intentionally, the cache value will always be the same
-                        cache.get_or_init(|| Box::new(node))
+                    let node = match cache
+                        .get_or_try_init(|| Node::load(self.conf, &self.store, cid).map(Box::new))
+                    {
+                        Ok(node) => node,
+                        Err(e) => return Some(Err(e)),
                     };
                     self.stack.push(node.pointers.iter())
                 }
@@ -150,7 +127,7 @@ where
 
 impl<'a, K, V, BS, H, Ver> FusedIterator for IterImpl<'a, BS, V, K, H, Ver>
 where
-    K: DeserializeOwned,
+    K: DeserializeOwned + PartialOrd,
     V: DeserializeOwned,
     Ver: Version,
     BS: Blockstore,

--- a/ipld/hamt/src/iter.rs
+++ b/ipld/hamt/src/iter.rs
@@ -63,9 +63,9 @@ where
             stack.push(node.pointers[node.index_for_bit_pos(idx)..].iter());
             node = match stack.last_mut().unwrap().next() {
                 Some(p) => match p {
-                    Pointer::Link { cid, cache } => {
-                        cache.get_or_try_init(|| Node::load(conf, store, cid).map(Box::new))?
-                    }
+                    Pointer::Link { cid, cache } => cache.get_or_try_init(|| {
+                        Node::load(conf, store, cid, stack.len() as u32).map(Box::new)
+                    })?,
                     Pointer::Dirty(node) => node,
                     Pointer::Values(values) => {
                         return match values.iter().position(|kv| kv.key().borrow() == key) {
@@ -105,9 +105,10 @@ where
             };
             match next {
                 Pointer::Link { cid, cache } => {
-                    let node = match cache
-                        .get_or_try_init(|| Node::load(self.conf, &self.store, cid).map(Box::new))
-                    {
+                    let node = match cache.get_or_try_init(|| {
+                        Node::load(self.conf, &self.store, cid, self.stack.len() as u32)
+                            .map(Box::new)
+                    }) {
                         Ok(node) => node,
                         Err(e) => return Some(Err(e)),
                     };

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -340,6 +340,20 @@ fn set_delete_many(
 
     let cid_d = hamt.flush().unwrap();
     cids.check_next(cid_d);
+
+    // Assert that we can empty it.
+    for i in 0..size_factor {
+        assert!(hamt.delete(&tstring(i)).unwrap().is_some());
+    }
+
+    assert_eq!(hamt.iter().count(), 0);
+
+    let cid_d = hamt.flush().unwrap();
+    cids.check_next(cid_d);
+    if let Some(stats) = stats {
+        assert_eq!(*store.stats.borrow(), stats);
+    }
+
     if let Some(stats) = stats {
         assert_eq!(*store.stats.borrow(), stats);
     }
@@ -997,11 +1011,12 @@ mod test_default {
     #[test]
     fn set_delete_many() {
         #[rustfmt::skip]
-        let stats = BSStats {r: 0, w: 93, br: 0, bw: 11734};
+        let stats = BSStats {r: 0, w: 94, br: 0, bw: 11737};
         let cids = CidChecker::new(vec![
             "bafy2bzaceczhz54xmmz3xqnbmvxfbaty3qprr6dq7xh5vzwqbirlsnbd36z7a",
             "bafy2bzacecxcp736xkl2mcyjlors3tug6vdlbispbzxvb75xlrhthiw2xwxvw",
             "bafy2bzaceczhz54xmmz3xqnbmvxfbaty3qprr6dq7xh5vzwqbirlsnbd36z7a",
+            "bafy2bzaceamp42wmmgr2g2ymg46euououzfyck7szknvfacqscohrvaikwfay",
         ]);
         super::set_delete_many(200, HamtFactory::default(), Some(stats), cids);
     }


### PR DESCRIPTION
This duplicates some logic we already have in the go hamt implementation but failed to replicate here. The lack of validation here won't cause any issues on the current network as we only read HAMTs we've written, never untrusted HAMTs. However, we should fix this anyways.