### PR TITLE
[WIP] Implement external iteration for the AMT

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -937,7 +937,7 @@ impl EventsAccumulator {
 
         let root = if !self.events.is_empty() {
             const EVENTS_AMT_BITWIDTH: u32 = 5;
-            let root = Amt::new_from_iter_with_bit_width(
+            let root = Amt::new_from_iter_with_branching_factor(
                 DiscardBlockstore,
                 EVENTS_AMT_BITWIDTH,
                 self.events.iter(),

--- a/ipld/amt/benches/amt_benchmark.rs
+++ b/ipld/amt/benches/amt_benchmark.rs
@@ -116,17 +116,17 @@ fn from_slice(c: &mut Criterion) {
     });
 }
 
-fn for_each(c: &mut Criterion) {
-    let db = fvm_ipld_blockstore::MemoryBlockstore::default();
-    let cid = Amt::new_from_iter(&db, black_box(VALUES.iter().copied())).unwrap();
+// fn for_each(c: &mut Criterion) {
+//     let db = fvm_ipld_blockstore::MemoryBlockstore::default();
+//     let cid = Amt::new_from_iter(&db, black_box(VALUES.iter().copied())).unwrap();
 
-    c.bench_function("AMT for_each function", |b| {
-        b.iter(|| {
-            let a = Amt::load(&cid, &db).unwrap();
-            black_box(a).for_each(|_, _v: &u64| Ok(())).unwrap();
-        })
-    });
-}
+//     c.bench_function("AMT for_each function", |b| {
+//         b.iter(|| {
+//             let a = Amt::load(&cid, &db).unwrap();
+//             black_box(a).for_each(|_, _v: &u64| Ok(())).unwrap();
+//         })
+//     });
+// }
 
-criterion_group!(benches, insert, insert_load_flush, from_slice, for_each);
+criterion_group!(benches, insert, insert_load_flush, from_slice);
 criterion_main!(benches);

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -23,8 +23,8 @@ use crate::{
 #[derive(Debug)]
 #[doc(hidden)]
 pub struct AmtImpl<V, BS, Ver> {
-    pub(super) root: RootImpl<V, Ver>,
-    pub(super) block_store: BS,
+    pub(crate) root: RootImpl<V, Ver>,
+    pub(crate) block_store: BS,
     /// Remember the last flushed CID until it changes.
     flushed_cid: Option<Cid>,
 }
@@ -79,6 +79,7 @@ mod tests {
 /// // Generate cid by calling flush to remove cache
 /// let cid = amt.flush().unwrap();
 /// ```
+// TODO(jdjaustin): clean all this up
 pub type Amt<V, BS> = AmtImpl<V, BS, V3>;
 /// Legacy amt V0
 pub type Amtv0<V, BS> = AmtImpl<V, BS, V0>;

--- a/ipld/amt/src/iter.rs
+++ b/ipld/amt/src/iter.rs
@@ -2,39 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use crate::node::CollapsedNode;
 use crate::node::{Link, Node};
-use crate::root::version;
-use crate::root::version::Version;
-use crate::root::RootImpl;
 use crate::Error;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::de::DeserializeOwned;
 use fvm_ipld_encoding::CborStore;
-use std::borrow::Borrow;
-use std::iter::FusedIterator;
+use serde::de::DeserializeOwned;
 
-// David described a graph traversal algorithm to Josh.
-// Here are their notes:
-//
-// 1) Pop root node to list.
-// 2) Pop root and replace with child node/nodes.
-// 3) Pop child node/nodes and replace with child node/nodes or leaf/leaves.
+impl<V, BS> crate::Amt<V, BS>
+where
+    V: DeserializeOwned,
+{
+    pub fn iter(&self) -> Iter<'_, V, &BS> {
+        Iter {
+            current_links: None,
+            current_nodes: None,
+            stack: vec![&self.root.node],
+            blockstore: &self.block_store,
+            branching_factor: self.branching_factor(),
+        }
+    }
+}
 
 // TODO(aatifsyed): is this guaranteed to be acyclic?
-pub struct Iter2<'a, V, BS> {
+pub struct Iter<'a, V, BS> {
     current_links: Option<std::iter::Flatten<std::slice::Iter<'a, Option<Link<V>>>>>,
     current_nodes: Option<std::iter::Flatten<std::slice::Iter<'a, Option<V>>>>,
-    // "abstract data types"
-    // stack -> std::vec::Vec
-    // queue -> VecDeque
-    // list -> Vec // get by index, remove etc
-    // Map -> HashMap or a BTreeMap
     stack: Vec<&'a Node<V>>,
     blockstore: BS,
     branching_factor: u32,
 }
 
-
-impl<'a, V, BS> Iterator for Iter2<'a, V, BS>
+impl<'a, V, BS> Iterator for Iter<'a, V, BS>
 where
     BS: Blockstore,
     V: DeserializeOwned,
@@ -81,84 +78,4 @@ where
             }
         }
     }
