### PR TITLE
chore: release fvm_ipld_bitfield

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,7 +1605,7 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "frc46_token",
- "fvm_ipld_bitfield 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_bitfield 0.5.4",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.7.0",
@@ -1629,7 +1629,7 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_amt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_bitfield 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_bitfield 0.5.4",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.7.0",
@@ -1785,7 +1785,7 @@ dependencies = [
  "castaway",
  "cid 0.10.1",
  "fvm_ipld_amt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_bitfield 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_bitfield 0.5.4",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.7.0",
@@ -2519,6 +2519,18 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
+dependencies = [
+ "fvm_ipld_encoding 0.3.3",
+ "serde",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "fvm_ipld_bitfield"
+version = "0.6.0"
 dependencies = [
  "arbitrary",
  "criterion",
@@ -2528,18 +2540,6 @@ dependencies = [
  "rand_xorshift",
  "serde",
  "serde_json",
- "thiserror",
- "unsigned-varint",
-]
-
-[[package]]
-name = "fvm_ipld_bitfield"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
-dependencies = [
- "fvm_ipld_encoding 0.3.3",
- "serde",
  "thiserror",
  "unsigned-varint",
 ]

--- a/ipld/bitfield/CHANGELOG.md
+++ b/ipld/bitfield/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to Filecoin's Bitfield library.
 
 ## [Unreleased]
 
+## 0.6.0 [2023-08-31]
+
+- Bumps `fvm_ipld_encoding` to 0.4.0, and `fvm_ipld_blockstore` to 0.2.0.
+
 ## 0.5.4 [2022-10-11]
 
 - Bumps `fvm_ipld_encoding` and switches from `cs_serde_bytes` to `fvm_ipld_encoding::strict_bytes`.

--- a/ipld/bitfield/Cargo.toml
+++ b/ipld/bitfield/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_bitfield"
 description = "Bitfield logic for use in Filecoin actors"
-version = "0.5.4"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"


### PR DESCRIPTION
No code changes, but this pulls in a newer version of the blockstore/encoding crates.