### PR TITLE
feat(car): replace integer-encoding with unsigned-varint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,9 +2547,9 @@ dependencies = [
  "futures",
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
- "integer-encoding",
  "serde",
  "thiserror",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -4765,9 +4765,13 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
+checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+dependencies = [
+ "futures-io",
+ "futures-util",
+]
 
 [[package]]
 name = "url"

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -12,9 +12,9 @@ cid = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 futures = "0.3.28"
-integer-encoding = { version = "3.0", features = ["futures_async"] }
 fvm_ipld_blockstore = { version = "0.2", path = "../blockstore" }
 fvm_ipld_encoding = { version = "0.4", path = "../encoding" }
+unsigned-varint = { version = "0.7.2", features = ["futures"] }
 
 [dev-dependencies]
 async-std = { version = "1.12", features = ["attributes"] }

--- a/ipld/car/src/util.rs
+++ b/ipld/car/src/util.rs
@@ -4,7 +4,7 @@
 
 use cid::Cid;
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use integer_encoding::{VarIntAsyncReader, VarIntAsyncWriter};
+use unsigned_varint::io::ReadError;
 
 use super::error::Error;
 
@@ -13,14 +13,17 @@ where
     R: AsyncRead + Send + Unpin,
 {
     const MAX_ALLOC: usize = 1 << 20;
-    let l: usize = match VarIntAsyncReader::read_varint_async(&mut reader).await {
+    let l: usize = match unsigned_varint::aio::read_usize(&mut reader).await {
         Ok(len) => len,
-        Err(e) => {
-            if e.kind() == std::io::ErrorKind::UnexpectedEof {
-                return Ok(None);
+        Err(ReadError::Io(e)) => {
+            return if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                Ok(None)
+            } else {
+                Err(Error::Io(e))
             }
-            return Err(Error::Other(e.to_string()));
         }
+        Err(ReadError::Decode(e)) => return Err(Error::ParsingError(e.to_string())),
+        Err(e) => return Err(Error::Other(e.to_string())),
     };
     let mut buf = Vec::with_capacity(std::cmp::min(l, MAX_ALLOC));
     let bytes_read = reader
@@ -44,7 +47,9 @@ pub(crate) async fn ld_write<'a, W>(writer: &mut W, bytes: &[u8]) -> Result<(), 
 where
     W: AsyncWrite + Send + Unpin,
 {
-    writer.write_varint_async(bytes.len()).await?;
+    let mut len = unsigned_varint::encode::usize_buffer();
+    let len = unsigned_varint::encode::usize(bytes.len(), &mut len);
+    writer.write_all(len).await?;
     writer.write_all(bytes).await?;
     writer.flush().await?;
     Ok(())

--- a/ipld/car/src/util.rs
+++ b/ipld/car/src/util.rs
@@ -47,8 +47,8 @@ pub(crate) async fn ld_write<'a, W>(writer: &mut W, bytes: &[u8]) -> Result<(), 
 where
     W: AsyncWrite + Send + Unpin,
 {
-    let mut len = unsigned_varint::encode::usize_buffer();
-    let len = unsigned_varint::encode::usize(bytes.len(), &mut len);
+    let mut buff = unsigned_varint::encode::usize_buffer();
+    let len = unsigned_varint::encode::usize(bytes.len(), &mut buff);
     writer.write_all(len).await?;
     writer.write_all(bytes).await?;
     writer.flush().await?;


### PR DESCRIPTION
This is what we use in the FVM and the builtin actors. I'm switching to it now because we can't upgrade to the latest version of the integer-encoding library due to a breaking change (the futures it produces are no longer send).