### PR TITLE
actor upgrade error refactor

### DIFF
--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -201,9 +201,6 @@ where
                     events_root,
                 }
             }
-
-            Err(ExecutionError::Abort(e)) => return Err(anyhow!("actor aborted: {}", e)),
-
             Err(ExecutionError::OutOfGas) => Receipt {
                 exit_code: ExitCode::SYS_OUT_OF_GAS,
                 return_data: Default::default(),

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -209,7 +209,11 @@ pub trait ActorOps {
         delegated_address: Option<Address>,
     ) -> Result<()>;
 
-    fn upgrade_actor<K: Kernel>(&mut self, new_code_cid: Cid, params_id: BlockId) -> Result<u32>;
+    fn upgrade_actor<K: Kernel>(
+        &mut self,
+        new_code_cid: Cid,
+        params_id: BlockId,
+    ) -> Result<SendResult>;
 
     /// Installs actor code pointed by cid
     #[cfg(feature = "m2-native")]

--- a/fvm/src/syscalls/context.rs
+++ b/fvm/src/syscalls/context.rs
@@ -152,9 +152,6 @@ mod test {
                 $crate::kernel::ExecutionError::OutOfGas => {
                     panic!("got unexpected out of gas")
                 }
-                $crate::kernel::ExecutionError::Abort(abort) => {
-                    panic!("got unexpected abort {}", abort)
-                }
             }
         };
     }

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -17,9 +17,6 @@ pub enum Abort {
     /// The actor ran out of gas.
     #[error("out of gas")]
     OutOfGas,
-    /// The actor did not export the endpoint that was called.
-    #[error("entrypoint not found")]
-    EntrypointNotFound,
     /// The system failed with a fatal error.
     #[error("fatal error: {0}")]
     Fatal(anyhow::Error),
@@ -40,7 +37,6 @@ impl Abort {
             ),
             ExecutionError::OutOfGas => Abort::OutOfGas,
             ExecutionError::Fatal(err) => Abort::Fatal(err),
-            ExecutionError::Abort(e) => e,
         }
     }
 
@@ -50,7 +46,6 @@ impl Abort {
             ExecutionError::OutOfGas => Abort::OutOfGas,
             ExecutionError::Fatal(e) => Abort::Fatal(e),
             ExecutionError::Syscall(e) => Abort::Fatal(anyhow!("unexpected syscall error: {}", e)),
-            ExecutionError::Abort(e) => e,
         }
     }
 }

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -2,18 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_shared::error::ExitCode;
 use fvm_shared::sys::out::vm::MessageContext;
-use fvm_shared::sys::SyscallSafe;
 
 use super::error::Abort;
 use super::Context;
 use crate::kernel::Kernel;
-
-/// An uninhabited type. We use this in `abort` to make sure there's no way to return without
-/// returning an error.
-#[derive(Copy, Clone)]
-pub enum Never {}
-
-unsafe impl SyscallSafe for Never {}
 
 /// The maximum message length included in the backtrace. Given 1024 levels, this gives us a total
 /// maximum of around 1MiB for debugging.
@@ -26,14 +18,14 @@ pub fn exit(
     blk: u32,
     message_off: u32,
     message_len: u32,
-) -> Result<Never, Abort> {
+) -> Abort {
     let code = ExitCode::new(code);
     if !code.is_success() && code.is_system_error() {
-        return Err(Abort::Exit(
+        return Abort::Exit(
             ExitCode::SYS_ILLEGAL_EXIT_CODE,
             format!("actor aborted with code {}", code),
             blk,
-        ));
+        );
     }
 
     let message = if message_len == 0 {
@@ -57,7 +49,7 @@ pub fn exit(
             Err(e) => format!("failed to extract error message: {e}"),
         }
     };
-    Err(Abort::Exit(code, message, blk))
+    Abort::Exit(code, message, blk)
 }
 
 pub fn message_context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<MessageContext> {

--- a/fvm/tests/default_kernel/mod.rs
+++ b/fvm/tests/default_kernel/mod.rs
@@ -76,9 +76,6 @@ macro_rules! expect_syscall_err {
             ::fvm::kernel::ExecutionError::OutOfGas => {
                 panic!("got unexpected out of gas")
             }
-            ::fvm::kernel::ExecutionError::Abort(abort) => {
-                panic!("got unexpected abort {}", abort)
-            }
         }
     };
 }
@@ -93,9 +90,6 @@ macro_rules! expect_out_of_gas {
             }
             ::fvm::kernel::ExecutionError::Fatal(err) => {
                 panic!("got unexpected fatal error: {}", err)
-            }
-            ::fvm::kernel::ExecutionError::Abort(abort) => {
-                panic!("got unexpected abort {}", abort)
             }
         }
     };

--- a/sdk/src/sys/actor.rs
+++ b/sdk/src/sys/actor.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for creating and resolving actors.
 
+#[doc(inline)]
+pub use fvm_shared::sys::out::send::*;
+
 // for documentation links
 #[cfg(doc)]
 use crate::sys::ErrorNumber::*;
@@ -139,11 +142,11 @@ super::fvm_syscalls! {
     ///
     /// # Returns
     ///
-    /// On success, this syscall will not return. Instead, the current invocation will "complete" and
-    /// the return value will be the block returned by the new code's `upgrade` endpoint.
+    /// On successful upgrade, this syscall will not return. Instead, the current invocation will
+    /// "complete" and the return value will be the block returned by the new code's `upgrade` endpoint.
     ///
     /// If the new code rejects the upgrade (aborts) or performs an illegal operation, this syscall will
-    /// return the exit code of the `upgrade` endpoint.
+    /// return the exit code plus the error returned by the upgrade endpoint.
     ///
     /// Finally, the syscall will return an error if it fails to call the upgrade endpoint entirely.
     ///
@@ -159,7 +162,7 @@ super::fvm_syscalls! {
     pub fn upgrade_actor(
         new_code_cid_off: *const u8,
         params: u32,
-    ) -> Result<u32>;
+    ) -> Result<Send>;
 
     /// Installs and ensures actor code is valid and loaded.
     /// **Privileged:** May only be called by the init actor.

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -64,7 +64,8 @@ impl ExitCode {
     //pub const SYS_RESERVED_3 ExitCode = ExitCode::new(3);
     /// The message receiver trapped (panicked).
     pub const SYS_ILLEGAL_INSTRUCTION: ExitCode = ExitCode::new(4);
-    /// The message receiver doesn't exist and can't be automatically created
+    /// The message receiver either doesn't exist and can't be automatically created or it doesn't
+    /// implement the required entrypoint.
     pub const SYS_INVALID_RECEIVER: ExitCode = ExitCode::new(5);
     /// The message sender didn't have the requisite funds.
     pub const SYS_INSUFFICIENT_FUNDS: ExitCode = ExitCode::new(6);


### PR DESCRIPTION
Add a general-purpose ControlFlow syscall return value and use it. This way we don't need to add an `::Abort` case to the `ExecutionError` itself.