### PR TITLE
feat: charge event gas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2479,6 +2479,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "libsecp256k1",
+ "minstant",
  "multihash 0.18.1",
  "num-traits",
  "rand",
@@ -3462,9 +3463,9 @@ dependencies = [
 
 [[package]]
 name = "minstant"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5dcfca9a0725105ac948b84cfeb69c3942814c696326743797215413f854b9"
+checksum = "7df94bf4a15ed69e64ea45405e504ef293a3614413e7d8f5529112c5acd4a114"
 dependencies = [
  "ctor",
  "libc",

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -901,10 +901,17 @@ where
 /// If an actor aborts, the last layer should be discarded (discard_last_layer). This will also
 /// throw away any events collected from subcalls (and previously merged, as those subcalls returned
 /// normally).
-#[derive(Default)]
 pub struct EventsAccumulator {
     events: Vec<StampedEvent>,
     idxs: Vec<usize>,
+}
+impl Default for EventsAccumulator {
+    fn default() -> Self {
+        Self {
+            events: Vec::with_capacity(128),
+            idxs: Vec::with_capacity(8),
+        }
+    }
 }
 
 pub(crate) struct Events {

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -907,6 +907,8 @@ pub struct EventsAccumulator {
 }
 impl Default for EventsAccumulator {
     fn default() -> Self {
+        // Pre-allocate some space here for more consistent performance. We only do this once per
+        // message so the overhead is minimal.
         Self {
             events: Vec::with_capacity(128),
             idxs: Vec::with_capacity(8),

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -309,14 +309,11 @@ lazy_static! {
             memory_fill_per_byte_cost: Gas::from_milligas(400),
         },
 
-        // TODO(#1817): Per-entry event validation cost. These parameters were benchmarked for the
-        // EVM but haven't been revisited since revising the API.
         event_per_entry: ScalingCost {
             flat: Gas::new(2000),
             scale: Gas::new(1400),
         },
 
-        // TODO(#1817): Cost of validating utf8 (used in event parsing).
         utf8_validation: ScalingCost {
             flat: Gas::new(500),
             scale: Gas::new(16),

--- a/testing/calibration/shared/src/lib.rs
+++ b/testing/calibration/shared/src/lib.rs
@@ -19,7 +19,7 @@ pub enum Method {
     OnRecoverSecpPublicKey,
     /// Measure sends
     OnSend,
-    /// Emit events, driven by the selected mode. See EventCalibrationMode for more info.
+    /// Emit events
     OnEvent,
     /// Read/write blocks with different numbers of CBOR fields & links.
     OnScanIpldLinks,
@@ -65,17 +65,10 @@ pub struct OnRecoverSecpPublicKeyParams {
 }
 
 #[derive(Serialize, Deserialize)]
-pub enum EventCalibrationMode {
-    /// Produce events with the specified shape.
-    Shape((usize, usize, usize)),
-    /// Attempt to reach a target size for the CBOR event.
-    TargetSize(usize),
-}
-
-#[derive(Serialize, Deserialize)]
 pub struct OnEventParams {
     pub iterations: usize,
-    pub mode: EventCalibrationMode,
+    // Total size of the values.
+    pub total_value_size: usize,
     /// Number of entries in the event.
     pub entries: usize,
     /// Flags to apply to all entries.

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -41,8 +41,9 @@ serde_json = "1.0"
 bls-signatures = { version = "0.13", default-features = false }
 wat = "1.0.66"
 hex = "0.4.3"
+minstant = "0.1.3"
 
 [features]
 default = []
 m2-native = []
-calibration = []
+calibration = ["fvm/gas_calibration"]

--- a/testing/integration/tests/gas_calibration_test.rs
+++ b/testing/integration/tests/gas_calibration_test.rs
@@ -3,6 +3,7 @@
 mod calibration;
 #[cfg(feature = "calibration")]
 use calibration::*;
+#[cfg(feature = "calibration")]
 use fvm_gas_calibration_shared::*;
 
 #[test]
@@ -81,140 +82,148 @@ fn on_block() {
     }
 }
 
-// TODO (fridrik): Enable this test after closing #1699
-//#[test]
-#[allow(dead_code)]
+#[test]
 #[cfg(feature = "calibration")]
-fn on_event_evm_shapes() {
+fn on_event_by_value_size() {
     use fvm_shared::event::Flags;
     use rand::{thread_rng, Rng};
 
-    const CHARGE_VALIDATE: &str = "OnActorEventValidate";
-    const CHARGE_ACCEPT: &str = "OnActorEventAccept";
+    const CHARGE: &str = "OnActorEvent";
     const METHOD: Method = Method::OnEvent;
 
-    let entries = 1..=5;
-    let (key_size, value_size) = (2, 32); // 2 bytes per key, 32 bytes per value (topics)
-    let last_entry_value_sizes = (5u32..=13).map(|n| u64::pow(2, n) as usize); // 32 bytes to 8KiB (payload)
-
     let iterations = 500;
-
-    let (mut validate_obs, mut accept_obs) = (Vec::new(), Vec::new());
-
     let mut te = instantiate_tester();
-
     let mut rng = thread_rng();
 
-    for entry_count in entries {
-        for last_entry_value_size in last_entry_value_sizes.clone() {
-            let label = format!("{entry_count:?}entries");
+    let mut obs = Vec::new();
+
+    let entry_counts = &[1usize, 16, 127, 255];
+    for &entries in entry_counts {
+        for total_value_size in (8..=13).map(|x| usize::pow(2, x)) {
+            let label = format!("{entries}-entries");
             let params = OnEventParams {
                 iterations,
                 // number of entries to emit
-                entries: entry_count,
-                mode: EventCalibrationMode::Shape((key_size, value_size, last_entry_value_size)),
+                entries,
+                total_value_size,
                 flags: Flags::FLAG_INDEXED_ALL,
                 seed: rng.gen(),
             };
 
             let ret = te.execute_or_die(METHOD as u64, &params);
 
-            // Estimated length of the CBOR payload (confirmed with observations)
-            // 1 is the list header; 5 per entry CBOR overhead + flags.
-            let len = 1
-                + ((entry_count - 1) * value_size)
-                + last_entry_value_size
-                + entry_count * key_size
-                + entry_count * 5;
-
-            {
-                let mut series = collect_obs(&ret.clone(), CHARGE_VALIDATE, &label, len);
-                series = eliminate_outliers(series, 0.02, Eliminate::Top);
-                validate_obs.extend(series);
-            };
-
-            {
-                let mut series = collect_obs(&ret.clone(), CHARGE_ACCEPT, &label, len);
-                series = eliminate_outliers(series, 0.02, Eliminate::Top);
-                accept_obs.extend(series);
-            };
+            let mut series = collect_obs(&ret.clone(), CHARGE, &label, total_value_size);
+            series = eliminate_outliers(series, 0.02, Eliminate::Top);
+            obs.extend(series);
         }
     }
 
-    for (obs, name) in vec![(validate_obs, CHARGE_VALIDATE), (accept_obs, CHARGE_ACCEPT)].iter() {
-        let regression = run_linear_regression(obs);
+    let regression = run_linear_regression(&obs);
 
-        export(name, obs, &regression).unwrap();
-    }
+    export("OnActorEventValue", &obs, &regression).unwrap();
 }
 
-// intentionally left disabled since we're not interested in these observations at this stage.
-#[allow(dead_code)]
-fn on_event_target_size() {
-    const CHARGE_VALIDATE: &str = "OnActorEventValidate";
-    const CHARGE_ACCEPT: &str = "OnActorEventAccept";
-    const METHOD: Method = Method::OnEvent;
-
-    use calibration::*;
+#[test]
+#[cfg(feature = "calibration")]
+fn on_event_by_entry_count() {
     use fvm_shared::event::Flags;
     use rand::{thread_rng, Rng};
 
-    let mut config: Vec<(usize, usize)> = vec![];
-    // 1 entry, ranging 8..1024 bytes
-    config.extend((3u32..=10).map(|n| (1usize, u64::pow(2, n) as usize)));
-    // 2 entry, ranging 16..1024 bytes
-    config.extend((4u32..=10).map(|n| (2usize, u64::pow(2, n) as usize)));
-    // 4 entries, ranging 32..1024 bytes
-    config.extend((5u32..=10).map(|n| (4usize, u64::pow(2, n) as usize)));
-    // 8 entries, ranging 64..1024 bytes
-    config.extend((6u32..=10).map(|n| (8usize, u64::pow(2, n) as usize)));
-    // 16 entries, ranging 128..1024 bytes
-    config.extend((7u32..=10).map(|n| (16usize, u64::pow(2, n) as usize)));
-    // 32 entries, ranging 256..1024 bytes
-    config.extend((8u32..=10).map(|n| (32usize, u64::pow(2, n) as usize)));
-    // 64 entries, ranging 512..1024 bytes
-    config.extend((9u32..=10).map(|n| (64usize, u64::pow(2, n) as usize)));
+    const CHARGE: &str = "OnActorEvent";
+    const METHOD: Method = Method::OnEvent;
 
     let iterations = 500;
-
-    let (mut validate_obs, mut accept_obs) = (Vec::new(), Vec::new());
-
     let mut te = instantiate_tester();
-
     let mut rng = thread_rng();
 
-    for (entries, target_size) in config.iter() {
-        let label = format!("{entries:?}entries");
-        let params = OnEventParams {
-            iterations,
-            // number of entries to emit
-            entries: *entries,
-            // target size of the encoded CBOR; this is approximate.
-            mode: EventCalibrationMode::TargetSize(*target_size),
-            flags: Flags::FLAG_INDEXED_ALL,
-            seed: rng.gen(),
-        };
+    let mut obs = Vec::new();
 
-        let ret = te.execute_or_die(METHOD as u64, &params);
+    let total_value_sizes = &[255, 1024, 4096, 8192];
+    for &total_value_size in total_value_sizes {
+        for entries in (1..=8).map(|x| usize::pow(2, x) - 1) {
+            let label = format!("{total_value_size}-size");
+            let params = OnEventParams {
+                iterations,
+                // number of entries to emit
+                entries,
+                total_value_size,
+                flags: Flags::FLAG_INDEXED_ALL,
+                seed: rng.gen(),
+            };
 
-        {
-            let mut series = collect_obs(&ret.clone(), CHARGE_VALIDATE, &label, *target_size);
+            let ret = te.execute_or_die(METHOD as u64, &params);
+
+            let mut series = collect_obs(&ret.clone(), CHARGE, &label, entries);
             series = eliminate_outliers(series, 0.02, Eliminate::Top);
-            validate_obs.extend(series);
-        };
-
-        {
-            let mut series = collect_obs(&ret.clone(), CHARGE_ACCEPT, &label, *target_size);
-            series = eliminate_outliers(series, 0.02, Eliminate::Top);
-            accept_obs.extend(series);
-        };
+            obs.extend(series);
+        }
     }
 
-    for (obs, name) in vec![(validate_obs, CHARGE_VALIDATE), (accept_obs, CHARGE_ACCEPT)].iter() {
-        let regression = run_linear_regression(obs);
+    let regression = run_linear_regression(&obs);
 
-        export(name, obs, &regression).unwrap();
+    export("OnActorEventEntries", &obs, &regression).unwrap();
+}
+
+#[test]
+#[cfg(feature = "calibration")]
+fn utf8_validation() {
+    use fvm::gas::price_list_by_network_version;
+    use fvm_shared::version::NetworkVersion;
+    use rand::{distributions::Standard, thread_rng, Rng};
+
+    let mut chars = thread_rng().sample_iter(Standard);
+    const CHARGE: &str = "OnUtf8Validate";
+
+    let iterations = 500;
+    let price_list = price_list_by_network_version(NetworkVersion::V21);
+
+    let mut obs = Vec::new();
+    #[derive(Debug, Copy, Clone)]
+    enum Kind {
+        Ascii,
+        MaxUtf8,
+        RandomUtf8,
     }
+    use Kind::*;
+    for size in (0..=8).map(|x| usize::pow(2, x)) {
+        for kind in [Ascii, RandomUtf8, MaxUtf8] {
+            let mut series = Vec::new();
+            for _ in 0..iterations {
+                let rand_str: String = match kind {
+                    Ascii => "a".repeat(size),
+                    MaxUtf8 => char::REPLACEMENT_CHARACTER.to_string().repeat(size / 2),
+                    RandomUtf8 => chars
+                        .by_ref()
+                        .take_while({
+                            let mut total: usize = 0;
+                            move |c: &char| {
+                                total += c.len_utf8();
+                                total < size
+                            }
+                        })
+                        .collect(),
+                };
+                let charge = price_list.on_utf8_validation(rand_str.len());
+                let start = minstant::Instant::now();
+                let _ = std::hint::black_box(std::str::from_utf8(std::hint::black_box(
+                    rand_str.as_bytes(),
+                )));
+                let time = start.elapsed();
+                series.push(Obs {
+                    charge: CHARGE.into(),
+                    label: format!("{:?}-validate", kind),
+                    elapsed_nanos: time.as_nanos(),
+                    variables: vec![rand_str.len()],
+                    compute_gas: charge.compute_gas.as_milligas(),
+                })
+            }
+            obs.extend(eliminate_outliers(series, 0.02, Eliminate::Both));
+        }
+    }
+
+    let regression = run_linear_regression(&obs);
+
+    export(CHARGE, &obs, &regression).unwrap();
 }
 
 #[test]

--- a/testing/test_actors/actors/fil-events-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-events-actor/src/actor.rs
@@ -71,6 +71,56 @@ pub fn invoke(params: u32) -> u32 {
                 .is_err(),
                 "expected failed syscall"
             );
+
+            // Invalid utf8.
+            let emoji_key = "🧑";
+
+            // Partial code.
+             let entry = fvm_shared::sys::EventEntry {
+                flags: Flags::empty(),
+                codec: IPLD_RAW,
+                key_len: 1,
+                val_len: 0,
+            };
+            assert!(
+                sdk::sys::event::emit_event(
+                    &entry as *const fvm_shared::sys::EventEntry,
+                    1,
+                    emoji_key.as_ptr(),
+                    1,
+                    ptr::null(),
+                    0,
+                )
+                .is_err(),
+                "expected failed syscall"
+            );
+            // Correct utf8 but invalid boundaries.
+             let entries = [
+                fvm_shared::sys::EventEntry {
+                    flags: Flags::empty(),
+                    codec: IPLD_RAW,
+                    key_len: 1,
+                    val_len: 0,
+                },
+                fvm_shared::sys::EventEntry {
+                    flags: Flags::empty(),
+                    codec: IPLD_RAW,
+                    key_len: emoji_key.len() as u32 - 1,
+                    val_len: 0,
+                },
+            ];
+            assert!(
+                sdk::sys::event::emit_event(
+                    entries.as_ptr(),
+                    2,
+                    emoji_key.as_ptr(),
+                    emoji_key.len() as u32,
+                    ptr::null(),
+                    0,
+                )
+                .is_err(),
+                "expected failed syscall"
+            );
         },
         EMIT_SUBCALLS => {
             let msg_params = sdk::message::params_raw(params).unwrap().unwrap();

--- a/testing/test_actors/actors/fil-events-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-events-actor/src/actor.rs
@@ -40,7 +40,7 @@ pub fn invoke(params: u32) -> u32 {
         },
         Entry {
             flags: Flags::FLAG_INDEXED_KEY | Flags::FLAG_INDEXED_VALUE,
-            key: "baz".to_string(),
+            key: "👱".to_string(),
             codec: IPLD_RAW,
             value: payload3.to_owned(),
         },

--- a/testing/test_actors/actors/fil-events-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-events-actor/src/actor.rs
@@ -76,7 +76,7 @@ pub fn invoke(params: u32) -> u32 {
             let emoji_key = "🧑";
 
             // Partial code.
-             let entry = fvm_shared::sys::EventEntry {
+            let entry = fvm_shared::sys::EventEntry {
                 flags: Flags::empty(),
                 codec: IPLD_RAW,
                 key_len: 1,
@@ -95,7 +95,7 @@ pub fn invoke(params: u32) -> u32 {
                 "expected failed syscall"
             );
             // Correct utf8 but invalid boundaries.
-             let entries = [
+            let entries = [
                 fvm_shared::sys::EventEntry {
                     flags: Flags::empty(),
                     codec: IPLD_RAW,


### PR DESCRIPTION
This charges the correct event gas and adds a few benchmarks. It also:

1. Tries to remove some variability when recording events by pre-allocating space.`
2. Validates utf8 up-front, then slices the validated string for better performance (and easier benchmarking).