### PR TITLE
chore: fix build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-RUSTFLAGS="-C target-feature=+crt-static"
-
 all: build
 .PHONY: all
 
@@ -11,8 +9,8 @@ clean:
 	cargo clean
 
 lint:
-	cargo fmt --all
-	cargo clippy --all --all-targets -- -D warnings -A clippy::upper_case_acronyms
+	cargo fmt --all --check
+	cargo clippy --all --all-targets -- -D warnings
 
 license:
 	./scripts/add_license.sh

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ See the [Project Website](https://fvm.filecoin.io/) for details.
 
 ```sh
 $ git clone https://github.com/filecoin-project/ref-fvm.git
-$ cd fvm
-$ rustup target add wasm32-unknown-unknown
+$ cd ref-fvm
 $ make
 ```
 


### PR DESCRIPTION
- Don't set rust flags manually.
- Cargo fmt check, don't actually format.
- Don't allow warnings in the makefile.
- Let rustup install the correct targets automatically.

replaces #1883