### PR TITLE
fix: use better types in HAMT hashing

### DIFF
--- a/ipld/hamt/src/bitfield.rs
+++ b/ipld/hamt/src/bitfield.rs
@@ -69,20 +69,20 @@ impl Default for Bitfield {
 }
 
 impl Bitfield {
-    pub fn clear_bit(&mut self, idx: u32) {
+    pub fn clear_bit(&mut self, idx: u8) {
         let ai = idx / 64;
         let bi = idx % 64;
         self.0[ai as usize] &= u64::MAX - (1 << bi);
     }
 
-    pub fn test_bit(&self, idx: u32) -> bool {
+    pub fn test_bit(&self, idx: u8) -> bool {
         let ai = idx / 64;
         let bi = idx % 64;
 
         self.0[ai as usize] & (1 << bi) != 0
     }
 
-    pub fn set_bit(&mut self, idx: u32) {
+    pub fn set_bit(&mut self, idx: u8) {
         let ai = idx / 64;
         let bi = idx % 64;
 
@@ -106,14 +106,14 @@ impl Bitfield {
         Bitfield([0, 0, 0, 0])
     }
 
-    pub fn set_bits_le(self, bit: u32) -> Self {
+    pub fn set_bits_le(self, bit: u8) -> Self {
         if bit == 0 {
             return self;
         }
         self.set_bits_leq(bit - 1)
     }
 
-    pub fn set_bits_leq(mut self, bit: u32) -> Self {
+    pub fn set_bits_leq(mut self, bit: u8) -> Self {
         if bit < 64 {
             self.0[0] = set_bits_leq(self.0[0], bit);
         } else if bit < 128 {
@@ -135,7 +135,7 @@ impl Bitfield {
 }
 
 #[inline]
-fn set_bits_leq(v: u64, bit: u32) -> u64 {
+fn set_bits_leq(v: u64, bit: u8) -> u64 {
     (v as u128 | ((1u128 << (1 + bit)) - 1)) as u64
 }
 

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -478,18 +478,18 @@ where
         Ok(())
     }
 
-    fn rm_child(&mut self, i: usize, idx: u32) -> Pointer<K, V, H, Ver> {
+    fn rm_child(&mut self, i: usize, idx: u8) -> Pointer<K, V, H, Ver> {
         self.bitfield.clear_bit(idx);
         self.pointers.remove(i)
     }
 
-    fn insert_child(&mut self, idx: u32, key: K, value: V) {
+    fn insert_child(&mut self, idx: u8, key: K, value: V) {
         let i = self.index_for_bit_pos(idx);
         self.bitfield.set_bit(idx);
         self.pointers.insert(i, Pointer::from_key_value(key, value))
     }
 
-    fn insert_child_dirty(&mut self, idx: u32, node: Box<Node<K, V, H, Ver>>) {
+    fn insert_child_dirty(&mut self, idx: u8, node: Box<Node<K, V, H, Ver>>) {
         let i = self.index_for_bit_pos(idx);
         self.bitfield.set_bit(idx);
         self.pointers.insert(i, Pointer::Dirty(node))
@@ -517,9 +517,9 @@ where
 }
 
 impl<K, V, H, Ver> Node<K, V, H, Ver> {
-    pub(crate) fn index_for_bit_pos(&self, bp: u32) -> usize {
+    pub(crate) fn index_for_bit_pos(&self, bp: u8) -> usize {
         let mask = Bitfield::zero().set_bits_le(bp);
-        assert_eq!(mask.count_ones(), bp as usize);
+        debug_assert_eq!(mask.count_ones(), bp as usize);
         mask.and(&self.bitfield).count_ones()
     }
 }


### PR DESCRIPTION
Using a u8 here means we can statically guarantee that no bitfield access will panic due to a bounds error.

Based on https://github.com/filecoin-project/ref-fvm/pull/1864