### PR TITLE
fix test failure when running cargo test

### DIFF
--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -393,12 +393,12 @@ pub(crate) fn from_leb_bytes(bz: &[u8]) -> Result<u64, Error> {
 mod tests {
     // Test cases for FOR-02: https://github.com/ChainSafe/forest/issues/1134
     use crate::address::errors::Error;
-    use crate::address::{from_leb_bytes, to_leb_bytes};
+    use crate::address::{current_network, from_leb_bytes, to_leb_bytes};
 
     #[test]
     fn test_debug() {
         assert_eq!(
-            "Address(\"f01\")",
+            format!("Address(\"{}01\")", current_network().to_prefix()),
             format!("{:?}", super::Address::new_id(1))
         )
     }

--- a/shared/src/address/mod.rs
+++ b/shared/src/address/mod.rs
@@ -393,14 +393,16 @@ pub(crate) fn from_leb_bytes(bz: &[u8]) -> Result<u64, Error> {
 mod tests {
     // Test cases for FOR-02: https://github.com/ChainSafe/forest/issues/1134
     use crate::address::errors::Error;
-    use crate::address::{current_network, from_leb_bytes, to_leb_bytes};
+    use crate::address::{from_leb_bytes, to_leb_bytes};
 
     #[test]
     fn test_debug() {
-        assert_eq!(
-            format!("Address(\"{}01\")", current_network().to_prefix()),
-            format!("{:?}", super::Address::new_id(1))
-        )
+        // the address string is dependent on current network state which is set
+        // globally so we need to check against possible valid options
+        let addr_debug_str = format!("{:?}", super::Address::new_id(1));
+        assert!(["Address(\"f01\")", "Address(\"t01\")"]
+            .iter()
+            .any(|&s| s == addr_debug_str));
     }
 
     #[test]


### PR DESCRIPTION
Running `cargo test` seems to non-deterministically select different networks causing the Address test_debug() test to fail