### PR TITLE
Move circulating supply to FilecoinKernel

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -554,18 +554,6 @@ where
     }
 }
 
-impl<C> CircSupplyOps for DefaultKernel<C>
-where
-    C: CallManager,
-{
-    fn total_fil_circ_supply(&self) -> Result<TokenAmount> {
-        // From v15 and onwards, Filecoin mainnet was fixed to use a static circ supply per epoch.
-        // The value reported to the FVM from clients is now the static value,
-        // the FVM simply reports that value to actors.
-        Ok(self.call_manager.context().circ_supply.clone())
-    }
-}
-
 impl<C> CryptoOps for DefaultKernel<C>
 where
     C: CallManager,

--- a/fvm/src/kernel/filecoin.rs
+++ b/fvm/src/kernel/filecoin.rs
@@ -70,12 +70,21 @@ pub trait FilecoinKernel: Kernel {
     /// Verify replica update verifies a snap deal: an upgrade from a CC sector to a sector with
     /// deals.
     fn verify_replica_update(&self, replica: &ReplicaUpdateInfo) -> Result<bool>;
+
+    /// Returns the total token supply in circulation at the beginning of the current epoch.
+    /// The circulating supply is the sum of:
+    /// - rewards emitted by the reward actor,
+    /// - funds vested from lock-ups in the genesis state,
+    /// less the sum of:
+    /// - funds burnt,
+    /// - pledge collateral locked in storage miner actors (recorded in the storage power actor)
+    /// - deal collateral locked by the storage market actor
+    fn total_fil_circ_supply(&self) -> Result<TokenAmount>;
 }
 
 #[derive(Delegate)]
 #[delegate(IpldBlockOps)]
 #[delegate(ActorOps)]
-#[delegate(CircSupplyOps)]
 #[delegate(CryptoOps)]
 #[delegate(DebugOps)]
 #[delegate(EventOps)]
@@ -225,6 +234,13 @@ where
         t.record(catch_and_log_panic("verifying replica update", || {
             verify_replica_update(replica)
         }))
+    }
+
+    fn total_fil_circ_supply(&self) -> Result<TokenAmount> {
+        // From v15 and onwards, Filecoin mainnet was fixed to use a static circ supply per epoch.
+        // The value reported to the FVM from clients is now the static value,
+        // the FVM simply reports that value to actors.
+        Ok(self.0.call_manager.context().circ_supply.clone())
     }
 }
 

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -56,7 +56,7 @@ pub struct CallResult {
 /// Actors may call into the kernel via the syscalls defined in the [`syscalls`][crate::syscalls]
 /// module.
 pub trait Kernel:
-    SyscallHandler<Self>
+    SyscallHandler
     + ActorOps
     + IpldBlockOps
     + CircSupplyOps
@@ -126,7 +126,7 @@ pub trait Kernel:
     ) -> Result<CallResult>;
 }
 
-pub trait SyscallHandler<K: Kernel>: Sized {
+pub trait SyscallHandler<K = Self>: Sized {
     fn bind_syscalls(&self, linker: &mut Linker<InvocationData<K>>) -> anyhow::Result<()>;
 }
 

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -59,7 +59,6 @@ pub trait Kernel:
     SyscallHandler
     + ActorOps
     + IpldBlockOps
-    + CircSupplyOps
     + CryptoOps
     + DebugOps
     + EventOps
@@ -239,20 +238,6 @@ pub trait ActorOps {
 
     /// Returns the balance associated with an actor id
     fn balance_of(&self, actor_id: ActorID) -> Result<TokenAmount>;
-}
-
-/// Operations to query the circulating supply.
-#[delegatable_trait]
-pub trait CircSupplyOps {
-    /// Returns the total token supply in circulation at the beginning of the current epoch.
-    /// The circulating supply is the sum of:
-    /// - rewards emitted by the reward actor,
-    /// - funds vested from lock-ups in the genesis state,
-    /// less the sum of:
-    /// - funds burnt,
-    /// - pledge collateral locked in storage miner actors (recorded in the storage power actor)
-    /// - deal collateral locked by the storage market actor
-    fn total_fil_circ_supply(&self) -> Result<TokenAmount>;
 }
 
 /// Operations for explicit gas charging.

--- a/fvm/src/syscalls/filecoin.rs
+++ b/fvm/src/syscalls/filecoin.rs
@@ -178,3 +178,15 @@ pub fn batch_verify_seals(
     }
     Ok(())
 }
+
+/// Returns the network circ supply split as two u64 ordered in little endian.
+pub fn total_fil_circ_supply(
+    context: Context<'_, impl FilecoinKernel>,
+) -> Result<sys::TokenAmount> {
+    context
+        .kernel
+        .total_fil_circ_supply()?
+        .try_into()
+        .context("circulating supply exceeds u128 limit")
+        .or_fatal()
+}

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -247,11 +247,6 @@ where
         linker.bind("vm", "exit", vm::exit)?;
         linker.bind("vm", "message_context", vm::message_context)?;
 
-        linker.bind(
-            "network",
-            "total_fil_circ_supply",
-            network::total_fil_circ_supply,
-        )?;
         linker.bind("network", "context", network::context)?;
         linker.bind("network", "tipset_cid", network::tipset_cid)?;
 
@@ -358,6 +353,13 @@ where
             filecoin::verify_replica_update,
         )?;
         linker.bind("crypto", "batch_verify_seals", filecoin::batch_verify_seals)?;
+
+        // And bind a syscall for getting the total circulating supply.
+        linker.bind(
+            "network",
+            "total_fil_circ_supply",
+            filecoin::total_fil_circ_supply,
+        )?;
 
         Ok(())
     }

--- a/fvm/src/syscalls/network.rs
+++ b/fvm/src/syscalls/network.rs
@@ -1,21 +1,9 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use anyhow::Context as _;
-use fvm_shared::sys;
 use fvm_shared::sys::out::network::NetworkContext;
 
 use super::Context;
-use crate::kernel::{ClassifyResult, Kernel, Result};
-
-/// Returns the network circ supply split as two u64 ordered in little endian.
-pub fn total_fil_circ_supply(context: Context<'_, impl Kernel>) -> Result<sys::TokenAmount> {
-    context
-        .kernel
-        .total_fil_circ_supply()?
-        .try_into()
-        .context("circulating supply exceeds u128 limit")
-        .or_fatal()
-}
+use crate::kernel::{Kernel, Result};
 
 pub fn context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<NetworkContext> {
     context.kernel.network_context()


### PR DESCRIPTION
This is specific to Filecoin and will likely be moved into actors. The next step is removing it from the `MachineContext` (pluggable kernel configuration).

Also, make `SyscallHandler<K = Self>`.