### PR TITLE
test: exclude test logic from coverage reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "coverage-helper"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3036399e8abfc9d696c1ee94f7677f9704e903d96299b0026e339eed6055dcaf"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +2337,7 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "cid 0.10.1",
+ "coverage-helper",
  "derive_more",
  "filecoin-proofs-api",
  "fvm",
@@ -2781,6 +2788,7 @@ dependencies = [
  "blake2b_simd",
  "bls-signatures",
  "cid 0.10.1",
+ "coverage-helper",
  "data-encoding",
  "data-encoding-macro",
  "filecoin-proofs-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ criterion = "0.5.1"
 quickcheck = "1.0.0"
 quickcheck_macros = "1.0.0"
 minstant = "0.1.3"
+coverage-helper = "0.2.0"
 
 # workspace
 fvm = { path = "fvm", version = "~4.1.1", default-features = false }

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -49,6 +49,7 @@ static_assertions = "1.1.0"
 [dev-dependencies]
 pretty_assertions = "1.3.0"
 fvm = { path = ".", features = ["testing"], default-features = false }
+coverage-helper = { workspace = true }
 
 [features]
 default = ["opencl"]

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -7,6 +7,7 @@
 //!
 //! This package emits logs using the log façade. Configure the logging backend
 //! of your choice during the initialization of the consuming application.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 pub use kernel::default::DefaultKernel;
 pub use kernel::Kernel;

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -41,6 +41,7 @@ rand = { workspace = true }
 serde_json = { workspace = true }
 multihash = { workspace = true, features = ["multihash-impl", "sha2", "sha3", "ripemd"] }
 quickcheck_macros = { workspace = true }
+coverage-helper = { workspace = true }
 fvm_shared = { path = ".", features = ["arb"] }
 rand_chacha = { workspace = true }
 rusty-fork = { version = "0.3.0", default-features = false }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -2,6 +2,8 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
That way, we actually get useful information.