-}
-
-pub struct IterImpl<'a, BS, V> {
-    store: &'a BS,
-    stack: &'a Node<V>,
-    current: std::slice::Iter<'a, V>,
-}
-
-/// Iterator over AMT.
-// TODO(aatifsyed): this is Go code masquerading as Rust
-pub type Iter<'a, BS, V> = IterImpl<'a, BS, V>;
-
-impl<'a, V, BS> IterImpl<'a, BS, V>
-where
-    V: DeserializeOwned,
-    BS: Blockstore,
-{
-    pub(crate) fn new<Ver>(store: &'a BS, root: &'a RootImpl<V, Ver>) -> Self {
-        Self {
-            store,
-            stack: &root.node,
-            current: [].iter(),
-        }
-    }
-}
-
-impl<'a, V, BS> Iterator for IterImpl<'a, BS, V>
-where
-    BS: Blockstore,
-    V: DeserializeOwned + 'a,
-{
-    type Item = &'a V;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let idx = 0;
-        loop {
-            match &self.stack {
-                Node::Leaf { ref vals } => loop {
-                    match vals.iter().next() {
-                        Some(val) => {
-                            if let Some(v) = val {
-                                return Some(v);
-                            }
-                        }
-                        None => {
-                            return None;
-                        }
-                    }
-                },
-                Node::Link { links } => {
-                    if let Some(link) = links.get(idx) {
-                        match link.as_ref().unwrap() {
-                            Link::Cid { cid: _, cache } => {
-                                // TODO(aatifsyed): talk about this
-                                todo!();
-                                match cache.into_inner() {
-                                    Some(node) => {}
-                                    None => {
-                                        return None;
-                                    }
-                                };
-                            }
-                            Link::Dirty(_) => {
-                                return None;
-                            }
-                        }
-                    }
-                    todo!();
-                    idx += 1;
-                }
-            }
-        }
-    }
-}
-
-impl<'a, V, BS> FusedIterator for IterImpl<'a, BS, V>
-where
-    V: DeserializeOwned,
-    BS: Blockstore,
-{
 }

