### PR TITLE
chore: move some deps from shared to the FVM

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 thiserror = "1.0.40"
 num-traits = "0.2"
 cid = { workspace = true, features = ["serde-codec"] }
-multihash = { workspace = true }
+multihash = { workspace = true, features = ["sha2", "sha3", "ripemd"] }
 fvm_shared = { version = "3.5.0", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.8.0", path = "../ipld/hamt" }
 fvm_ipld_amt = { version = "0.6.1", path = "../ipld/amt" }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -18,7 +18,7 @@ data-encoding = "2.4.0"
 data-encoding-macro = "0.1.13"
 lazy_static = "1.4.0"
 cid = { workspace = true, features = ["serde-codec", "std"] }
-multihash = { workspace = true, features = ["multihash-impl", "sha2", "sha3", "ripemd"] }
+multihash = { workspace = true }
 unsigned-varint = "0.7.1"
 anyhow = "1.0.71"
 fvm_ipld_encoding = { version = "0.4", path = "../ipld/encoding" }


### PR DESCRIPTION
These should have been deps of the FVM all along. This removes a few dependencies from the sdk.