### PR TITLE
[WIP] Kernel Refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,6 +2366,7 @@ dependencies = [
 name = "fvm_conformance_tests"
 version = "0.1.0"
 dependencies = [
+ "ambassador",
  "anyhow",
  "async-std",
  "base64 0.21.4",

--- a/fvm/src/engine/mod.rs
+++ b/fvm/src/engine/mod.rs
@@ -23,6 +23,7 @@ use wasmtime::{
 };
 
 use crate::gas::{Gas, GasTimer, WasmGasPrices};
+use crate::kernel::SyscallHandler;
 use crate::machine::limiter::MemoryLimiter;
 use crate::machine::{Machine, NetworkConfig};
 use crate::syscalls::error::Abort;
@@ -515,12 +516,7 @@ impl Engine {
                 .insert({
                     let mut linker = Linker::new(&self.inner.engine);
                     linker.allow_shadowing(true);
-
-                    store
-                        .data()
-                        .kernel
-                        .bind_syscalls(&mut linker)
-                        .map_err(Abort::Fatal)?;
+                    K::SyscallHandler::bind_syscalls(&mut linker).map_err(Abort::Fatal)?;
 
                     Box::new(Cache { linker })
                 })

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -48,36 +48,14 @@ pub struct CallResult {
     pub exit_code: ExitCode,
 }
 
-/// The "kernel" implements the FVM interface as presented to the actors. It:
-///
-/// - Manages the Actor's state.
-/// - Tracks and charges for IPLD & syscall-specific gas.
-///
-/// Actors may call into the kernel via the syscalls defined in the [`syscalls`][crate::syscalls]
-/// module.
-pub trait Kernel:
-    SyscallHandler<Self>
-    + ActorOps
-    + IpldBlockOps
-    + CircSupplyOps
-    + CryptoOps
-    + DebugOps
-    + EventOps
-    + GasOps
-    + MessageOps
-    + NetworkOps
-    + RandomnessOps
-    + SelfOps
-    + LimiterOps
-    + 'static
-{
-    /// The [`Kernel`]'s [`CallManager`] is
+/// The base [`Kernel`] trait implemented by all kernels.
+pub trait Kernel: Sized + 'static {
+    /// The [`Kernel`]'s [`CallManager`].
     type CallManager: CallManager;
-
-    /// Consume the [`Kernel`] and return the underlying [`CallManager`] and [`BlockRegistry`].
-    fn into_inner(self) -> (Self::CallManager, BlockRegistry)
-    where
-        Self: Sized;
+    /// The [`Kernel`]'s memory allocation tracker.
+    type Limiter: MemoryLimiter;
+    /// The [`SyscallHandler`] used by this kernel to expose syscalls to the actor.
+    type SyscallHandler: SyscallHandler<Self>;
 
     /// Construct a new [`Kernel`] from the given [`CallManager`].
     ///
@@ -99,52 +77,62 @@ pub trait Kernel:
     where
         Self: Sized;
 
+    /// Give access to the limiter of the underlying call manager.
+    fn limiter_mut(&mut self) -> &mut Self::Limiter;
+
+    /// XXX Returns the currently active gas price list.
+    fn price_list(&self) -> &PriceList;
+
+    /// Consume the [`Kernel`] and return the underlying [`CallManager`] and [`BlockRegistry`].
+    fn into_inner(self) -> (Self::CallManager, BlockRegistry)
+    where
+        Self: Sized;
+
     /// The kernel's underlying "machine".
     fn machine(&self) -> &<Self::CallManager as CallManager>::Machine;
 
-    /// Sends a message to another actor.
-    /// The method type parameter K is the type of the kernel to instantiate for
-    /// the receiving actor. This is necessary to support wrapping a kernel, so the outer
-    /// kernel can specify its Self as the receiver's kernel type, rather than the wrapped
-    /// kernel specifying its Self.
-    /// This method is part of the Kernel trait so it can refer to the Self::CallManager
-    /// associated type necessary to constrain K.
-    fn send<K: Kernel<CallManager = Self::CallManager>>(
-        &mut self,
-        recipient: &Address,
-        method: u64,
-        params: BlockId,
-        value: &TokenAmount,
-        gas_limit: Option<Gas>,
-        flags: SendFlags,
-    ) -> Result<CallResult>;
+    /// ChargeGas charges specified amount of `gas` for execution.
+    /// `name` provides information about gas charging point.
+    fn charge_gas(&self, name: &str, compute: Gas) -> Result<GasTimer>;
 
-    fn upgrade_actor<K: Kernel<CallManager = Self::CallManager>>(
-        &mut self,
-        new_code_cid: Cid,
-        params_id: BlockId,
-    ) -> Result<CallResult>;
+    // XXX: Move these somewhere else?
+
+    /// Returns the remaining gas for the transaction.
+    fn gas_available(&self) -> Gas;
+
+    /// XXX: Testing only!
+    fn gas_used(&self) -> Gas;
 }
 
-pub trait SyscallHandler<K: Kernel>: Sized {
-    fn bind_syscalls(&self, linker: &mut Linker<InvocationData<K>>) -> anyhow::Result<()>;
+/// This trait links the kernel to a wasm module via wasm "host" calls (syscalls).
+pub trait SyscallHandler<K>: Sized {
+    fn bind_syscalls(linker: &mut Linker<InvocationData<K>>) -> anyhow::Result<()>;
 }
 
-/// Network-related operations.
+/// The chain-related kernel operations.
 #[delegatable_trait]
-pub trait NetworkOps {
+pub trait ChainOps {
+    /// Randomness returns a (pseudo)random byte array drawing from the latest
+    /// ticket chain from a given epoch.
+    /// This randomness is fork dependant but also biasable because of this.
+    fn get_randomness_from_tickets(
+        &self,
+        rand_epoch: fvm_shared::clock::ChainEpoch,
+    ) -> Result<[u8; fvm_shared::randomness::RANDOMNESS_LENGTH]>;
+
+    /// Randomness returns a (pseudo)random byte array drawing from the latest
+    /// beacon from a given epoch.
+    /// This randomness is not tied to any fork of the chain, and is unbiasable.
+    fn get_randomness_from_beacon(
+        &self,
+        rand_epoch: fvm_shared::clock::ChainEpoch,
+    ) -> Result<[u8; fvm_shared::randomness::RANDOMNESS_LENGTH]>;
+
     /// Network information (epoch, version, etc.).
-    fn network_context(&self) -> Result<NetworkContext>;
+    fn network_context(&self) -> Result<fvm_shared::sys::out::network::NetworkContext>;
 
     /// The CID of the tipset at the specified epoch.
-    fn tipset_cid(&self, epoch: ChainEpoch) -> Result<Cid>;
-}
-
-/// Accessors to query attributes of the incoming message.
-#[delegatable_trait]
-pub trait MessageOps {
-    /// Message information.
-    fn msg_context(&self) -> Result<MessageContext>;
+    fn tipset_cid(&self, epoch: fvm_shared::clock::ChainEpoch) -> Result<Cid>;
 }
 
 /// The IPLD subset of the kernel.
@@ -181,39 +169,114 @@ pub trait IpldBlockOps {
 }
 
 /// Actor state access and manipulation.
-/// Depends on BlockOps to read and write blocks in the state tree.
 #[delegatable_trait]
-pub trait SelfOps: IpldBlockOps {
+pub trait ActorOps {
+    /// Message information.
+    fn msg_context(&self) -> Result<fvm_shared::sys::out::vm::MessageContext>;
+
+    /// Returns the balance associated with an actor id
+    fn balance_of(&self, actor_id: ActorID) -> Result<TokenAmount>;
+
+    /// The balance of the receiver.
+    fn current_balance(&self) -> Result<TokenAmount>;
+
+    /// Look up the code CID of an actor.
+    fn get_actor_code_cid(&self, id: ActorID) -> Result<Cid>;
+
+    /// Looks up the "delegated" (f4) address of the specified actor, if any.
+    fn lookup_delegated_address(&self, actor_id: ActorID) -> Result<Option<Address>>;
+
+    /// Resolves an address of any protocol to an ID address (via the Init actor's table).
+    /// This allows resolution of externally-provided SECP, BLS, or actor addresses to the canonical
+    /// form. If the argument is an ID address it is returned directly.
+    fn resolve_address(&self, address: &Address) -> Result<ActorID>;
+
     /// Get the state root.
     fn root(&mut self) -> Result<Cid>;
+
+    /// Deletes the executing actor from the state tree, burning any remaining balance if requested.
+    fn self_destruct(&mut self, burn_unspent: bool) -> Result<()>;
 
     /// Update the state-root.
     ///
     /// This method will fail if the new state-root isn't reachable.
     fn set_root(&mut self, root: Cid) -> Result<()>;
 
-    /// The balance of the receiver.
-    fn current_balance(&self) -> Result<TokenAmount>;
-
-    /// Deletes the executing actor from the state tree, burning any remaining balance if requested.
-    fn self_destruct(&mut self, burn_unspent: bool) -> Result<()>;
+    /// Records an event emitted throughout execution.
+    fn emit_event(
+        &mut self,
+        event_headers: &[fvm_shared::sys::EventEntry],
+        raw_key: &[u8],
+        raw_val: &[u8],
+    ) -> Result<()>;
 }
 
-/// Actors operations whose scope of action is actors other than the calling
-/// actor. The calling actor's state may be consulted to resolve some.
+/// The actor calling operations.
 #[delegatable_trait]
-pub trait ActorOps {
-    /// Resolves an address of any protocol to an ID address (via the Init actor's table).
-    /// This allows resolution of externally-provided SECP, BLS, or actor addresses to the canonical form.
-    /// If the argument is an ID address it is returned directly.
-    fn resolve_address(&self, address: &Address) -> Result<ActorID>;
+pub trait CallOps<K: Kernel = Self> {
+    /// Sends a message to another actor.
+    /// The method type parameter K is the type of the kernel to instantiate for
+    /// the receiving actor. This is necessary to support wrapping a kernel, so the outer
+    /// kernel can specify its Self as the receiver's kernel type, rather than the wrapped
+    /// kernel specifying its Self.
+    /// This method is part of the Kernel trait so it can refer to the Self::CallManager
+    /// associated type necessary to constrain K.
+    fn send(
+        &mut self,
+        recipient: &Address,
+        method: u64,
+        params: BlockId,
+        value: &TokenAmount,
+        gas_limit: Option<Gas>,
+        flags: SendFlags,
+    ) -> Result<CallResult>;
 
-    /// Looks up the "delegated" (f4) address of the specified actor, if any.
-    fn lookup_delegated_address(&self, actor_id: ActorID) -> Result<Option<Address>>;
+    fn upgrade_actor(&mut self, new_code_cid: Cid, params_id: BlockId) -> Result<CallResult>;
+}
 
-    /// Look up the code CID of an actor.
-    fn get_actor_code_cid(&self, id: ActorID) -> Result<Cid>;
+/// Cryptographic primitives provided by the kernel.
+#[delegatable_trait]
+pub trait CryptoOps {
+    /// Verifies that a signature is valid for an address and plaintext.
+    fn verify_signature(
+        &self,
+        sig_type: fvm_shared::crypto::signature::SignatureType,
+        signature: &[u8],
+        signer: &Address,
+        plaintext: &[u8],
+    ) -> Result<bool>;
 
+    /// Given a message hash and its signature, recovers the public key of the signer.
+    fn recover_secp_public_key(
+        &self,
+        hash: &[u8; fvm_shared::crypto::signature::SECP_SIG_MESSAGE_HASH_SIZE],
+        signature: &[u8; fvm_shared::crypto::signature::SECP_SIG_LEN],
+    ) -> Result<[u8; fvm_shared::crypto::signature::SECP_PUB_LEN]>;
+
+    /// Hashes input `data_in` using with the specified hash function, writing the output to
+    /// `digest_out`, returning the size of the digest written to `digest_out`. If `digest_out` is
+    /// to small to fit the entire digest, it will be truncated. If too large, the leftover space
+    /// will not be overwritten.
+    fn hash(&self, code: u64, data: &[u8]) -> Result<multihash::MultihashGeneric<64>>;
+}
+
+/// Debugging APIs.
+#[delegatable_trait]
+pub trait DebugOps {
+    /// Log a message.
+    fn log(&self, msg: String);
+
+    /// Returns whether debug mode is enabled.
+    fn debug_enabled(&self) -> bool;
+
+    /// Store an artifact.
+    /// Returns error on malformed name, returns Ok and logs the error on system/os errors.
+    fn store_artifact(&self, name: &str, data: &[u8]) -> Result<()>;
+}
+
+/// Private system operations.
+#[delegatable_trait]
+pub trait SystemOps {
     /// Computes an address for a new actor. The returned address is intended to uniquely refer to
     /// the actor even in the event of a chain re-org (whereas an ID-address might refer to a
     /// different actor after messages are re-ordered).
@@ -236,120 +299,4 @@ pub trait ActorOps {
 
     /// Returns the CodeCID for the supplied built-in actor type.
     fn get_code_cid_for_type(&self, typ: u32) -> Result<Cid>;
-
-    /// Returns the balance associated with an actor id
-    fn balance_of(&self, actor_id: ActorID) -> Result<TokenAmount>;
-}
-
-/// Operations to query the circulating supply.
-#[delegatable_trait]
-pub trait CircSupplyOps {
-    /// Returns the total token supply in circulation at the beginning of the current epoch.
-    /// The circulating supply is the sum of:
-    /// - rewards emitted by the reward actor,
-    /// - funds vested from lock-ups in the genesis state,
-    /// less the sum of:
-    /// - funds burnt,
-    /// - pledge collateral locked in storage miner actors (recorded in the storage power actor)
-    /// - deal collateral locked by the storage market actor
-    fn total_fil_circ_supply(&self) -> Result<TokenAmount>;
-}
-
-/// Operations for explicit gas charging.
-#[delegatable_trait]
-pub trait GasOps {
-    /// Returns the gas used by the transaction so far.
-    fn gas_used(&self) -> Gas;
-
-    /// Returns the remaining gas for the transaction.
-    fn gas_available(&self) -> Gas;
-
-    /// ChargeGas charges specified amount of `gas` for execution.
-    /// `name` provides information about gas charging point.
-    fn charge_gas(&self, name: &str, compute: Gas) -> Result<GasTimer>;
-
-    /// Returns the currently active gas price list.
-    fn price_list(&self) -> &PriceList;
-}
-
-/// Cryptographic primitives provided by the kernel.
-#[delegatable_trait]
-pub trait CryptoOps {
-    /// Verifies that a signature is valid for an address and plaintext.
-    fn verify_signature(
-        &self,
-        sig_type: SignatureType,
-        signature: &[u8],
-        signer: &Address,
-        plaintext: &[u8],
-    ) -> Result<bool>;
-
-    /// Given a message hash and its signature, recovers the public key of the signer.
-    fn recover_secp_public_key(
-        &self,
-        hash: &[u8; SECP_SIG_MESSAGE_HASH_SIZE],
-        signature: &[u8; SECP_SIG_LEN],
-    ) -> Result<[u8; SECP_PUB_LEN]>;
-
-    /// Hashes input `data_in` using with the specified hash function, writing the output to
-    /// `digest_out`, returning the size of the digest written to `digest_out`. If `digest_out` is
-    /// to small to fit the entire digest, it will be truncated. If too large, the leftover space
-    /// will not be overwritten.
-    fn hash(&self, code: u64, data: &[u8]) -> Result<MultihashGeneric<64>>;
-}
-
-/// Randomness queries.
-#[delegatable_trait]
-pub trait RandomnessOps {
-    /// Randomness returns a (pseudo)random byte array drawing from the latest
-    /// ticket chain from a given epoch.
-    /// This randomness is fork dependant but also biasable because of this.
-    fn get_randomness_from_tickets(
-        &self,
-        rand_epoch: ChainEpoch,
-    ) -> Result<[u8; RANDOMNESS_LENGTH]>;
-
-    /// Randomness returns a (pseudo)random byte array drawing from the latest
-    /// beacon from a given epoch.
-    /// This randomness is not tied to any fork of the chain, and is unbiasable.
-    fn get_randomness_from_beacon(&self, rand_epoch: ChainEpoch)
-        -> Result<[u8; RANDOMNESS_LENGTH]>;
-}
-
-/// Debugging APIs.
-#[delegatable_trait]
-pub trait DebugOps {
-    /// Log a message.
-    fn log(&self, msg: String);
-
-    /// Returns whether debug mode is enabled.
-    fn debug_enabled(&self) -> bool;
-
-    /// Store an artifact.
-    /// Returns error on malformed name, returns Ok and logs the error on system/os errors.
-    fn store_artifact(&self, name: &str, data: &[u8]) -> Result<()>;
-}
-
-/// Track and limit memory expansion.
-///
-/// This interface is not one of the operations the kernel provides to actors.
-/// It's only part of the kernel out of necessity to pass it through to the
-/// call manager which tracks the limits across the whole execution stack.
-#[delegatable_trait]
-pub trait LimiterOps {
-    type Limiter: MemoryLimiter;
-    /// Give access to the limiter of the underlying call manager.
-    fn limiter_mut(&mut self) -> &mut Self::Limiter;
-}
-
-/// Eventing APIs.
-#[delegatable_trait]
-pub trait EventOps {
-    /// Records an event emitted throughout execution.
-    fn emit_event(
-        &mut self,
-        event_headers: &[fvm_shared::sys::EventEntry],
-        raw_key: &[u8],
-        raw_val: &[u8],
-    ) -> Result<()>;
 }

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -54,11 +54,11 @@ mod test {
 
     use crate::call_manager::DefaultCallManager;
     use crate::engine::EnginePool;
+    use crate::executor;
     use crate::externs::{Chain, Consensus, Externs, Rand};
     use crate::kernel::filecoin::DefaultFilecoinKernel;
     use crate::machine::{DefaultMachine, Manifest, NetworkConfig};
     use crate::state_tree::StateTree;
-    use crate::{executor, DefaultKernel};
 
     struct DummyExterns;
 
@@ -125,8 +125,9 @@ mod test {
 
         let machine = DefaultMachine::new(&mc, bs, DummyExterns).unwrap();
         let engine = EnginePool::new_default((&mc.network).into()).unwrap();
-        let _ = executor::DefaultExecutor::<
-            DefaultFilecoinKernel<DefaultKernel<DefaultCallManager<_>>>,
-        >::new(engine, Box::new(machine));
+        let _ = executor::DefaultExecutor::<DefaultFilecoinKernel<DefaultCallManager<_>>>::new(
+            engine,
+            Box::new(machine),
+        );
     }
 }

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -6,11 +6,11 @@ use fvm_shared::{sys, ActorID};
 use super::bind::ControlFlow;
 use super::error::Abort;
 use super::Context;
-use crate::kernel::{CallResult, ClassifyResult, Result};
+use crate::kernel::{ActorOps, CallOps, CallResult, ClassifyResult, Result, SystemOps};
 use crate::{syscall_error, Kernel};
 
 pub fn resolve_address(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ActorOps>,
     addr_off: u32, // Address
     addr_len: u32,
 ) -> Result<u64> {
@@ -20,7 +20,7 @@ pub fn resolve_address(
 }
 
 pub fn lookup_delegated_address(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ActorOps>,
     actor_id: ActorID,
     obuf_off: u32,
     obuf_len: u32,
@@ -41,7 +41,7 @@ pub fn lookup_delegated_address(
 }
 
 pub fn get_actor_code_cid(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ActorOps>,
     actor_id: u64,
     obuf_off: u32, // Cid
     obuf_len: u32,
@@ -59,7 +59,7 @@ pub fn get_actor_code_cid(
 /// The output buffer must be at least 21 bytes long, which is the length of a class 2 address
 /// (protocol-generated actor address).
 pub fn next_actor_address(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl SystemOps>,
     obuf_off: u32, // Address (out)
     obuf_len: u32,
 ) -> Result<u32> {
@@ -93,7 +93,7 @@ pub fn next_actor_address(
 }
 
 pub fn create_actor(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl SystemOps>,
     actor_id: u64, // ID
     typ_off: u32,  // Cid
     delegated_addr_off: u32,
@@ -111,7 +111,7 @@ pub fn create_actor(
     context.kernel.create_actor(typ, actor_id, addr)
 }
 
-pub fn upgrade_actor<K: Kernel>(
+pub fn upgrade_actor<K: CallOps + Kernel>(
     context: Context<'_, K>,
     new_code_cid_off: u32,
     params_id: u32,
@@ -121,7 +121,7 @@ pub fn upgrade_actor<K: Kernel>(
         Err(err) => return err.into(),
     };
 
-    match context.kernel.upgrade_actor::<K>(cid, params_id) {
+    match context.kernel.upgrade_actor(cid, params_id) {
         Ok(CallResult {
             block_id,
             block_stat,
@@ -143,7 +143,7 @@ pub fn upgrade_actor<K: Kernel>(
 }
 
 pub fn get_builtin_actor_type(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl SystemOps>,
     code_cid_off: u32, // Cid
 ) -> Result<i32> {
     let cid = context.memory.read_cid(code_cid_off)?;
@@ -151,7 +151,7 @@ pub fn get_builtin_actor_type(
 }
 
 pub fn get_code_cid_for_type(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl SystemOps>,
     typ: i32,
     obuf_off: u32, // Cid
     obuf_len: u32,
@@ -163,14 +163,14 @@ pub fn get_code_cid_for_type(
 }
 
 pub fn install_actor(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl SystemOps>,
     typ_off: u32, // Cid
 ) -> Result<()> {
     let typ = context.memory.read_cid(typ_off)?;
     context.kernel.install_actor(typ)
 }
 
-pub fn balance_of(context: Context<'_, impl Kernel>, actor_id: u64) -> Result<sys::TokenAmount> {
+pub fn balance_of(context: Context<'_, impl ActorOps>, actor_id: u64) -> Result<sys::TokenAmount> {
     let balance = context.kernel.balance_of(actor_id)?;
     balance
         .try_into()

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -9,8 +9,7 @@ use fvm_shared::crypto::signature::{
 use num_traits::FromPrimitive;
 
 use super::Context;
-use crate::kernel::{ClassifyResult, Result};
-use crate::Kernel;
+use crate::kernel::{ClassifyResult, CryptoOps, Result};
 
 /// Verifies that a signature is valid for an address and plaintext.
 ///
@@ -19,7 +18,7 @@ use crate::Kernel;
 ///  - -1: verification failed.
 #[allow(clippy::too_many_arguments)]
 pub fn verify_signature(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl CryptoOps>,
     sig_type: u32,
     sig_off: u32,
     sig_len: u32,
@@ -42,7 +41,7 @@ pub fn verify_signature(
 }
 
 pub fn recover_secp_public_key(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl CryptoOps>,
     hash_off: u32,
     sig_off: u32,
 ) -> Result<[u8; SECP_PUB_LEN]> {
@@ -66,7 +65,7 @@ pub fn recover_secp_public_key(
 /// Hashes input data using the specified hash function, writing the digest into the provided
 /// buffer.
 pub fn hash(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl CryptoOps>,
     hash_code: u64,
     data_off: u32, // input
     data_len: u32,

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -1,10 +1,9 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use crate::kernel::{ClassifyResult, Result};
+use crate::kernel::{ClassifyResult, DebugOps, Result};
 use crate::syscalls::context::Context;
-use crate::Kernel;
 
-pub fn log(context: Context<'_, impl Kernel>, msg_off: u32, msg_len: u32) -> Result<()> {
+pub fn log(context: Context<'_, impl DebugOps>, msg_off: u32, msg_len: u32) -> Result<()> {
     // No-op if disabled.
     if !context.kernel.debug_enabled() {
         return Ok(());
@@ -16,7 +15,7 @@ pub fn log(context: Context<'_, impl Kernel>, msg_off: u32, msg_len: u32) -> Res
     Ok(())
 }
 
-pub fn enabled(context: Context<'_, impl Kernel>) -> Result<i32> {
+pub fn enabled(context: Context<'_, impl DebugOps>) -> Result<i32> {
     Ok(if context.kernel.debug_enabled() {
         0
     } else {
@@ -25,7 +24,7 @@ pub fn enabled(context: Context<'_, impl Kernel>) -> Result<i32> {
 }
 
 pub fn store_artifact(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl DebugOps>,
     name_off: u32,
     name_len: u32,
     data_off: u32,

--- a/fvm/src/syscalls/event.rs
+++ b/fvm/src/syscalls/event.rs
@@ -4,8 +4,7 @@
 use anyhow::Context as _;
 
 use super::Context;
-use crate::kernel::{ClassifyResult, Result};
-use crate::Kernel;
+use crate::kernel::{ActorOps, ClassifyResult, Result};
 
 /// Emits an actor event. The event is split into three raw byte buffers that have
 /// been written to Wasm memory. This is done so that the FVM can accurately charge
@@ -25,7 +24,7 @@ use crate::Kernel;
 /// Calling this syscall may immediately halt execution with an out of gas error,
 /// if such condition arises.
 pub fn emit_event(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ActorOps>,
     event_off: u32,
     event_len: u32,
     key_off: u32,

--- a/fvm/src/syscalls/filecoin.rs
+++ b/fvm/src/syscalls/filecoin.rs
@@ -178,3 +178,15 @@ pub fn batch_verify_seals(
     }
     Ok(())
 }
+
+/// Returns the network circ supply split as two u64 ordered in little endian.
+pub fn total_fil_circ_supply(
+    context: Context<'_, impl FilecoinKernel>,
+) -> Result<sys::TokenAmount> {
+    context
+        .kernel
+        .total_fil_circ_supply()?
+        .try_into()
+        .context("circulating supply exceeds u128 limit")
+        .or_fatal()
+}

--- a/fvm/src/syscalls/gas.rs
+++ b/fvm/src/syscalls/gas.rs
@@ -8,7 +8,7 @@ use crate::kernel::{ClassifyResult, Result};
 use crate::Kernel;
 
 pub fn charge_gas(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl Kernel>, // XXX Move charge gas?
     name_off: u32,
     name_len: u32,
     compute: u64,

--- a/fvm/src/syscalls/ipld.rs
+++ b/fvm/src/syscalls/ipld.rs
@@ -3,10 +3,12 @@
 use fvm_shared::sys;
 
 use super::Context;
-use crate::kernel::Result;
-use crate::Kernel;
+use crate::kernel::{IpldBlockOps, Result};
 
-pub fn block_open(context: Context<'_, impl Kernel>, cid: u32) -> Result<sys::out::ipld::IpldOpen> {
+pub fn block_open(
+    context: Context<'_, impl IpldBlockOps>,
+    cid: u32,
+) -> Result<sys::out::ipld::IpldOpen> {
     let cid = context.memory.read_cid(cid)?;
     let (id, stat) = context.kernel.block_open(&cid)?;
     Ok(sys::out::ipld::IpldOpen {
@@ -17,7 +19,7 @@ pub fn block_open(context: Context<'_, impl Kernel>, cid: u32) -> Result<sys::ou
 }
 
 pub fn block_create(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl IpldBlockOps>,
     codec: u64,
     data_off: u32,
     data_len: u32,
@@ -27,7 +29,7 @@ pub fn block_create(
 }
 
 pub fn block_link(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl IpldBlockOps>,
     id: u32,
     hash_fun: u64,
     hash_len: u32,
@@ -45,7 +47,7 @@ pub fn block_link(
 }
 
 pub fn block_read(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl IpldBlockOps>,
     id: u32,
     offset: u32,
     obuf_off: u32,
@@ -55,7 +57,10 @@ pub fn block_read(
     context.kernel.block_read(id, offset, data)
 }
 
-pub fn block_stat(context: Context<'_, impl Kernel>, id: u32) -> Result<sys::out::ipld::IpldStat> {
+pub fn block_stat(
+    context: Context<'_, impl IpldBlockOps>,
+    id: u32,
+) -> Result<sys::out::ipld::IpldStat> {
     context
         .kernel
         .block_stat(id)

--- a/fvm/src/syscalls/network.rs
+++ b/fvm/src/syscalls/network.rs
@@ -1,28 +1,16 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use anyhow::Context as _;
-use fvm_shared::sys;
 use fvm_shared::sys::out::network::NetworkContext;
 
 use super::Context;
-use crate::kernel::{ClassifyResult, Kernel, Result};
+use crate::kernel::{ChainOps, Result};
 
-/// Returns the network circ supply split as two u64 ordered in little endian.
-pub fn total_fil_circ_supply(context: Context<'_, impl Kernel>) -> Result<sys::TokenAmount> {
-    context
-        .kernel
-        .total_fil_circ_supply()?
-        .try_into()
-        .context("circulating supply exceeds u128 limit")
-        .or_fatal()
-}
-
-pub fn context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<NetworkContext> {
+pub fn context(context: Context<'_, impl ChainOps>) -> crate::kernel::Result<NetworkContext> {
     context.kernel.network_context()
 }
 
 pub fn tipset_cid(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ChainOps>,
     epoch: i64,
     obuf_off: u32,
     obuf_len: u32,

--- a/fvm/src/syscalls/rand.rs
+++ b/fvm/src/syscalls/rand.rs
@@ -3,15 +3,14 @@
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
 
 use super::Context;
-use crate::kernel::Result;
-use crate::Kernel;
+use crate::kernel::{ChainOps, Result};
 
 /// Gets 32 bytes of randomness from the ticket chain.
 /// The supplied output buffer must have at least 32 bytes of capacity.
 /// If this syscall succeeds, exactly 32 bytes will be written starting at the
 /// supplied offset.
 pub fn get_chain_randomness(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ChainOps>,
     round: i64, // ChainEpoch
 ) -> Result<[u8; RANDOMNESS_LENGTH]> {
     context.kernel.get_randomness_from_tickets(round)
@@ -22,7 +21,7 @@ pub fn get_chain_randomness(
 /// If this syscall succeeds, exactly 32 bytes will be written starting at the
 /// supplied offset.
 pub fn get_beacon_randomness(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ChainOps>,
     round: i64, // ChainEpoch
 ) -> Result<[u8; RANDOMNESS_LENGTH]> {
     context.kernel.get_randomness_from_beacon(round)

--- a/fvm/src/syscalls/send.rs
+++ b/fvm/src/syscalls/send.rs
@@ -7,13 +7,13 @@ use fvm_shared::sys::{self, SendFlags};
 
 use super::Context;
 use crate::gas::Gas;
-use crate::kernel::{CallResult, ClassifyResult, Result};
+use crate::kernel::{CallOps, CallResult, ClassifyResult, Result};
 use crate::Kernel;
 
 /// Send a message to another actor. The result is placed as a CBOR-encoded
 /// receipt in the block registry, and can be retrieved by the returned BlockId.
 #[allow(clippy::too_many_arguments)]
-pub fn send<K: Kernel>(
+pub fn send<K: CallOps + Kernel>(
     context: Context<'_, K>,
     recipient_off: u32,
     recipient_len: u32,
@@ -43,7 +43,7 @@ pub fn send<K: Kernel>(
         exit_code,
     } = context
         .kernel
-        .send::<K>(&recipient, method, params_id, &value, gas_limit, flags)?;
+        .send(&recipient, method, params_id, &value, gas_limit, flags)?;
 
     Ok(sys::out::send::Send {
         exit_code: exit_code.value(),

--- a/fvm/src/syscalls/sself.rs
+++ b/fvm/src/syscalls/sself.rs
@@ -4,14 +4,14 @@ use anyhow::Context as _;
 use fvm_shared::sys;
 
 use super::Context;
-use crate::kernel::{ClassifyResult, Kernel, Result};
+use crate::kernel::{ActorOps, ClassifyResult, Result};
 
 /// Returns the root CID of the actor's state by writing it in the specified buffer.
 ///
 /// The returned u32 represents the _actual_ length of the CID. If the supplied
 /// buffer is smaller, no value will have been written. The caller must retry
 /// with a larger buffer.
-pub fn root(context: Context<'_, impl Kernel>, obuf_off: u32, obuf_len: u32) -> Result<u32> {
+pub fn root(context: Context<'_, impl ActorOps>, obuf_off: u32, obuf_len: u32) -> Result<u32> {
     context.memory.check_bounds(obuf_off, obuf_len)?;
 
     let root = context.kernel.root()?;
@@ -19,13 +19,13 @@ pub fn root(context: Context<'_, impl Kernel>, obuf_off: u32, obuf_len: u32) -> 
     context.memory.write_cid(&root, obuf_off, obuf_len)
 }
 
-pub fn set_root(context: Context<'_, impl Kernel>, cid_off: u32) -> Result<()> {
+pub fn set_root(context: Context<'_, impl ActorOps>, cid_off: u32) -> Result<()> {
     let cid = context.memory.read_cid(cid_off)?;
     context.kernel.set_root(cid)?;
     Ok(())
 }
 
-pub fn current_balance(context: Context<'_, impl Kernel>) -> Result<sys::TokenAmount> {
+pub fn current_balance(context: Context<'_, impl ActorOps>) -> Result<sys::TokenAmount> {
     let balance = context.kernel.current_balance()?;
     balance
         .try_into()
@@ -33,7 +33,7 @@ pub fn current_balance(context: Context<'_, impl Kernel>) -> Result<sys::TokenAm
         .or_fatal()
 }
 
-pub fn self_destruct(context: Context<'_, impl Kernel>, burn_unspent: u32) -> Result<()> {
+pub fn self_destruct(context: Context<'_, impl ActorOps>, burn_unspent: u32) -> Result<()> {
     context.kernel.self_destruct(burn_unspent > 0)?;
     Ok(())
 }

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -5,7 +5,7 @@ use fvm_shared::sys::out::vm::MessageContext;
 
 use super::error::Abort;
 use super::Context;
-use crate::kernel::Kernel;
+use crate::kernel::{ActorOps, Kernel};
 
 /// The maximum message length included in the backtrace. Given 1024 levels, this gives us a total
 /// maximum of around 1MiB for debugging.
@@ -52,6 +52,8 @@ pub fn exit(
     Abort::Exit(code, message, blk)
 }
 
-pub fn message_context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<MessageContext> {
+pub fn message_context(
+    context: Context<'_, impl ActorOps>,
+) -> crate::kernel::Result<MessageContext> {
     context.kernel.msg_context()
 }

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -435,7 +435,6 @@ mod ipld {
 
 mod gas {
     use fvm::gas::*;
-    use fvm::kernel::GasOps;
     use pretty_assertions::assert_eq;
 
     use super::*;

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -37,6 +37,7 @@ ittapi-rs = { version = "0.3.0", optional = true }
 libipld-core = { version = "0.16.0", features = ["serde-codec"] }
 tar = { version = "0.4.38", default-features = false }
 zstd = { version = "0.12.3", default-features = false }
+ambassador = "0.3.5"
 
 [dependencies.fvm]
 version = "4.0.0"

--- a/testing/conformance/src/lib.rs
+++ b/testing/conformance/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2021-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
+#[macro_use]
+extern crate fvm;
 
 pub mod actors;
 pub mod cidjson;

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -3,11 +3,10 @@
 use std::convert::TryFrom;
 use std::sync::{Arc, Mutex};
 
+use ambassador::Delegate;
 use anyhow::anyhow;
 use cid::Cid;
 use fvm::kernel::filecoin::{DefaultFilecoinKernel, FilecoinKernel};
-use fvm::syscalls::InvocationData;
-use multihash::MultihashGeneric;
 
 use fvm::call_manager::{CallManager, DefaultCallManager};
 use fvm::gas::{price_list_by_network_version, Gas, GasTimer, PriceList};
@@ -15,24 +14,17 @@ use fvm::kernel::*;
 use fvm::machine::limiter::MemoryLimiter;
 use fvm::machine::{DefaultMachine, Machine, MachineContext, Manifest, NetworkConfig};
 use fvm::state_tree::StateTree;
-use fvm::DefaultKernel;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::address::Address;
-use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
-use fvm_shared::crypto::signature::{
-    SignatureType, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
-};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PieceInfo;
-use fvm_shared::randomness::RANDOMNESS_LENGTH;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, ReplicaUpdateInfo, SealVerifyInfo,
 };
-use fvm_shared::sys::{EventEntry, SendFlags};
+use fvm_shared::sys::SendFlags;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum, TOTAL_FILECOIN};
-use wasmtime::Linker;
 
 use crate::externs::TestExterns;
 use crate::vector::{MessageVector, Variant};
@@ -182,31 +174,28 @@ where
     }
 }
 
+type InnerKernel = DefaultFilecoinKernel<DefaultCallManager<TestMachine>>;
+
 /// A kernel for intercepting syscalls.
 // TestKernel is coupled to TestMachine because it needs to use that to plumb the
 // TestData through when it's destroyed into a CallManager then recreated by that CallManager.
-pub struct TestKernel<K = DefaultFilecoinKernel<DefaultKernel<DefaultCallManager<TestMachine>>>>(
-    pub K,
-    pub TestData,
-);
+#[derive(Delegate)]
+#[delegate(IpldBlockOps, target = "0")]
+#[delegate(ActorOps, target = "0")]
+#[delegate(CryptoOps, target = "0")]
+#[delegate(CallOps<K>, generics = "K", where = "K: FilecoinKernel", target = "0")]
+#[delegate(DebugOps, target = "0")]
+#[delegate(SystemOps, target = "0")]
+#[delegate(ChainOps, target = "0")]
+pub struct TestKernel(pub InnerKernel, pub TestData);
 
-impl<M, C, K> Kernel for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    type CallManager = K::CallManager;
-
-    fn into_inner(self) -> (Self::CallManager, BlockRegistry)
-    where
-        Self: Sized,
-    {
-        self.0.into_inner()
-    }
+impl Kernel for TestKernel {
+    type CallManager = <InnerKernel as Kernel>::CallManager;
+    type Limiter = <InnerKernel as Kernel>::Limiter;
+    type SyscallHandler = <InnerKernel as Kernel>::SyscallHandler;
 
     fn new(
-        mgr: C,
+        mgr: Self::CallManager,
         blocks: BlockRegistry,
         caller: ActorID,
         actor_id: ActorID,
@@ -221,7 +210,7 @@ where
         let data = mgr.machine().data.clone();
 
         TestKernel(
-            K::new(
+            InnerKernel::new(
                 mgr,
                 blocks,
                 caller,
@@ -234,138 +223,39 @@ where
         )
     }
 
+    fn into_inner(self) -> (Self::CallManager, BlockRegistry)
+    where
+        Self: Sized,
+    {
+        self.0.into_inner()
+    }
+
     fn machine(&self) -> &<Self::CallManager as CallManager>::Machine {
         self.0.machine()
     }
 
-    fn send<KK>(
-        &mut self,
-        recipient: &Address,
-        method: u64,
-        params: BlockId,
-        value: &TokenAmount,
-        gas_limit: Option<Gas>,
-        flags: SendFlags,
-    ) -> Result<CallResult> {
-        // Note that KK, the type of the kernel to crate for the receiving actor, is ignored,
-        // and Self is passed as the type parameter for the nested call.
-        // If we could find the correct bound to specify KK for the call, we would.
-        // This restricts the ability for the TestKernel to itself be wrapped by another kernel type.
-        self.0
-            .send::<Self>(recipient, method, params, value, gas_limit, flags)
+    fn limiter_mut(&mut self) -> &mut Self::Limiter {
+        self.0.limiter_mut()
     }
 
-    fn upgrade_actor<KK>(&mut self, new_code_cid: Cid, params_id: BlockId) -> Result<CallResult> {
-        self.0.upgrade_actor::<Self>(new_code_cid, params_id)
+    fn price_list(&self) -> &PriceList {
+        self.0.price_list()
+    }
+
+    fn charge_gas(&self, name: &str, compute: Gas) -> Result<GasTimer> {
+        self.0.charge_gas(name, compute)
+    }
+
+    fn gas_available(&self) -> Gas {
+        self.0.gas_available()
+    }
+
+    fn gas_used(&self) -> Gas {
+        self.0.gas_available()
     }
 }
 
-impl<M, C, K> SyscallHandler<TestKernel<K>> for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    fn bind_syscalls(
-        &self,
-        _linker: &mut Linker<InvocationData<TestKernel<K>>>,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-}
-
-impl<M, C, K> ActorOps for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    fn resolve_address(&self, address: &Address) -> Result<ActorID> {
-        self.0.resolve_address(address)
-    }
-
-    fn get_actor_code_cid(&self, id: ActorID) -> Result<Cid> {
-        self.0.get_actor_code_cid(id)
-    }
-
-    fn next_actor_address(&self) -> Result<Address> {
-        self.0.next_actor_address()
-    }
-
-    fn create_actor(
-        &mut self,
-        code_id: Cid,
-        actor_id: ActorID,
-        delegated_address: Option<Address>,
-    ) -> Result<()> {
-        self.0.create_actor(code_id, actor_id, delegated_address)
-    }
-
-    fn install_actor(&mut self, _code_id: Cid) -> Result<()> {
-        Ok(())
-    }
-
-    fn get_builtin_actor_type(&self, code_cid: &Cid) -> Result<u32> {
-        self.0.get_builtin_actor_type(code_cid)
-    }
-
-    fn get_code_cid_for_type(&self, typ: u32) -> Result<Cid> {
-        self.0.get_code_cid_for_type(typ)
-    }
-
-    fn balance_of(&self, actor_id: ActorID) -> Result<TokenAmount> {
-        self.0.balance_of(actor_id)
-    }
-
-    fn lookup_delegated_address(&self, actor_id: ActorID) -> Result<Option<Address>> {
-        self.0.lookup_delegated_address(actor_id)
-    }
-}
-
-impl<M, C, K> IpldBlockOps for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    fn block_open(&mut self, cid: &Cid) -> Result<(BlockId, BlockStat)> {
-        self.0.block_open(cid)
-    }
-
-    fn block_create(&mut self, codec: u64, data: &[u8]) -> Result<BlockId> {
-        self.0.block_create(codec, data)
-    }
-
-    fn block_link(&mut self, id: BlockId, hash_fun: u64, hash_len: u32) -> Result<Cid> {
-        self.0.block_link(id, hash_fun, hash_len)
-    }
-
-    fn block_read(&self, id: BlockId, offset: u32, buf: &mut [u8]) -> Result<i32> {
-        self.0.block_read(id, offset, buf)
-    }
-
-    fn block_stat(&self, id: BlockId) -> Result<BlockStat> {
-        self.0.block_stat(id)
-    }
-}
-
-impl<M, C, K> CircSupplyOps for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    // Not forwarded. Circulating supply is taken from the TestData.
-    fn total_fil_circ_supply(&self) -> Result<TokenAmount> {
-        Ok(self.1.circ_supply.clone())
-    }
-}
-impl<M, C, K> FilecoinKernel for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: FilecoinKernel<CallManager = C>,
-{
+impl FilecoinKernel for TestKernel {
     fn compute_unsealed_sector_cid(
         &self,
         proof_type: RegisteredSealProof,
@@ -411,177 +301,10 @@ where
         let _ = self.0.charge_gas(&charge.name, charge.total())?;
         Ok(true)
     }
-}
 
-impl<M, C, K> CryptoOps for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    // forwarded
-    fn hash(&self, code: u64, data: &[u8]) -> Result<MultihashGeneric<64>> {
-        self.0.hash(code, data)
-    }
-
-    // forwarded
-    fn verify_signature(
-        &self,
-        sig_type: SignatureType,
-        signature: &[u8],
-        signer: &Address,
-        plaintext: &[u8],
-    ) -> Result<bool> {
-        self.0
-            .verify_signature(sig_type, signature, signer, plaintext)
-    }
-
-    // forwarded
-    fn recover_secp_public_key(
-        &self,
-        hash: &[u8; SECP_SIG_MESSAGE_HASH_SIZE],
-        signature: &[u8; SECP_SIG_LEN],
-    ) -> Result<[u8; SECP_PUB_LEN]> {
-        self.0.recover_secp_public_key(hash, signature)
-    }
-}
-
-impl<M, C, K> DebugOps for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    fn log(&self, msg: String) {
-        self.0.log(msg)
-    }
-
-    fn debug_enabled(&self) -> bool {
-        self.0.debug_enabled()
-    }
-
-    fn store_artifact(&self, name: &str, data: &[u8]) -> Result<()> {
-        self.0.store_artifact(name, data)
-    }
-}
-
-impl<M, C, K> GasOps for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    fn gas_used(&self) -> Gas {
-        self.0.gas_used()
-    }
-
-    fn charge_gas(&self, name: &str, compute: Gas) -> Result<GasTimer> {
-        self.0.charge_gas(name, compute)
-    }
-
-    fn price_list(&self) -> &PriceList {
-        self.0.price_list()
-    }
-
-    fn gas_available(&self) -> Gas {
-        self.0.gas_available()
-    }
-}
-
-impl<M, C, K> MessageOps for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    fn msg_context(&self) -> Result<fvm_shared::sys::out::vm::MessageContext> {
-        self.0.msg_context()
-    }
-}
-
-impl<M, C, K> NetworkOps for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    fn network_context(&self) -> Result<fvm_shared::sys::out::network::NetworkContext> {
-        self.0.network_context()
-    }
-
-    fn tipset_cid(&self, epoch: ChainEpoch) -> Result<Cid> {
-        self.0.tipset_cid(epoch)
-    }
-}
-
-impl<M, C, K> RandomnessOps for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    fn get_randomness_from_tickets(
-        &self,
-        rand_epoch: ChainEpoch,
-    ) -> Result<[u8; RANDOMNESS_LENGTH]> {
-        self.0.get_randomness_from_tickets(rand_epoch)
-    }
-
-    fn get_randomness_from_beacon(
-        &self,
-        rand_epoch: ChainEpoch,
-    ) -> Result<[u8; RANDOMNESS_LENGTH]> {
-        self.0.get_randomness_from_beacon(rand_epoch)
-    }
-}
-
-impl<M, C, K> SelfOps for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    fn root(&mut self) -> Result<Cid> {
-        self.0.root()
-    }
-
-    fn set_root(&mut self, root: Cid) -> Result<()> {
-        self.0.set_root(root)
-    }
-
-    fn current_balance(&self) -> Result<TokenAmount> {
-        self.0.current_balance()
-    }
-
-    fn self_destruct(&mut self, burn_unspent: bool) -> Result<()> {
-        self.0.self_destruct(burn_unspent)
-    }
-}
-
-impl<K> LimiterOps for TestKernel<K>
-where
-    K: LimiterOps,
-{
-    type Limiter = K::Limiter;
-
-    fn limiter_mut(&mut self) -> &mut Self::Limiter {
-        self.0.limiter_mut()
-    }
-}
-
-impl<M, C, K> EventOps for TestKernel<K>
-where
-    M: Machine,
-    C: CallManager<Machine = TestMachine<M>>,
-    K: Kernel<CallManager = C>,
-{
-    fn emit_event(
-        &mut self,
-        event_headers: &[EventEntry],
-        key_evt: &[u8],
-        val_evt: &[u8],
-    ) -> Result<()> {
-        self.0.emit_event(event_headers, key_evt, val_evt)
+    // Not forwarded. Circulating supply is taken from the TestData.
+    fn total_fil_circ_supply(&self) -> Result<TokenAmount> {
+        Ok(self.1.circ_supply.clone())
     }
 }
 

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -9,7 +9,7 @@ use fvm::externs::Externs;
 use fvm::kernel::filecoin::DefaultFilecoinKernel;
 use fvm::machine::{DefaultMachine, Machine, MachineContext, NetworkConfig};
 use fvm::state_tree::{ActorState, StateTree};
-use fvm::{init_actor, system_actor, DefaultKernel};
+use fvm::{init_actor, system_actor};
 use fvm_ipld_blockstore::{Block, Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::{ser, CborStore};
 use fvm_shared::address::{Address, Protocol};
@@ -36,7 +36,7 @@ lazy_static! {
 pub trait Store: Blockstore + Sized + 'static {}
 
 pub type IntegrationExecutor<B, E> =
-    DefaultExecutor<DefaultFilecoinKernel<DefaultKernel<DefaultCallManager<DefaultMachine<B, E>>>>>;
+    DefaultExecutor<DefaultFilecoinKernel<DefaultCallManager<DefaultMachine<B, E>>>>;
 
 pub type Account = (ActorID, Address);
 
@@ -298,7 +298,7 @@ where
         let machine = DefaultMachine::new(&mc, blockstore, externs)?;
 
         let executor = DefaultExecutor::<
-            DefaultFilecoinKernel<DefaultKernel<DefaultCallManager<DefaultMachine<B, E>>>>,
+            DefaultFilecoinKernel<DefaultCallManager<DefaultMachine<B, E>>>,
         >::new(engine, machine)?;
 
         self.executor = Some(executor);


### PR DESCRIPTION
This is an attempt at refactoring the kernel, implementing a bunch of things I've been thinking about for a while. I'll probably need to break it into multiple PRs and/or continue to work on it, but it's good enough right now for some basic feedback.

This PR:

1. Reworks the layering to look more like https://github.com/filecoin-project/FIPs/discussions/845.
2. Improves the ability to "delegate" the implementation.
3. Moves the circulating supply to the Filecoin kernel (could be a separate PR).
4. Makes `SyscallHandler::bind_syscalls` a _static_ method. IMO, this is "more correct" as we memoize the result of calling this method so the kernel on which we called `bind_syscalls` may not (usually, _will_ not) be the kernel on which we actually _use_ those syscalls.
5. Makes syscalls explicitly declare the "kernel ops" they need. E.g., `K: DebugOps` for the `debug` syscalls.
6. Makes the `SyscallHandler` an associated type on the `Kernel`. This makes it a bit easier to wrap/alter the kernel without touching the syscall bindings.