--- a/ipld/amt/src/iter.rs
+++ b/ipld/amt/src/iter.rs
@@ -1,0 +1,164 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use crate::node::CollapsedNode;
+use crate::node::{Link, Node};
+use crate::root::version;
+use crate::root::version::Version;
+use crate::root::RootImpl;
+use crate::Error;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::de::DeserializeOwned;
+use fvm_ipld_encoding::CborStore;
+use std::borrow::Borrow;
+use std::iter::FusedIterator;
+
+// David described a graph traversal algorithm to Josh.
+// Here are their notes:
+//
+// 1) Pop root node to list.
+// 2) Pop root and replace with child node/nodes.
+// 3) Pop child node/nodes and replace with child node/nodes or leaf/leaves.
+
+// TODO(aatifsyed): is this guaranteed to be acyclic?
+pub struct Iter2<'a, V, BS> {
+    current_links: Option<std::iter::Flatten<std::slice::Iter<'a, Option<Link<V>>>>>,
+    current_nodes: Option<std::iter::Flatten<std::slice::Iter<'a, Option<V>>>>,
+    // "abstract data types"
+    // stack -> std::vec::Vec
+    // queue -> VecDeque
+    // list -> Vec // get by index, remove etc
+    // Map -> HashMap or a BTreeMap
+    stack: Vec<&'a Node<V>>,
+    blockstore: BS,
+    branching_factor: u32,
+}
+
+
+impl<'a, V, BS> Iterator for Iter2<'a, V, BS>
+where
+    BS: Blockstore,
+    V: DeserializeOwned,
+{
+    type Item = anyhow::Result<&'a V>;
+    fn next(&mut self) -> Option<Self::Item> {
+        // do we have any work saved?
+        // TODO(jdjaustin): simplify this state machine
+        loop {
+            if let Some(link) = self.current_links.as_mut().and_then(Iterator::next) {
+                match link {
+                    Link::Cid { cid, cache } => {
+                        match cache.get_or_try_init(|| {
+                            self.blockstore
+                                .get_cbor::<CollapsedNode<V>>(cid)?
+                                .ok_or_else(|| Error::CidNotFound(cid.to_string()))?
+                                .expand(self.branching_factor)
+                                .map(Box::new) // TODO(jdjaustin): why is this a Box??
+                        }) {
+                            // failed to load from blockstore
+                            Err(e) => return Some(Err(e.into())),
+                            Ok(node) => self.stack.push(node),
+                        }
+                    }
+                    Link::Dirty(dirty) => self.stack.push(dirty),
+                };
+            }
+
+            if let Some(node) = self.current_nodes.as_mut().and_then(Iterator::next) {
+                return Some(Ok(node));
+            }
+            match self.stack.pop() {
+                // TODO(jdjaustin): all these need renaming so they're more understandable
+                Some(Node::Link { links }) => {
+                    // if there are children, expand the stack and continue
+                    self.current_links = Some(links.iter().flatten());
+                    continue;
+                }
+                Some(Node::Leaf { vals }) => {
+                    self.current_nodes = Some(vals.iter().flatten());
+                }
+                // all done!
+                None => return None,
+            }
+        }
+    }
+}
+
+pub struct IterImpl<'a, BS, V> {
+    store: &'a BS,
+    stack: &'a Node<V>,
+    current: std::slice::Iter<'a, V>,
+}
+
+/// Iterator over AMT.
+// TODO(aatifsyed): this is Go code masquerading as Rust
+pub type Iter<'a, BS, V> = IterImpl<'a, BS, V>;
+
+impl<'a, V, BS> IterImpl<'a, BS, V>
+where
+    V: DeserializeOwned,
+    BS: Blockstore,
+{
+    pub(crate) fn new<Ver>(store: &'a BS, root: &'a RootImpl<V, Ver>) -> Self {
+        Self {
+            store,
+            stack: &root.node,
+            current: [].iter(),
+        }
+    }
+}
+
+impl<'a, V, BS> Iterator for IterImpl<'a, BS, V>
+where
+    BS: Blockstore,
+    V: DeserializeOwned + 'a,
+{
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let idx = 0;
+        loop {
+            match &self.stack {
+                Node::Leaf { ref vals } => loop {
+                    match vals.iter().next() {
+                        Some(val) => {
+                            if let Some(v) = val {
+                                return Some(v);
+                            }
+                        }
+                        None => {
+                            return None;
+                        }
+                    }
+                },
+                Node::Link { links } => {
+                    if let Some(link) = links.get(idx) {
+                        match link.as_ref().unwrap() {
+                            Link::Cid { cid: _, cache } => {
+                                // TODO(aatifsyed): talk about this
+                                todo!();
+                                match cache.into_inner() {
+                                    Some(node) => {}
+                                    None => {
+                                        return None;
+                                    }
+                                };
+                            }
+                            Link::Dirty(_) => {
+                                return None;
+                            }
+                        }
+                    }
+                    todo!();
+                    idx += 1;
+                }
+            }
+        }
+    }
+}
+
+impl<'a, V, BS> FusedIterator for IterImpl<'a, BS, V>
+where
+    V: DeserializeOwned,
+    BS: Blockstore,
+{
+}

