### PR TITLE
chore: release fvm_ipld_amt, fvm_sdk, and fvm crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
  "cid 0.10.1",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_amt 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_amt 0.6.2",
  "fvm_ipld_bitfield 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1725,12 +1725,12 @@ dependencies = [
  "byteorder",
  "castaway",
  "cid 0.10.1",
- "fvm_ipld_amt 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_amt 0.6.2",
  "fvm_ipld_bitfield 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
- "fvm_sdk 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.0.0",
  "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 3.0.4",
  "itertools 0.10.5",
@@ -1754,7 +1754,7 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
 ]
 
@@ -1791,7 +1791,7 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
 ]
 
@@ -1800,7 +1800,7 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
  "serde",
  "serde_tuple",
@@ -1811,7 +1811,7 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
 ]
 
@@ -1823,7 +1823,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
  "libipld",
  "num-derive 0.4.1",
@@ -1836,7 +1836,7 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
  "log",
  "serde",
@@ -1847,7 +1847,7 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
 ]
 
@@ -1859,7 +1859,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
  "serde",
  "serde_tuple",
@@ -1870,7 +1870,7 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
  "minicov",
 ]
@@ -1879,7 +1879,7 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
 ]
 
@@ -1887,7 +1887,7 @@ dependencies = [
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
 ]
 
@@ -1897,7 +1897,7 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
 ]
 
@@ -1907,7 +1907,7 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
 ]
 
@@ -1915,7 +1915,7 @@ dependencies = [
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
 ]
 
@@ -1925,7 +1925,7 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
  "minicov",
  "multihash 0.18.1",
@@ -1937,7 +1937,7 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
  "serde",
  "serde_tuple",
@@ -1949,7 +1949,7 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
+ "fvm_sdk 4.1.0",
  "fvm_shared 4.0.0",
  "serde",
  "serde_tuple",
