### PR TITLE
fix: auto-create the burnt funds account

### DIFF
--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -20,7 +20,9 @@ use lazy_static::lazy_static;
 use libsecp256k1::{PublicKey, SecretKey};
 use multihash::Code;
 
-use crate::builtin::{fetch_builtin_code_cid, set_eam_actor, set_init_actor, set_sys_actor};
+use crate::builtin::{
+    fetch_builtin_code_cid, set_burnt_funds_account, set_eam_actor, set_init_actor, set_sys_actor,
+};
 use crate::dummy::DummyExterns;
 use crate::error::Error::{FailedToFlushTree, NoManifestInformation};
 
@@ -96,10 +98,11 @@ where
         let init_state = init_actor::State::new_test(&blockstore);
         let mut state_tree = StateTree::new(blockstore, stv).map_err(anyhow::Error::from)?;
 
-        // Deploy init, sys, and eam actors
+        // Deploy init, sys, burn, and eam actors
         let sys_state = system_actor::State { builtin_actors };
         set_sys_actor(&mut state_tree, sys_state, sys_code_cid)?;
         set_init_actor(&mut state_tree, init_code_cid, init_state)?;
+        set_burnt_funds_account(&mut state_tree, accounts_code_cid)?;
         set_eam_actor(&mut state_tree, eam_code_cid)?;
 
         Ok(Tester {


### PR DESCRIPTION
The FVM relies on this so it can burn funds on self-destruct.