--- a/ipld/amt/src/lib.rs
+++ b/ipld/amt/src/lib.rs
@@ -6,10 +6,12 @@
 //!
 //! Data structure reference:
 //! https://github.com/ipld/specs/blob/51fab05b4fe4930d3d851d50cc1e5f1a02092deb/data-structures/vector.md
+// TODO(jdjaustin): diagram
 
 mod amt;
 mod diff;
 mod error;
+mod iter;
 mod node;
 mod root;
 mod value_mut;
@@ -17,18 +19,19 @@ mod value_mut;
 pub use self::amt::{Amt, Amtv0};
 pub use self::diff::{diff, Change, ChangeType};
 pub use self::error::Error;
+pub use self::iter::Iter;
 pub(crate) use self::node::Node;
 pub use self::value_mut::ValueMut;
 
-const DEFAULT_BIT_WIDTH: u32 = 3;
+const DEFAULT_BRANCHING_FACTOR: u32 = 3;
 const MAX_HEIGHT: u32 = 64;
 
 /// MaxIndex is the maximum index for elements in the AMT. This u64::MAX-1 so we
 /// don't overflow u64::MAX when computing the length.
 pub const MAX_INDEX: u64 = std::u64::MAX - 1;
 
-fn nodes_for_height(bit_width: u32, height: u32) -> u64 {
-    let height_log_two = bit_width as u64 * height as u64;
+fn nodes_for_height(branching_factor: u32, height: u32) -> u64 {
+    let height_log_two = branching_factor as u64 * height as u64;
     if height_log_two >= 64 {
         return std::u64::MAX;
     }

--- a/ipld/amt/src/lib.rs
+++ b/ipld/amt/src/lib.rs
@@ -16,7 +16,7 @@ mod node;
 mod root;
 mod value_mut;
 
-pub use self::amt::{Amt, Amtv0};
+pub use self::amt::{Amt, AmtImpl, Amtv0};
 pub use self::diff::{diff, Change, ChangeType};
 pub use self::error::Error;
 pub use self::iter::Iter;

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -78,6 +78,22 @@ pub(super) enum Node<V> {
     Leaf { vals: Vec<Option<V>> },
 }
 
+impl<V> Iterator for Node<V> {
+    type Item = Option<V>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Node::Leaf { vals } => vals.iter_mut().next().map(|v| v.take()),
+            Node::Link { links } => links.iter_mut().next().map(|l| {
+                l.as_mut().and_then(|l| match l {
+                    Link::Cid { cache, .. } => cache.get_mut().and_then(|n| n.next()).flatten(),
+                    Link::Dirty(n) => n.next().flatten(),
+                })
+            }),
+        }
+    }
+}
+
 impl<V> Serialize for Node<V>
 where
     V: Serialize,

--- a/ipld/amt/tests/diff_tests.rs
+++ b/ipld/amt/tests/diff_tests.rs
@@ -21,11 +21,11 @@ impl Arbitrary for BitWidth2to18 {
 }
 
 #[quickcheck]
