### PR TITLE
chore: release fvm v2.7.0 & fvm_shared v2.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,13 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 2.7.0 (2023-09-06)
+
+- Upgrade wasmtime to v12. Unlike prior wasmtime upgrades, this shouldn't be a breaking change as it now mangles its symbols.
+- BREAKING: Upgrade the proofs API to v16.
+- BREAKING (linking): upgrade blstrs to v0.7 and
+- BREAKING: update the minimum rust version to 1.70.0
+
 ## 2.6.0 (2023-08-18)
 
 Breaking Changes:

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "2.6.0"
+version = "2.7.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -19,7 +19,7 @@ derive_builder = "0.12.0"
 num-derive = "0.4.0"
 cid = { workspace = true, features = ["serde-codec"] }
 multihash = { workspace = true }
-fvm_shared = { version = "2.5.0", path = "../shared", features = ["crypto"] }
+fvm_shared = { version = "2.6.0", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { workspace = true }
-fvm_shared = { version = "2.5.0", path = "../shared" }
+fvm_shared = { version = "2.6.0", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = { version = "1.4.0" }

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.6.0 (2023-09-06)
+
+- BREAKING: Upgrade the proofs API to v16.
+- BREAKING (linking): upgrade blstrs to v0.7 and
+- BREAKING: update the minimum rust version to 1.70.0
+
 ## 2.5.0 (2023-06-28)
 
 Breaking Changes:

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "2.5.0", path = "../../shared" }
+fvm_shared = { version = "2.6.0", path = "../../shared" }
 fvm_ipld_hamt = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 fvm_ipld_car = { workspace = true }
@@ -51,7 +51,7 @@ tar = { version = "0.4.38", default-features = false }
 zstd = { version = "0.12.3", default-features = false }
 
 [dependencies.fvm]
-version = "2.6.0"
+version = "2.7.0"
 path = "../../fvm"
 default-features = false
 features = ["testing"]


### PR DESCRIPTION
- Updates proofs.
- Updates wasmtime.
- Other misc dep updates.