### PR TITLE
chore: release integration tests 3.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_integration_tests"
 description = "Filecoin Virtual Machine integration tests framework"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs", "Polyphene"]


### PR DESCRIPTION
We need this in the helix libraries.