### PR TITLE
chore: release v4.0.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,17 +235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,19 +395,6 @@ dependencies = [
  "arrayref",
  "arrayvec 0.7.4",
  "constant_time_eq 0.2.6",
-]
-
-[[package]]
-name = "blake3"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.4",
- "cc",
- "cfg-if",
- "constant_time_eq 0.3.0",
 ]
 
 [[package]]
@@ -690,29 +666,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_derive 3.2.25",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
 dependencies = [
  "clap_builder",
- "clap_derive 4.4.2",
+ "clap_derive",
 ]
 
 [[package]]
@@ -722,20 +681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
 dependencies = [
  "anstyle",
- "clap_lex 0.5.1",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "clap_lex",
 ]
 
 [[package]]
@@ -748,15 +694,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.31",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -810,12 +747,6 @@ name = "constant_time_eq"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "convert_case"
@@ -977,7 +908,7 @@ dependencies = [
  "async-std",
  "cast",
  "ciborium",
- "clap 4.4.2",
+ "clap",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -1452,7 +1383,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_account"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
  "fil_actors_runtime",
@@ -1468,27 +1399,27 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_bundler"
-version = "5.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3138c84b845e64c6ad0c50ef299f954d979bd265c8b74509a22b9d1b8107e0"
+checksum = "e0b1448c65c9a054c640fc086e03b730919ca4feca697c34ed3bda9f16aa982f"
 dependencies = [
  "anyhow",
  "async-std",
- "cid 0.8.6",
- "clap 3.2.25",
+ "cid 0.10.1",
+ "clap",
  "futures",
- "fvm_ipld_blockstore 0.1.2",
- "fvm_ipld_car 0.6.0",
- "fvm_ipld_encoding 0.3.3",
+ "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_car 0.7.0",
+ "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
- "serde_ipld_dagcbor 0.2.2",
+ "serde_ipld_dagcbor",
  "serde_json",
 ]
 
 [[package]]
 name = "fil_actor_cron"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1503,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_datacap"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "cid 0.10.1",
  "fil_actors_runtime",
@@ -1524,7 +1455,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_eam"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1545,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_ethaccount"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
@@ -1561,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_evm"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1585,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_init"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1604,14 +1535,14 @@ dependencies = [
 [[package]]
 name = "fil_actor_market"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
  "fil_actors_runtime",
  "frc42_dispatch",
  "frc46_token",
- "fvm_ipld_bitfield 0.5.4",
+ "fvm_ipld_bitfield 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.7.0",
@@ -1627,15 +1558,16 @@ dependencies = [
 [[package]]
 name = "fil_actor_miner"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
+ "bitflags 2.4.0",
  "byteorder",
  "cid 0.10.1",
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_amt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_bitfield 0.5.4",
+ "fvm_ipld_bitfield 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.7.0",
@@ -1652,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_multisig"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1673,7 +1605,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_paych"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1690,12 +1622,12 @@ dependencies = [
 [[package]]
 name = "fil_actor_placeholder"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 
 [[package]]
 name = "fil_actor_power"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1717,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_reward"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1733,7 +1665,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_system"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1749,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_verifreg"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1771,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_evm_shared"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1784,15 +1716,14 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
- "base64 0.21.3",
  "byteorder",
  "castaway",
  "cid 0.10.1",
  "fvm_ipld_amt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_bitfield 0.5.4",
+ "fvm_ipld_bitfield 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.7.0",
@@ -1827,10 +1758,10 @@ dependencies = [
 [[package]]
 name = "fil_builtin_actors_bundle"
 version = "12.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "cid 0.10.1",
- "clap 3.2.25",
+ "clap",
  "fil_actor_account",
  "fil_actor_bundler",
  "fil_actor_cron",
@@ -1891,7 +1822,6 @@ dependencies = [
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 4.0.0-alpha.1",
  "fvm_shared 4.0.0-alpha.1",
- "libipld",
  "num-derive 0.4.0",
  "num-traits",
  "serde",
@@ -2099,12 +2029,6 @@ checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
  "spin 0.9.8",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forest_hash_utils"
@@ -2352,7 +2276,6 @@ dependencies = [
  "replace_with",
  "serde",
  "serde_tuple",
- "static_assertions",
  "thiserror",
  "wasmtime",
  "wasmtime-environ",
@@ -2365,7 +2288,7 @@ name = "fvm-bench"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.4.2",
+ "clap",
  "env_logger 0.10.0",
  "fvm",
  "fvm_integration_tests",
@@ -2472,7 +2395,6 @@ dependencies = [
  "hex",
  "lazy_static",
  "libsecp256k1",
- "minstant",
  "multihash 0.18.1",
  "num-traits",
  "rand",
@@ -2520,18 +2442,6 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_bitfield"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
-dependencies = [
- "fvm_ipld_encoding 0.3.3",
- "serde",
- "thiserror",
- "unsigned-varint",
-]
-
-[[package]]
-name = "fvm_ipld_bitfield"
 version = "0.6.0"
 dependencies = [
  "arbitrary",
@@ -2547,14 +2457,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "fvm_ipld_blockstore"
-version = "0.1.2"
+name = "fvm_ipld_bitfield"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee8c75be2b58943e1a9755802d34d4c3934f6ea151b6be192ff98f644e515bd"
+checksum = "da94287cafa663c2e295fe45c4c9dbf5ab7b52f648568f9ae3823deaf9873a89"
 dependencies = [
- "anyhow",
- "cid 0.8.6",
- "multihash 0.16.3",
+ "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "thiserror",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2579,14 +2490,14 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_car"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60423568393a284de6d7c342cd664690611f27d223eb78629fa568ddd4e7951"
+checksum = "42a70f56d42a428d60b89440136428f8af7abc723dcf6d763d82e28d518a8141"
 dependencies = [
- "cid 0.8.6",
+ "cid 0.10.1",
  "futures",
- "fvm_ipld_blockstore 0.1.2",
- "fvm_ipld_encoding 0.3.3",
+ "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding",
  "serde",
  "thiserror",
@@ -2608,23 +2519,6 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_encoding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0816a2a6df4853de08a723d261110d56a121aa313bc570fe9d248f0a4bc5288"
-dependencies = [
- "anyhow",
- "cid 0.8.6",
- "fvm_ipld_blockstore 0.1.2",
- "multihash 0.16.3",
- "serde",
- "serde_ipld_dagcbor 0.2.2",
- "serde_repr",
- "serde_tuple",
- "thiserror",
-]
-
-[[package]]
-name = "fvm_ipld_encoding"
 version = "0.4.0"
 dependencies = [
  "anyhow",
@@ -2632,7 +2526,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "multihash 0.18.1",
  "serde",
- "serde_ipld_dagcbor 0.4.1",
+ "serde_ipld_dagcbor",
  "serde_json",
  "serde_repr",
  "serde_tuple",
@@ -2650,7 +2544,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash 0.18.1",
  "serde",
- "serde_ipld_dagcbor 0.4.1",
+ "serde_ipld_dagcbor",
  "serde_repr",
  "serde_tuple",
  "thiserror",
@@ -2759,7 +2653,6 @@ dependencies = [
 name = "fvm_sdk"
 version = "4.0.0-alpha.1"
 dependencies = [
- "byteorder",
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_shared 4.0.0-alpha.1",
@@ -2968,15 +2861,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -3119,7 +3003,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
@@ -3139,7 +3023,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "rustix 0.38.11",
  "windows-sys",
 ]
@@ -3261,20 +3145,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
-name = "libipld"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ccd6b8ffb3afee7081fcaec00e1b099fd1c7ccf35ba5729d88538fcc3b4599"
-dependencies = [
- "fnv",
- "libipld-core 0.16.0",
- "libipld-macro",
- "log",
- "multihash 0.18.1",
- "thiserror",
-]
-
-[[package]]
 name = "libipld-core"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3302,15 +3172,6 @@ dependencies = [
  "multihash 0.18.1",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "libipld-macro"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71171c54214f866ae6722f3027f81dff0931e600e5a61e6b1b6a49ca0b5ed4ae"
-dependencies = [
- "libipld-core 0.16.0",
 ]
 
 [[package]]
@@ -3504,16 +3365,10 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
- "blake2b_simd",
- "blake2s_simd 1.0.1",
- "blake3",
  "core2",
- "digest 0.10.7",
  "multihash-derive",
  "serde",
  "serde-big-array",
- "sha2 0.10.7",
- "sha3",
  "unsigned-varint",
 ]
 
@@ -3692,7 +3547,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3753,12 +3608,6 @@ dependencies = [
  "cl3",
  "libc",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "pairing"
@@ -4310,18 +4159,6 @@ dependencies = [
 
 [[package]]
 name = "serde_ipld_dagcbor"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e23de7a4a18dff77ab9531f279a882500b8cf3549fde044d4e10481b411f1e"
-dependencies = [
- "cbor4ii",
- "cid 0.8.6",
- "scopeguard",
- "serde",
-]
-
-[[package]]
-name = "serde_ipld_dagcbor"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74e4c1e1617be5feb2f03f629f8097f76b51373785a83a875453c2b04c880f4e"
@@ -4632,12 +4469,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "substrate-bn"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4753,12 +4584,6 @@ checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -4927,7 +4752,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vm_api"
 version = "1.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=fvm-next#0154f8f05d0699bb2cf01446781fd31bd4e0cf93"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#807630512ba0df9a2d41836f7591c3607ddb0d4f"
 dependencies = [
  "anyhow",
  "cid 0.10.1",

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,16 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.0.0-alpha.2 (2023-09-21)
+
+- Update to wasmtime 12.0.2 (bug fix release)
+- Drop support for versions prior to nv21.
+- Implement FIP-0071, FIP-0072, FIP-0073, FIP-0075
+
+## 4.0.0-alpha.1 (2023-09-20)
+
+Unreleased. This release simply marks the change-over to v4.
+
 ## 3.8.0 (2023-09-06)
 
 - Upgrade wasmtime to v12. Unlike prior wasmtime upgrades, this shouldn't be a breaking change as it now mangles its symbols.

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "4.0.0-alpha.1"
+version = "4.0.0-alpha.2"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -17,7 +17,7 @@ thiserror = "1.0.40"
 num-traits = "0.2"
 cid = { workspace = true, features = ["serde-codec"] }
 multihash = { workspace = true, features = ["sha2", "sha3", "ripemd"] }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../shared", features = ["crypto"] }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.8.0", path = "../ipld/hamt" }
 fvm_ipld_amt = { version = "0.6.1", path = "../ipld/amt" }
 fvm_ipld_blockstore = { version = "0.2.0", path = "../ipld/blockstore" }

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## 4.0.0-alpha.2 (2023-09-21)
+
+- Implement FIP-0071, FIP-0072, FIP-0073, FIP-0075
+
+## 4.0.0-alpha.1 (2023-09-20)
+
+Unreleased. This release simply marks the change-over to v4.
+
 ## 3.3.0 [2023-06-28]
 
 Breaking Changes:

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "4.0.0-alpha.1"
+version = "4.0.0-alpha.2"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cid = { workspace = true }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../shared" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../shared" }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.15", default-features = false }
 lazy_static = { version = "1.4.0" }

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## 4.0.0-alpha.2 (2023-09-21)
+
+- Implement FIP-0071, FIP-0072, FIP-0073, FIP-0075
+
+## 4.0.0-alpha.1 (2023-09-20)
+
+Unreleased. This release simply marks the change-over to v4.
+
 ## 3.6.0 (2023-09-06)
 
 - BREAKING: Upgrade the proofs API to v16.

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "4.0.0-alpha.1"
+version = "4.0.0-alpha.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]

--- a/testing/calibration/shared/Cargo.toml
+++ b/testing/calibration/shared/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Protocol Labs", "Filecoin Core Devs"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../shared", features = ["testing"] }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../shared", features = ["testing"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 num-traits = "0.2"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../shared" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../shared" }
 fvm_ipld_car = { version = "0.7.1", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.2.0", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../ipld/encoding" }
@@ -39,7 +39,7 @@ tar = { version = "0.4.38", default-features = false }
 zstd = { version = "0.12.3", default-features = false }
 
 [dependencies.fvm]
-version = "4.0.0-alpha.1"
+version = "4.0.0-alpha.2"
 path = "../../fvm"
 default-features = false
 features = ["testing"]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "fvm_integration_tests"
 description = "Filecoin Virtual Machine integration tests framework"
-version = "4.0.0-alpha.1"
+version = "4.0.0-alpha.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs", "Polyphene"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "4.0.0-alpha.1", path = "../../fvm", default-features = false, features = ["testing"] }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../shared", features = ["testing"] }
+fvm = { version = "4.0.0-alpha.2", path = "../../fvm", default-features = false, features = ["testing"] }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../shared", features = ["testing"] }
 fvm_ipld_car = { version = "0.7.1", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.2.0", path = "../../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../ipld/encoding" }

--- a/testing/test_actors/actors/fil-address-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-address-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-create-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-create-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 actors_v12_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "fvm-next" }
 
 [lib]

--- a/testing/test_actors/actors/fil-events-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-events-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 serde = {version = "1.0.164", features = ["derive"] }
 serde_tuple = "0.5.0"
 

--- a/testing/test_actors/actors/fil-exit-data-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-exit-data-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 
 [lib]

--- a/testing/test_actors/actors/fil-gas-calibration-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-gas-calibration-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 fvm_gas_calibration_shared = { path = "../../../calibration/shared" }
 

--- a/testing/test_actors/actors/fil-gaslimit-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-gaslimit-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 serde = {version = "1.0.164", features = ["derive"] }
 serde_tuple = "0.5.0"
 log = "0.4.19"

--- a/testing/test_actors/actors/fil-hello-world-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-hello-world-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 fvm_ipld_blockstore = { version = "0.2.0", path = "../../../../ipld/blockstore" }
 

--- a/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 
 [target.'cfg(coverage)'.dependencies]
 minicov = "0.3"

--- a/testing/test_actors/actors/fil-malformed-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-malformed-syscall-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-oom-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-oom-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-readonly-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-readonly-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 cid = { workspace = true }
 

--- a/testing/test_actors/actors/fil-sself-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-sself-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 cid = { workspace = true }
 

--- a/testing/test_actors/actors/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-stack-overflow-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "4.0.0-alpha.1", path = "../../../../sdk" }
-fvm_shared = { version = "4.0.0-alpha.1", path = "../../../../shared" }
+fvm_sdk = { version = "4.0.0-alpha.2", path = "../../../../sdk" }
+fvm_shared = { version = "4.0.0-alpha.2", path = "../../../../shared" }
 minicov = {version = "0.3", optional = true}
 actors_v12_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "fvm-next" }
 multihash = { workspace = true }


### PR DESCRIPTION
We're skipping alpha.1 as we used that release to mark the switch over and I like to keep the version bump at the _end_ of the release cycle (to make it clear where the release happened).