### PR TITLE
test: run the address::set_network test in a new process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2722,6 +2722,7 @@ dependencies = [
  "quickcheck_macros",
  "rand",
  "rand_chacha",
+ "rusty-fork",
  "serde",
  "serde_json",
  "serde_tuple",
@@ -3888,6 +3889,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4154,6 +4161,17 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+]
 
 [[package]]
 name = "ryu"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -43,6 +43,7 @@ multihash = { workspace = true, features = ["multihash-impl", "sha2", "sha3", "r
 quickcheck_macros = "1"
 
 fvm_shared = { path = ".", features = ["arb"] }
+rusty-fork = { version = "0.3.0", default-features = false }
 
 [features]
 default = []

--- a/shared/src/address/network.rs
+++ b/shared/src/address/network.rs
@@ -75,28 +75,32 @@ mod tests {
     use super::*;
     use crate::address::Address;
 
-    #[test]
-    fn set_network() {
-        assert_eq!(current_network(), Network::default());
-        assert_eq!(Network::default(), Network::Mainnet);
+    // We fork this test into a new process because it messes with global state.
+    use rusty_fork::rusty_fork_test;
+    rusty_fork_test! {
+        #[test]
+        fn set_network() {
+            assert_eq!(current_network(), Network::default());
+            assert_eq!(Network::default(), Network::Mainnet);
 
-        // We're in mainnet mode.
-        let addr1 = Address::from_str("f01");
-        Address::from_str("t01").expect_err("should have failed to parse testnet address");
-        assert_eq!(
-            addr1,
-            Network::Testnet.parse_address("t01"),
-            "parsing an explicit address should still work"
-        );
+            // We're in mainnet mode.
+            let addr1 = Address::from_str("f01");
+            Address::from_str("t01").expect_err("should have failed to parse testnet address");
+            assert_eq!(
+                addr1,
+                Network::Testnet.parse_address("t01"),
+                "parsing an explicit address should still work"
+            );
 
-        // Switch to testnet mode.
-        set_current_network(Network::Testnet);
+            // Switch to testnet mode.
+            set_current_network(Network::Testnet);
 
-        // Now we're in testnet mode.
-        let addr2 = Address::from_str("t01");
-        Address::from_str("f01").expect_err("should have failed to parse testnet address");
+            // Now we're in testnet mode.
+            let addr2 = Address::from_str("t01");
+            Address::from_str("f01").expect_err("should have failed to parse testnet address");
 
-        // Networks are relevent for parsing only.
-        assert_eq!(addr1, addr2)
+            // Networks are relevent for parsing only.
+            assert_eq!(addr1, addr2)
+        }
     }
 }


### PR DESCRIPTION
This prevents it from messing with the other tests.

fixes #1924