### PR TITLE
Remove support of v1 proofs

### DIFF
--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -192,27 +192,6 @@ lazy_static! {
 
         verify_replica_update: Gas::new(36316136),
         verify_post_lookup: [
-            (
-                RegisteredPoStProof::StackedDRGWindow512MiBV1,
-                ScalingCost {
-                    flat: Gas::new(117680921),
-                    scale: Gas::new(43780),
-                },
-            ),
-            (
-                RegisteredPoStProof::StackedDRGWindow32GiBV1,
-                ScalingCost {
-                    flat: Gas::new(117680921),
-                    scale: Gas::new(43780),
-                },
-            ),
-            (
-                RegisteredPoStProof::StackedDRGWindow64GiBV1,
-                ScalingCost {
-                    flat: Gas::new(117680921),
-                    scale: Gas::new(43780),
-                },
-            ),
             (RegisteredPoStProof::StackedDRGWindow512MiBV1P1,
                 ScalingCost {
                     flat: Gas::new(117680921),
@@ -705,10 +684,10 @@ impl PriceList {
             .proofs
             .first()
             .map(|p| p.post_proof)
-            .unwrap_or(RegisteredPoStProof::StackedDRGWindow512MiBV1);
+            .unwrap_or(RegisteredPoStProof::StackedDRGWindow512MiBV1P1);
         let cost = self.verify_post_lookup.get(&p_proof).unwrap_or_else(|| {
             self.verify_post_lookup
-                .get(&RegisteredPoStProof::StackedDRGWindow512MiBV1)
+                .get(&RegisteredPoStProof::StackedDRGWindow512MiBV1P1)
                 .expect("512MiB lookup must exist in price table")
         });
 

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -11,14 +11,12 @@ use filecoin_proofs_api::{self as proofs, ProverId, PublicReplicaInfo, SectorId}
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{bytes_32, IPLD_RAW};
 use fvm_shared::address::Payload;
-use fvm_shared::chainid::ChainID;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::signature;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::event::{ActorEvent, Entry, Flags};
 use fvm_shared::piece::{zero_piece_commitment, PaddedPieceSize};
-use fvm_shared::sector::RegisteredPoStProof::StackedDRGWindow32GiBV1P1;
 use fvm_shared::sector::{RegisteredPoStProof, SectorInfo};
 use fvm_shared::sys::out::vm::ContextFlags;
 use fvm_shared::{commcid, ActorID};
@@ -566,26 +564,9 @@ where
             .call_manager
             .charge_gas(self.call_manager.price_list().on_verify_post(verify_info))?;
 
-        // Due to a bug on calibrationnet, we have some _valid_ StackedDRGWindow32GiBV1P1
-        // proofs that were deemed invalid on chain. This was fixed WITHOUT a network version check.
-        // As a result, we need to explicitly consider all such proofs invalid, ONLY on calibrationnet,
-        // and ONLY before epoch 498691,
-        let calibnet_chain_id = ChainID::from(314159);
-        let mut verify_info = verify_info.clone();
-
-        #[allow(clippy::collapsible_if)]
-        if self.call_manager.context().network.chain_id == calibnet_chain_id {
-            if self.call_manager.context().epoch <= 498691
-                && !verify_info.proofs.is_empty()
-                && verify_info.proofs[0].post_proof == StackedDRGWindow32GiBV1P1
-            {
-                verify_info.proofs[0].post_proof = StackedDRGWindow32GiBV1P1;
-            }
-        }
-
         // This is especially important to catch as, otherwise, a bad "post" could be undisputable.
         t.record(catch_and_log_panic("verifying post", || {
-            verify_post(&verify_info)
+            verify_post(verify_info)
         }))
     }
 

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -18,7 +18,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::event::{ActorEvent, Entry, Flags};
 use fvm_shared::piece::{zero_piece_commitment, PaddedPieceSize};
-use fvm_shared::sector::RegisteredPoStProof::{StackedDRGWindow32GiBV1, StackedDRGWindow32GiBV1P1};
+use fvm_shared::sector::RegisteredPoStProof::StackedDRGWindow32GiBV1P1;
 use fvm_shared::sector::{RegisteredPoStProof, SectorInfo};
 use fvm_shared::sys::out::vm::ContextFlags;
 use fvm_shared::{commcid, ActorID};
@@ -579,7 +579,7 @@ where
                 && !verify_info.proofs.is_empty()
                 && verify_info.proofs[0].post_proof == StackedDRGWindow32GiBV1P1
             {
-                verify_info.proofs[0].post_proof = StackedDRGWindow32GiBV1;
+                verify_info.proofs[0].post_proof = StackedDRGWindow32GiBV1P1;
             }
         }
 
@@ -1227,19 +1227,19 @@ fn check_valid_proof_type(post_type: RegisteredPoStProof, seal_type: RegisteredS
         .unwrap_or(RegisteredPoStProof::Invalid(-1));
     let proof_type_v1 = match proof_type_v1p1 {
         RegisteredPoStProof::StackedDRGWindow2KiBV1P1 => {
-            RegisteredPoStProof::StackedDRGWindow2KiBV1
+            RegisteredPoStProof::StackedDRGWindow2KiBV1P1
         }
         RegisteredPoStProof::StackedDRGWindow8MiBV1P1 => {
-            RegisteredPoStProof::StackedDRGWindow8MiBV1
+            RegisteredPoStProof::StackedDRGWindow8MiBV1P1
         }
         RegisteredPoStProof::StackedDRGWindow512MiBV1P1 => {
-            RegisteredPoStProof::StackedDRGWindow512MiBV1
+            RegisteredPoStProof::StackedDRGWindow512MiBV1P1
         }
         RegisteredPoStProof::StackedDRGWindow32GiBV1P1 => {
-            RegisteredPoStProof::StackedDRGWindow32GiBV1
+            RegisteredPoStProof::StackedDRGWindow32GiBV1P1
         }
         RegisteredPoStProof::StackedDRGWindow64GiBV1P1 => {
-            RegisteredPoStProof::StackedDRGWindow64GiBV1
+            RegisteredPoStProof::StackedDRGWindow64GiBV1P1
         }
         _ => {
             return false;

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -1222,31 +1222,11 @@ fn to_fil_public_replica_infos(
 }
 
 fn check_valid_proof_type(post_type: RegisteredPoStProof, seal_type: RegisteredSealProof) -> bool {
-    let proof_type_v1p1 = seal_type
-        .registered_window_post_proof()
-        .unwrap_or(RegisteredPoStProof::Invalid(-1));
-    let proof_type_v1 = match proof_type_v1p1 {
-        RegisteredPoStProof::StackedDRGWindow2KiBV1P1 => {
-            RegisteredPoStProof::StackedDRGWindow2KiBV1P1
-        }
-        RegisteredPoStProof::StackedDRGWindow8MiBV1P1 => {
-            RegisteredPoStProof::StackedDRGWindow8MiBV1P1
-        }
-        RegisteredPoStProof::StackedDRGWindow512MiBV1P1 => {
-            RegisteredPoStProof::StackedDRGWindow512MiBV1P1
-        }
-        RegisteredPoStProof::StackedDRGWindow32GiBV1P1 => {
-            RegisteredPoStProof::StackedDRGWindow32GiBV1P1
-        }
-        RegisteredPoStProof::StackedDRGWindow64GiBV1P1 => {
-            RegisteredPoStProof::StackedDRGWindow64GiBV1P1
-        }
-        _ => {
-            return false;
-        }
-    };
-
-    proof_type_v1 == post_type || proof_type_v1p1 == post_type
+    if let Ok(proof_type_v1p1) = seal_type.registered_window_post_proof() {
+        proof_type_v1p1 == post_type
+    } else {
+        false
+    }
 }
 
 fn verify_seal(vi: &SealVerifyInfo) -> Result<bool> {

--- a/shared/src/sector/post.rs
+++ b/shared/src/sector/post.rs
@@ -35,16 +35,6 @@ impl quickcheck::Arbitrary for PoStProof {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
         let registered_postproof = g
             .choose(&[
-                RegisteredPoStProof::StackedDRGWinning2KiBV1,
-                RegisteredPoStProof::StackedDRGWinning8MiBV1,
-                RegisteredPoStProof::StackedDRGWinning512MiBV1,
-                RegisteredPoStProof::StackedDRGWinning32GiBV1,
-                RegisteredPoStProof::StackedDRGWinning64GiBV1,
-                RegisteredPoStProof::StackedDRGWindow2KiBV1,
-                RegisteredPoStProof::StackedDRGWindow8MiBV1,
-                RegisteredPoStProof::StackedDRGWindow512MiBV1,
-                RegisteredPoStProof::StackedDRGWindow32GiBV1,
-                RegisteredPoStProof::StackedDRGWindow64GiBV1,
                 RegisteredPoStProof::StackedDRGWindow2KiBV1P1,
                 RegisteredPoStProof::StackedDRGWindow8MiBV1P1,
                 RegisteredPoStProof::StackedDRGWindow512MiBV1P1,

--- a/shared/src/sector/registered_proof.rs
+++ b/shared/src/sector/registered_proof.rs
@@ -115,16 +115,6 @@ impl Default for RegisteredSealProof {
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[cfg_attr(feature = "arb", derive(arbitrary::Arbitrary))]
 pub enum RegisteredPoStProof {
-    StackedDRGWinning2KiBV1,
-    StackedDRGWinning8MiBV1,
-    StackedDRGWinning512MiBV1,
-    StackedDRGWinning32GiBV1,
-    StackedDRGWinning64GiBV1,
-    StackedDRGWindow2KiBV1,
-    StackedDRGWindow8MiBV1,
-    StackedDRGWindow512MiBV1,
-    StackedDRGWindow32GiBV1,
-    StackedDRGWindow64GiBV1,
     StackedDRGWindow2KiBV1P1,
     StackedDRGWindow8MiBV1P1,
     StackedDRGWindow512MiBV1P1,
@@ -138,21 +128,11 @@ impl RegisteredPoStProof {
     pub fn sector_size(self) -> Result<SectorSize, String> {
         use RegisteredPoStProof::*;
         match self {
-            StackedDRGWindow2KiBV1P1 | StackedDRGWindow2KiBV1 | StackedDRGWinning2KiBV1 => {
-                Ok(SectorSize::_2KiB)
-            }
-            StackedDRGWindow8MiBV1P1 | StackedDRGWindow8MiBV1 | StackedDRGWinning8MiBV1 => {
-                Ok(SectorSize::_8MiB)
-            }
-            StackedDRGWindow512MiBV1P1 | StackedDRGWindow512MiBV1 | StackedDRGWinning512MiBV1 => {
-                Ok(SectorSize::_512MiB)
-            }
-            StackedDRGWindow32GiBV1P1 | StackedDRGWindow32GiBV1 | StackedDRGWinning32GiBV1 => {
-                Ok(SectorSize::_32GiB)
-            }
-            StackedDRGWindow64GiBV1P1 | StackedDRGWindow64GiBV1 | StackedDRGWinning64GiBV1 => {
-                Ok(SectorSize::_64GiB)
-            }
+            StackedDRGWindow2KiBV1P1 => Ok(SectorSize::_2KiB),
+            StackedDRGWindow8MiBV1P1 => Ok(SectorSize::_8MiB),
+            StackedDRGWindow512MiBV1P1 => Ok(SectorSize::_512MiB),
+            StackedDRGWindow32GiBV1P1 => Ok(SectorSize::_32GiB),
+            StackedDRGWindow64GiBV1P1 => Ok(SectorSize::_64GiB),
             Invalid(i) => Err(format!("unsupported proof type: {}", i)),
         }
     }
@@ -161,17 +141,7 @@ impl RegisteredPoStProof {
     pub fn proof_size(self) -> Result<usize, String> {
         use RegisteredPoStProof::*;
         match self {
-            StackedDRGWinning2KiBV1
-            | StackedDRGWinning8MiBV1
-            | StackedDRGWinning512MiBV1
-            | StackedDRGWinning32GiBV1
-            | StackedDRGWinning64GiBV1
-            | StackedDRGWindow2KiBV1
-            | StackedDRGWindow8MiBV1
-            | StackedDRGWindow512MiBV1
-            | StackedDRGWindow32GiBV1
-            | StackedDRGWindow64GiBV1
-            | StackedDRGWindow2KiBV1P1
+            StackedDRGWindow2KiBV1P1
             | StackedDRGWindow8MiBV1P1
             | StackedDRGWindow512MiBV1P1
             | StackedDRGWindow32GiBV1P1
@@ -185,17 +155,11 @@ impl RegisteredPoStProof {
         // Resolve to post proof and then compute size from that.
         use RegisteredPoStProof::*;
         match self {
-            StackedDRGWinning64GiBV1 | StackedDRGWindow64GiBV1 | StackedDRGWindow64GiBV1P1 => {
-                Ok(2300)
-            }
-            StackedDRGWinning32GiBV1 | StackedDRGWindow32GiBV1 | StackedDRGWindow32GiBV1P1 => {
-                Ok(2349)
-            }
-            StackedDRGWinning2KiBV1 | StackedDRGWindow2KiBV1 | StackedDRGWindow2KiBV1P1 => Ok(2),
-            StackedDRGWinning8MiBV1 | StackedDRGWindow8MiBV1 | StackedDRGWindow8MiBV1P1 => Ok(2),
-            StackedDRGWinning512MiBV1 | StackedDRGWindow512MiBV1 | StackedDRGWindow512MiBV1P1 => {
-                Ok(2)
-            }
+            StackedDRGWindow64GiBV1P1 => Ok(2300),
+            StackedDRGWindow32GiBV1P1 => Ok(2349),
+            StackedDRGWindow2KiBV1P1 => Ok(2),
+            StackedDRGWindow8MiBV1P1 => Ok(2),
+            StackedDRGWindow512MiBV1P1 => Ok(2),
             Invalid(i) => Err(format!("unsupported proof type: {}", i)),
         }
     }
@@ -253,19 +217,19 @@ impl RegisteredSealProof {
         match self {
             Self::StackedDRG64GiBV1
             | Self::StackedDRG64GiBV1P1
-            | Self::StackedDRG64GiBV1P1_Feat_SyntheticPoRep => Ok(StackedDRGWinning64GiBV1),
+            | Self::StackedDRG64GiBV1P1_Feat_SyntheticPoRep => Ok(StackedDRGWindow64GiBV1P1),
             Self::StackedDRG32GiBV1
             | Self::StackedDRG32GiBV1P1
-            | Self::StackedDRG32GiBV1P1_Feat_SyntheticPoRep => Ok(StackedDRGWinning32GiBV1),
+            | Self::StackedDRG32GiBV1P1_Feat_SyntheticPoRep => Ok(StackedDRGWindow32GiBV1P1),
             Self::StackedDRG2KiBV1
             | Self::StackedDRG2KiBV1P1
-            | Self::StackedDRG2KiBV1P1_Feat_SyntheticPoRep => Ok(StackedDRGWinning2KiBV1),
+            | Self::StackedDRG2KiBV1P1_Feat_SyntheticPoRep => Ok(StackedDRGWindow2KiBV1P1),
             Self::StackedDRG8MiBV1
             | Self::StackedDRG8MiBV1P1
-            | Self::StackedDRG8MiBV1P1_Feat_SyntheticPoRep => Ok(StackedDRGWinning8MiBV1),
+            | Self::StackedDRG8MiBV1P1_Feat_SyntheticPoRep => Ok(StackedDRGWindow8MiBV1P1),
             Self::StackedDRG512MiBV1
             | Self::StackedDRG512MiBV1P1
-            | Self::StackedDRG512MiBV1P1_Feat_SyntheticPoRep => Ok(StackedDRGWinning512MiBV1),
+            | Self::StackedDRG512MiBV1P1_Feat_SyntheticPoRep => Ok(StackedDRGWindow512MiBV1P1),
             Self::Invalid(_) => Err(format!(
                 "Unsupported mapping from {:?} to PoSt-winning RegisteredProof",
                 self
@@ -369,21 +333,11 @@ macro_rules! i64_conversion {
 
 i64_conversion! {
     RegisteredPoStProof;
-    StackedDRGWinning2KiBV1 => 0,
-    StackedDRGWinning8MiBV1 => 1,
-    StackedDRGWinning512MiBV1 => 2,
-    StackedDRGWinning32GiBV1 => 3,
-    StackedDRGWinning64GiBV1 => 4,
-    StackedDRGWindow2KiBV1 => 5,
-    StackedDRGWindow8MiBV1 => 6,
-    StackedDRGWindow512MiBV1 => 7,
-    StackedDRGWindow32GiBV1 => 8,
-    StackedDRGWindow64GiBV1 => 9,
-    StackedDRGWindow2KiBV1P1 => 10,
-    StackedDRGWindow8MiBV1P1 => 11,
-    StackedDRGWindow512MiBV1P1 => 12,
-    StackedDRGWindow32GiBV1P1 => 13,
-    StackedDRGWindow64GiBV1P1 => 14,
+    StackedDRGWindow2KiBV1P1 => 0,
+    StackedDRGWindow8MiBV1P1 => 1,
+    StackedDRGWindow512MiBV1P1 => 2,
+    StackedDRGWindow32GiBV1P1 => 3,
+    StackedDRGWindow64GiBV1P1 => 4,
 }
 
 i64_conversion! {
@@ -476,16 +430,6 @@ impl TryFrom<RegisteredPoStProof> for filecoin_proofs_api::RegisteredPoStProof {
     fn try_from(p: RegisteredPoStProof) -> Result<Self, Self::Error> {
         use RegisteredPoStProof::*;
         match p {
-            StackedDRGWinning2KiBV1 => Ok(Self::StackedDrgWinning2KiBV1),
-            StackedDRGWinning8MiBV1 => Ok(Self::StackedDrgWinning8MiBV1),
-            StackedDRGWinning512MiBV1 => Ok(Self::StackedDrgWinning512MiBV1),
-            StackedDRGWinning32GiBV1 => Ok(Self::StackedDrgWinning32GiBV1),
-            StackedDRGWinning64GiBV1 => Ok(Self::StackedDrgWinning64GiBV1),
-            StackedDRGWindow2KiBV1 => Ok(Self::StackedDrgWindow2KiBV1),
-            StackedDRGWindow8MiBV1 => Ok(Self::StackedDrgWindow8MiBV1),
-            StackedDRGWindow512MiBV1 => Ok(Self::StackedDrgWindow512MiBV1),
-            StackedDRGWindow32GiBV1 => Ok(Self::StackedDrgWindow32GiBV1),
-            StackedDRGWindow64GiBV1 => Ok(Self::StackedDrgWindow64GiBV1),
             StackedDRGWindow2KiBV1P1 => Ok(Self::StackedDrgWindow2KiBV1_2),
             StackedDRGWindow8MiBV1P1 => Ok(Self::StackedDrgWindow8MiBV1_2),
             StackedDRGWindow512MiBV1P1 => Ok(Self::StackedDrgWindow512MiBV1_2),


### PR DESCRIPTION
This is the counterpart of [PR 1391](https://github.com/filecoin-project/builtin-actors/pull/1391) from builtin actors repository.