### PR TITLE
feat: pretty-print addresses when debug-formatting

### DIFF
--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -67,7 +67,7 @@ const TESTNET_PREFIX: &str = "t";
 
 /// Address is the struct that defines the protocol and data payload conversion from either
 /// a public key or value
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "testing", derive(Default))]
 #[cfg_attr(feature = "arb", derive(arbitrary::Arbitrary))]
 pub struct Address {
@@ -226,6 +226,15 @@ impl fmt::Display for Address {
                 )
             }
         }
+    }
+}
+
+// Manually implement Debug so we print a "real" address.
+impl fmt::Debug for Address {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Address")
+            .field(&format_args!("\"{}\"", self))
+            .finish()
     }
 }
 

--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -396,6 +396,14 @@ mod tests {
     use crate::address::{from_leb_bytes, to_leb_bytes};
 
     #[test]
+    fn test_debug() {
+        assert_eq!(
+            "Address(\"f01\")",
+            format!("{:?}", super::Address::new_id(1))
+        )
+    }
+
+    #[test]
     fn test_from_leb_bytes_passing() {
         let passing = vec![67];
         assert_eq!(to_leb_bytes(from_leb_bytes(&passing).unwrap()), vec![67]);


### PR DESCRIPTION
We currently just print the protocol and bytes, but that's not very human friendly.

Now:

```rust
println!("{:?}", Address::new_id(1));
```

Prints:

> `Address("f01")`