### PR TITLE
fix: publicly export `GasDuration`

### DIFF
--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -12,7 +12,7 @@ use num_traits::Zero;
 pub use self::charge::GasCharge;
 pub(crate) use self::outputs::GasOutputs;
 pub use self::price_list::{price_list_by_network_version, PriceList, WasmGasPrices};
-pub use self::timer::{GasInstant, GasTimer};
+pub use self::timer::{GasDuration, GasInstant, GasTimer};
 use crate::kernel::{ClassifyResult, ExecutionError, Result};
 
 mod charge;


### PR DESCRIPTION
`GasDuration` is used in public API `GasTimer::new(duration: &mut GasDuration)` and as a public field `pub elapsed: GasDuration` in `GasCharge`, however, it's not publicly exported from the crate.  It will be helpful for e.g. converting between GasDuration in fvm@3 and fvm@4

This PR tries to fix that by publicly exporting it. Please let me know your feedback, thanks!