### PR TITLE
pre-check AMT height when iterating

### DIFF
--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -424,6 +424,12 @@ where
     where
         F: FnMut(u64, &V) -> anyhow::Result<()>,
     {
+        if let Some(start_at) = start_at {
+            if start_at >= nodes_for_height(self.bit_width(), self.height() + 1) {
+                return Ok((0, None));
+            }
+        }
+
         let (_, num_traversed, next_index) = self.root.node.for_each_while_ranged(
             &self.block_store,
             start_at,
@@ -457,6 +463,12 @@ where
     where
         F: FnMut(u64, &V) -> anyhow::Result<bool>,
     {
+        if let Some(start_at) = start_at {
+            if start_at >= nodes_for_height(self.bit_width(), self.height() + 1) {
+                return Ok((0, None));
+            }
+        }
+
         let (_, num_traversed, next_index) = self.root.node.for_each_while_ranged(
             &self.block_store,
             start_at,

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -431,6 +431,17 @@ fn for_each_ranged() {
         assert_eq!(count, retrieved_values.len() as u64);
     }
 
+    // Iterate out of bounds
+    for i in [RANGE, RANGE + 1, 2 * RANGE, 8 * RANGE] {
+        let (count, next_key) = a
+            .for_each_while_ranged(Some(i), None, |_, _: &BytesDe| {
+                panic!("didn't expect to iterate")
+            })
+            .unwrap();
+        assert_eq!(count, 0);
+        assert_eq!(next_key, None);
+    }
+
     // Iterate over amt with dirty cache with different page sizes
     for page_size in 1..=RANGE {
         let mut retrieved_values = Vec::new();


### PR DESCRIPTION
This lets us avoid traversing the AMT entirely when it isn't deep enough for the value to even appear.