-fn test_simple_equals(BitWidth2to18(bit_width): BitWidth2to18) -> Result<()> {
+fn test_simple_equals(BitWidth2to18(branching_factor): BitWidth2to18) -> Result<()> {
     let prev_store = MemoryBlockstore::new();
     let curr_store = MemoryBlockstore::new();
-    let mut a: Amt<String, _> = Amt::new_with_bit_width(prev_store, bit_width);
-    let mut b: Amt<String, _> = Amt::new_with_bit_width(curr_store, bit_width);
+    let mut a: Amt<String, _> = Amt::new_with_branching_factor(prev_store, branching_factor);
+    let mut b: Amt<String, _> = Amt::new_with_branching_factor(curr_store, branching_factor);
 
     let changes = diff(&a, &b)?;
     ensure!(changes.is_empty());
@@ -42,11 +42,11 @@ fn test_simple_equals(BitWidth2to18(bit_width): BitWidth2to18) -> Result<()> {
 }
 
 #[quickcheck]
-fn test_simple_add(BitWidth2to18(bit_width): BitWidth2to18) -> Result<()> {
+fn test_simple_add(BitWidth2to18(branching_factor): BitWidth2to18) -> Result<()> {
     let prev_store = MemoryBlockstore::new();
     let curr_store = MemoryBlockstore::new();
-    let mut a: Amt<String, _> = Amt::new_with_bit_width(prev_store, bit_width);
-    let mut b: Amt<String, _> = Amt::new_with_bit_width(curr_store, bit_width);
+    let mut a: Amt<String, _> = Amt::new_with_branching_factor(prev_store, branching_factor);
+    let mut b: Amt<String, _> = Amt::new_with_branching_factor(curr_store, branching_factor);
     a.set(2, "foo".into())?;
     a.flush()?;
     b.set(2, "foo".into())?;
@@ -68,11 +68,11 @@ fn test_simple_add(BitWidth2to18(bit_width): BitWidth2to18) -> Result<()> {
 }
 
 #[quickcheck]
-fn test_simple_remove(BitWidth2to18(bit_width): BitWidth2to18) -> Result<()> {
+fn test_simple_remove(BitWidth2to18(branching_factor): BitWidth2to18) -> Result<()> {
     let prev_store = MemoryBlockstore::new();
     let curr_store = MemoryBlockstore::new();
-    let mut a: Amt<String, _> = Amt::new_with_bit_width(prev_store, bit_width);
-    let mut b: Amt<String, _> = Amt::new_with_bit_width(curr_store, bit_width);
+    let mut a: Amt<String, _> = Amt::new_with_branching_factor(prev_store, branching_factor);
+    let mut b: Amt<String, _> = Amt::new_with_branching_factor(curr_store, branching_factor);
     a.set(2, "foo".into())?;
     a.set(5, "bar".into())?;
     a.flush()?;
@@ -94,11 +94,11 @@ fn test_simple_remove(BitWidth2to18(bit_width): BitWidth2to18) -> Result<()> {
 }
 
 #[quickcheck]
-fn test_simple_modify(BitWidth2to18(bit_width): BitWidth2to18) -> Result<()> {
+fn test_simple_modify(BitWidth2to18(branching_factor): BitWidth2to18) -> Result<()> {
     let prev_store = MemoryBlockstore::new();
     let curr_store = MemoryBlockstore::new();
-    let mut a: Amt<String, _> = Amt::new_with_bit_width(prev_store, bit_width);
-    let mut b: Amt<String, _> = Amt::new_with_bit_width(curr_store, bit_width);
+    let mut a: Amt<String, _> = Amt::new_with_branching_factor(prev_store, branching_factor);
+    let mut b: Amt<String, _> = Amt::new_with_branching_factor(curr_store, branching_factor);
     a.set(2, "foo".into())?;
     a.flush()?;
     b.set(2, "bar".into())?;
@@ -119,11 +119,11 @@ fn test_simple_modify(BitWidth2to18(bit_width): BitWidth2to18) -> Result<()> {
 }
 
 #[quickcheck]
-fn test_large_modify(BitWidth2to18(bit_width): BitWidth2to18) -> Result<()> {
+fn test_large_modify(BitWidth2to18(branching_factor): BitWidth2to18) -> Result<()> {
     let prev_store = MemoryBlockstore::new();
     let curr_store = MemoryBlockstore::new();
-    let mut a: Amt<String, _> = Amt::new_with_bit_width(prev_store, bit_width);
-    let mut b: Amt<String, _> = Amt::new_with_bit_width(curr_store, bit_width);
+    let mut a: Amt<String, _> = Amt::new_with_branching_factor(prev_store, branching_factor);
+    let mut b: Amt<String, _> = Amt::new_with_branching_factor(curr_store, branching_factor);
     for i in 0..100 {
         a.set(i, format!("foo{i}"))?;
     }
@@ -155,11 +155,11 @@ fn test_large_modify(BitWidth2to18(bit_width): BitWidth2to18) -> Result<()> {
 }
 
 #[quickcheck]
-fn test_large_additions(BitWidth2to18(bit_width): BitWidth2to18) -> Result<()> {
+fn test_large_additions(BitWidth2to18(branching_factor): BitWidth2to18) -> Result<()> {
     let prev_store = MemoryBlockstore::new();
     let curr_store = MemoryBlockstore::new();
-    let mut a: Amt<String, _> = Amt::new_with_bit_width(prev_store, bit_width);
-    let mut b: Amt<String, _> = Amt::new_with_bit_width(curr_store, bit_width);
+    let mut a: Amt<String, _> = Amt::new_with_branching_factor(prev_store, branching_factor);
+    let mut b: Amt<String, _> = Amt::new_with_branching_factor(curr_store, branching_factor);
     for i in 0..100 {
         a.set(i, format!("foo{i}"))?;
         b.set(i, format!("foo{i}"))?;
@@ -189,14 +189,14 @@ fn test_large_additions(BitWidth2to18(bit_width): BitWidth2to18) -> Result<()> {
 
 #[quickcheck]
 fn test_big_diff(
-    BitWidth2to18(bit_width): BitWidth2to18,
+    BitWidth2to18(branching_factor): BitWidth2to18,
     flush_a: bool,
     flush_b: bool,
 ) -> Result<()> {
     let prev_store = MemoryBlockstore::new();
     let curr_store = MemoryBlockstore::new();
-    let mut a: Amt<String, _> = Amt::new_with_bit_width(prev_store, bit_width);
-    let mut b: Amt<String, _> = Amt::new_with_bit_width(curr_store, bit_width);
+    let mut a: Amt<String, _> = Amt::new_with_branching_factor(prev_store, branching_factor);
+    let mut b: Amt<String, _> = Amt::new_with_branching_factor(curr_store, branching_factor);
     for i in 0..100 {
         a.set(i, format!("foo{i}"))?;
     }
@@ -272,12 +272,12 @@ fn test_big_diff(
 
 #[quickcheck]
 fn test_diff_empty_state_with_non_empty_state(
-    BitWidth2to18(bit_width): BitWidth2to18,
+    BitWidth2to18(branching_factor): BitWidth2to18,
 ) -> Result<()> {
     let prev_store = MemoryBlockstore::new();
     let curr_store = MemoryBlockstore::new();
-    let mut a: Amt<String, _> = Amt::new_with_bit_width(prev_store, bit_width);
-    let mut b: Amt<String, _> = Amt::new_with_bit_width(curr_store, bit_width);
+    let mut a: Amt<String, _> = Amt::new_with_branching_factor(prev_store, branching_factor);
+    let mut b: Amt<String, _> = Amt::new_with_branching_factor(curr_store, branching_factor);
 
     a.set(2, "foo".into())?;
     a.flush()?;


### PR DESCRIPTION
Implement a Rust `Iterator` for the AMT and re-implement the `for_each` implementation in terms of this new iterator. Also improve documentation and rename `bitwidth` to `branching_factor`. Closes issue #1861 