### PR TITLE
fix: make delegation simpler by introducing a prelude module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,7 +2366,6 @@ dependencies = [
 name = "fvm_conformance_tests"
 version = "0.1.0"
 dependencies = [
- "ambassador",
  "anyhow",
  "async-std",
  "base64 0.21.4",

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -72,7 +72,7 @@ where
             };
 
         struct MachineExecRet {
-            result: crate::kernel::error::Result<InvocationResult>,
+            result: crate::kernel::Result<InvocationResult>,
             gas_used: u64,
             backtrace: Backtrace,
             exec_trace: ExecutionTrace,

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -10,12 +10,10 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::IPLD_RAW;
 use fvm_shared::address::Payload;
 use fvm_shared::crypto::signature;
-use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::event::{ActorEvent, Entry, Flags};
 use fvm_shared::sys::out::vm::ContextFlags;
 use fvm_shared::upgrade::UpgradeInfo;
-use fvm_shared::ActorID;
 use multihash::MultihashDigest;
 
 use super::blocks::{Block, BlockRegistry};
@@ -606,7 +604,7 @@ where
         )
     }
 
-    fn hash(&self, code: u64, data: &[u8]) -> Result<MultihashGeneric<64>> {
+    fn hash(&self, code: u64, data: &[u8]) -> Result<Multihash> {
         let hasher = SupportedHashes::try_from(code).map_err(|e| {
             if let multihash::Error::UnsupportedCode(code) = e {
                 syscall_error!(IllegalArgument; "unsupported hash code {}", code)

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -360,4 +360,4 @@ pub mod prelude {
     };
 }
 
-pub use prelude::*;
+use prelude::*;

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -37,7 +37,6 @@ ittapi-rs = { version = "0.3.0", optional = true }
 libipld-core = { version = "0.16.0", features = ["serde-codec"] }
 tar = { version = "0.4.38", default-features = false }
 zstd = { version = "0.12.3", default-features = false }
-ambassador = "0.3.5"
 
 [dependencies.fvm]
 version = "4.0.0"

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -3,41 +3,27 @@
 use std::convert::TryFrom;
 use std::sync::{Arc, Mutex};
 
-use ambassador::Delegate;
 use anyhow::anyhow;
-use cid::Cid;
 use fvm::kernel::filecoin::{DefaultFilecoinKernel, FilecoinKernel};
 use fvm::syscalls::InvocationData;
-use multihash::MultihashGeneric;
 
 use fvm::call_manager::{CallManager, DefaultCallManager};
-use fvm::gas::{price_list_by_network_version, Gas, GasTimer, PriceList};
+use fvm::gas::price_list_by_network_version;
 use fvm::machine::limiter::MemoryLimiter;
 use fvm::machine::{DefaultMachine, Machine, MachineContext, Manifest, NetworkConfig};
 use fvm::state_tree::StateTree;
 use fvm_ipld_blockstore::MemoryBlockstore;
-use fvm_shared::address::Address;
-use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
-use fvm_shared::crypto::signature::{
-    SignatureType, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
-};
-use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PieceInfo;
-use fvm_shared::randomness::RANDOMNESS_LENGTH;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, ReplicaUpdateInfo, SealVerifyInfo,
 };
-use fvm_shared::sys::out::network::NetworkContext;
-use fvm_shared::sys::out::vm::MessageContext;
-use fvm_shared::sys::SendFlags;
-use fvm_shared::version::NetworkVersion;
-use fvm_shared::{ActorID, MethodNum};
 use wasmtime::Linker;
 
 // We have glob imports here because delegation doesn't work well without it.
-use fvm::*;
-use kernel::*;
+use fvm::kernel::prelude::*;
+use fvm::kernel::Result;
+use fvm::DefaultKernel;
 
 use crate::externs::TestExterns;
 use crate::vector::{MessageVector, Variant};


### PR DESCRIPTION
Users can now glob-import the kernel's "prelude" module instead of, e.g., glob-importing the entire `kernel` and the top-level `fvm` crate. Ideally ambassador would handle importing all of its internal types, but it doesn't.