@@ -2106,7 +2106,7 @@ dependencies = [
  "frc42_hasher",
  "frc42_macros",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.0.0",
  "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
@@ -2117,7 +2117,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a35e7214108f81cefc17b0466be01279f384faf913918a12dbc8528bb758a4"
 dependencies = [
- "fvm_sdk 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.0.0",
  "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
@@ -2147,7 +2147,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
- "fvm_sdk 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.0.0",
  "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 4.0.0",
  "num-traits",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2290,7 +2290,7 @@ dependencies = [
  "filecoin-proofs-api",
  "fvm",
  "fvm-wasm-instrument",
- "fvm_ipld_amt 0.6.2",
+ "fvm_ipld_amt 0.7.0",
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
@@ -2354,7 +2354,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.0.0",
  "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits",
  "serde",
@@ -2445,6 +2445,22 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fea333475130094f27ce67809aae3f69eb5247541d835950b7c5da733dbbb34"
+dependencies = [
+ "anyhow",
+ "cid 0.10.1",
+ "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.11.0",
+ "once_cell",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_ipld_amt"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -2455,22 +2471,6 @@ dependencies = [
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "fvm_ipld_amt"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fea333475130094f27ce67809aae3f69eb5247541d835950b7c5da733dbbb34"
-dependencies = [
- "anyhow",
- "cid 0.10.1",
- "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.11.0",
- "once_cell",
  "serde",
  "thiserror",
 ]
@@ -2672,11 +2672,13 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258cfc9a2e5dcb28ffcadd4abed504893996d31238488a07ef7d2a6a6e80e1ec"
 dependencies = [
  "byteorder",
  "cid 0.10.1",
- "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.0.0",
+ "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "num-traits",
@@ -2685,14 +2687,12 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258cfc9a2e5dcb28ffcadd4abed504893996d31238488a07ef7d2a6a6e80e1ec"
+version = "4.1.0"
 dependencies = [
  "byteorder",
  "cid 0.10.1",
- "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.4.0",
+ "fvm_shared 4.0.0",
  "lazy_static",
  "log",
  "num-traits",

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.1.0 (2023-12-05)
+
+- Add initial support for pluggable syscalls
+
 ## 4.0.0 (2023-10-31)
 
 Final release, no changes.

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "4.0.0"
+version = "4.1.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -19,7 +19,7 @@ cid = { workspace = true, features = ["serde-codec"] }
 multihash = { workspace = true, features = ["sha2", "sha3", "ripemd"] }
 fvm_shared = { version = "4.0.0", path = "../shared", features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.9.0", path = "../ipld/hamt" }
-fvm_ipld_amt = { version = "0.6.2", path = "../ipld/amt" }
+fvm_ipld_amt = { version = "0.7.0", path = "../ipld/amt" }
 fvm_ipld_blockstore = { version = "0.2.0", path = "../ipld/blockstore" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../ipld/encoding" }
 serde = { version = "1.0", features = ["derive"] }

--- a/ipld/amt/CHANGELOG.md
+++ b/ipld/amt/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 0.7.0 [2023-12-05)
+
+Implement a Rust Iterator for the AMT and re-implement the for_each implementation in terms of this new iterator.
+
 ## 0.6.2 [2023-09-28)
 
 Fix a bug in `for_each_ranged` if the start offset exceeds the max possible value in the AMT (due to the AMT's height).

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_amt"
 description = "Sharded IPLD Array implementation."
-version = "0.6.2"
+version = "0.7.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 4.1.0 (2023-12-05)
+
+- The `install_actor` syscall is no longer behind the `m2-native` feature flag
+
 ## 4.0.0 (2023-10-31)
 
 Final release, no changes.

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "4.0.0"
+version = "4.1.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -39,7 +39,7 @@ tar = { version = "0.4.38", default-features = false }
 zstd = { version = "0.12.3", default-features = false }
 
 [dependencies.fvm]
-version = "4.0.0"
+version = "4.1.0"
 path = "../../fvm"
 default-features = false
 features = ["testing"]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Protocol Labs", "Filecoin Core Devs", "Polyphene"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm = { version = "4.0.0", path = "../../fvm", default-features = false, features = ["testing", "upgrade-actor"] }
+fvm = { version = "4.1.0", path = "../../fvm", default-features = false, features = ["testing", "upgrade-actor"] }
 fvm_shared = { version = "4.0.0", path = "../../shared", features = ["testing"] }
 fvm_ipld_car = { version = "0.7.1", path = "../../ipld/car" }
 fvm_ipld_blockstore = { version = "0.2.0", path = "../../ipld/blockstore" }

--- a/testing/test_actors/actors/fil-address-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-address-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 
 [lib]

--- a/testing/test_actors/actors/fil-create-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-create-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 actors_v12_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }
 

--- a/testing/test_actors/actors/fil-events-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-events-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 serde = {version = "1.0.164", features = ["derive"] }
 serde_tuple = "0.5.0"

--- a/testing/test_actors/actors/fil-exit-data-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-exit-data-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 

--- a/testing/test_actors/actors/fil-gas-calibration-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-gas-calibration-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 fvm_gas_calibration_shared = { path = "../../../calibration/shared" }

--- a/testing/test_actors/actors/fil-gaslimit-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-gaslimit-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 serde = {version = "1.0.164", features = ["derive"] }
 serde_tuple = "0.5.0"

--- a/testing/test_actors/actors/fil-hello-world-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-hello-world-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 
 [lib]

--- a/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 fvm_ipld_blockstore = { version = "0.2.0", path = "../../../../ipld/blockstore" }

--- a/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 
 [target.'cfg(coverage)'.dependencies]

--- a/testing/test_actors/actors/fil-malformed-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-malformed-syscall-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-oom-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-oom-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 
 [lib]

--- a/testing/test_actors/actors/fil-readonly-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-readonly-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 cid = { workspace = true }

--- a/testing/test_actors/actors/fil-sself-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-sself-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 cid = { workspace = true }

--- a/testing/test_actors/actors/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-stack-overflow-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 
 [lib]

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
-fvm_sdk = { version = "4.0.0", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0", path = "../../../../shared" }
 minicov = {version = "0.3", optional = true}
 actors_v12_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }

--- a/testing/test_actors/actors/fil-upgrade-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-upgrade-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0-alpha.4", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0-alpha.4", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 cid = { workspace = true }

--- a/testing/test_actors/actors/fil-upgrade-receive-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-upgrade-receive-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "4.0.0-alpha.4", path = "../../../../sdk" }
+fvm_sdk = { version = "4.1.0", path = "../../../../sdk" }
 fvm_shared = { version = "4.0.0-alpha.4", path = "../../../../shared" }
 fvm_ipld_encoding = { version = "0.4.0", path = "../../../../ipld/encoding" }
 cid = { workspace = true }


### PR DESCRIPTION
This release will allow us to start running nv22 code on the FVM behind the `nv22-dev` feature flag.

I'm not sure how much of #1922 and #1861 constitute breaking changes. I'm choosing to release minor bumps of all 3 crates, but feel free to suggest otherwise.