### PR TITLE
fix: set the default thread-pool size by the available concurrency

### DIFF
--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+Default the concurrency of the `ThreadedExecutor` to the available parallelism instead of 8.
+
 ## 4.0.0 (2023-10-31)
 
 Final release, no changes.

--- a/fvm/src/executor/threaded.rs
+++ b/fvm/src/executor/threaded.rs
@@ -9,10 +9,10 @@ use super::{ApplyKind, ApplyRet, Executor};
 
 lazy_static! {
     static ref EXEC_POOL: yastl::Pool = yastl::Pool::with_config(
-        8,
+        std::thread::available_parallelism().map(|n|n.get()).unwrap_or(8),
         yastl::ThreadConfig::new()
             .prefix("fvm-executor")
-            // fvm needs more than the deafault available stack (2MiB):
+            // fvm needs more than the default available stack (2MiB):
             // - Max 2048 wasm stack elements, which is 16KiB of 64bit entries
             // - Roughly 20KiB overhead per actor call
             // - max 1024 nested calls, which means that in the worst case we need ~36MiB of stack


### PR DESCRIPTION
And default to 8 if we can't get this information. This isn't a perfect metric (e.g., it doesn't take IO into account) but it's better than nothing).