### PR TITLE
refactor: make partial kernels possible

### DIFF
--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -65,6 +65,7 @@ where
     C: CallManager,
 {
     type CallManager = C;
+    type Limiter = <<C as CallManager>::Machine as Machine>::Limiter;
 
     fn into_inner(self) -> (Self::CallManager, BlockRegistry)
     where
@@ -263,6 +264,10 @@ where
             }
             Err(err) => Err(err),
         }
+    }
+
+    fn limiter_mut(&mut self) -> &mut Self::Limiter {
+        self.call_manager.limiter_mut()
     }
 }
 
@@ -946,17 +951,6 @@ where
             )
         }
         Ok(())
-    }
-}
-
-impl<C> LimiterOps for DefaultKernel<C>
-where
-    C: CallManager,
-{
-    type Limiter = <<C as CallManager>::Machine as Machine>::Limiter;
-
-    fn limiter_mut(&mut self) -> &mut Self::Limiter {
-        self.call_manager.limiter_mut()
     }
 }
 

--- a/fvm/src/kernel/filecoin.rs
+++ b/fvm/src/kernel/filecoin.rs
@@ -98,7 +98,6 @@ pub trait FilecoinKernel: Kernel {
 #[delegate(NetworkOps)]
 #[delegate(RandomnessOps)]
 #[delegate(SelfOps)]
-#[delegate(LimiterOps)]
 pub struct DefaultFilecoinKernel<K>(pub K)
 where
     K: Kernel;
@@ -251,6 +250,7 @@ where
     C: CallManager,
 {
     type CallManager = C;
+    type Limiter = <DefaultKernel<C> as Kernel>::Limiter;
 
     fn into_inner(self) -> (Self::CallManager, BlockRegistry)
     where
@@ -302,6 +302,10 @@ where
             value_received,
             read_only,
         ))
+    }
+
+    fn limiter_mut(&mut self) -> &mut Self::Limiter {
+        self.0.call_manager.limiter_mut()
     }
 }
 

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -33,23 +33,11 @@ pub struct CallResult {
 ///
 /// Actors may call into the kernel via the syscalls defined in the [`syscalls`][crate::syscalls]
 /// module.
-pub trait Kernel:
-    SyscallHandler<Self>
-    + ActorOps
-    + IpldBlockOps
-    + CryptoOps
-    + DebugOps
-    + EventOps
-    + GasOps
-    + MessageOps
-    + NetworkOps
-    + RandomnessOps
-    + SelfOps
-    + LimiterOps
-    + 'static
-{
+pub trait Kernel: GasOps + SyscallHandler<Self> + 'static {
     /// The [`Kernel`]'s [`CallManager`] is
     type CallManager: CallManager;
+    /// The [`Kernel`]'s memory allocation tracker.
+    type Limiter: MemoryLimiter;
 
     /// Consume the [`Kernel`] and return the underlying [`CallManager`] and [`BlockRegistry`].
     fn into_inner(self) -> (Self::CallManager, BlockRegistry)
@@ -101,6 +89,9 @@ pub trait Kernel:
         new_code_cid: Cid,
         params_id: BlockId,
     ) -> Result<CallResult>;
+
+    /// Give access to the limiter of the underlying call manager.
+    fn limiter_mut(&mut self) -> &mut Self::Limiter;
 }
 
 pub trait SyscallHandler<K: Kernel>: Sized {
@@ -293,18 +284,6 @@ pub trait DebugOps {
     fn store_artifact(&self, name: &str, data: &[u8]) -> Result<()>;
 }
 
-/// Track and limit memory expansion.
-///
-/// This interface is not one of the operations the kernel provides to actors.
-/// It's only part of the kernel out of necessity to pass it through to the
-/// call manager which tracks the limits across the whole execution stack.
-#[delegatable_trait]
-pub trait LimiterOps {
-    type Limiter: MemoryLimiter;
-    /// Give access to the limiter of the underlying call manager.
-    fn limiter_mut(&mut self) -> &mut Self::Limiter;
-}
-
 /// Eventing APIs.
 #[delegatable_trait]
 pub trait EventOps {
@@ -322,17 +301,16 @@ pub trait EventOps {
 #[doc(hidden)]
 pub use {
     ambassador_impl_CryptoOps, ambassador_impl_DebugOps, ambassador_impl_EventOps,
-    ambassador_impl_GasOps, ambassador_impl_IpldBlockOps, ambassador_impl_LimiterOps,
-    ambassador_impl_MessageOps, ambassador_impl_NetworkOps, ambassador_impl_RandomnessOps,
-    ambassador_impl_SelfOps,
+    ambassador_impl_GasOps, ambassador_impl_IpldBlockOps, ambassador_impl_MessageOps,
+    ambassador_impl_NetworkOps, ambassador_impl_RandomnessOps, ambassador_impl_SelfOps,
 };
 
 /// Import this module (with a glob) if you're implementing a kernel, _especially_ if you want to
 /// use ambassador to delegate the implementation.
 pub mod prelude {
     pub use super::{
-        ActorOps, CryptoOps, DebugOps, EventOps, GasOps, IpldBlockOps, LimiterOps, MessageOps,
-        NetworkOps, RandomnessOps, SelfOps,
+        ActorOps, CryptoOps, DebugOps, EventOps, GasOps, IpldBlockOps, MessageOps, NetworkOps,
+        RandomnessOps, SelfOps,
     };
     pub use super::{Block, BlockId, BlockRegistry, BlockStat, CallResult, Kernel, SyscallHandler};
     pub use crate::gas::{Gas, GasTimer, PriceList};
@@ -355,8 +333,8 @@ pub mod prelude {
     pub use {
         ambassador_impl_ActorOps, ambassador_impl_CryptoOps, ambassador_impl_DebugOps,
         ambassador_impl_EventOps, ambassador_impl_GasOps, ambassador_impl_IpldBlockOps,
-        ambassador_impl_LimiterOps, ambassador_impl_MessageOps, ambassador_impl_NetworkOps,
-        ambassador_impl_RandomnessOps, ambassador_impl_SelfOps,
+        ambassador_impl_MessageOps, ambassador_impl_NetworkOps, ambassador_impl_RandomnessOps,
+        ambassador_impl_SelfOps,
     };
 }
 

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -6,11 +6,11 @@ use fvm_shared::{sys, ActorID};
 use super::bind::ControlFlow;
 use super::error::Abort;
 use super::Context;
-use crate::kernel::{CallResult, ClassifyResult, Result};
+use crate::kernel::{ActorOps, CallResult, ClassifyResult, Result};
 use crate::{syscall_error, Kernel};
 
 pub fn resolve_address(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ActorOps>,
     addr_off: u32, // Address
     addr_len: u32,
 ) -> Result<u64> {
@@ -20,7 +20,7 @@ pub fn resolve_address(
 }
 
 pub fn lookup_delegated_address(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ActorOps>,
     actor_id: ActorID,
     obuf_off: u32,
     obuf_len: u32,
@@ -41,7 +41,7 @@ pub fn lookup_delegated_address(
 }
 
 pub fn get_actor_code_cid(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ActorOps>,
     actor_id: u64,
     obuf_off: u32, // Cid
     obuf_len: u32,
@@ -59,7 +59,7 @@ pub fn get_actor_code_cid(
 /// The output buffer must be at least 21 bytes long, which is the length of a class 2 address
 /// (protocol-generated actor address).
 pub fn next_actor_address(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ActorOps>,
     obuf_off: u32, // Address (out)
     obuf_len: u32,
 ) -> Result<u32> {
@@ -93,7 +93,7 @@ pub fn next_actor_address(
 }
 
 pub fn create_actor(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ActorOps>,
     actor_id: u64, // ID
     typ_off: u32,  // Cid
     delegated_addr_off: u32,
@@ -143,7 +143,7 @@ pub fn upgrade_actor<K: Kernel>(
 }
 
 pub fn get_builtin_actor_type(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ActorOps>,
     code_cid_off: u32, // Cid
 ) -> Result<i32> {
     let cid = context.memory.read_cid(code_cid_off)?;
@@ -151,7 +151,7 @@ pub fn get_builtin_actor_type(
 }
 
 pub fn get_code_cid_for_type(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ActorOps>,
     typ: i32,
     obuf_off: u32, // Cid
     obuf_len: u32,
@@ -163,14 +163,14 @@ pub fn get_code_cid_for_type(
 }
 
 pub fn install_actor(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl ActorOps>,
     typ_off: u32, // Cid
 ) -> Result<()> {
     let typ = context.memory.read_cid(typ_off)?;
     context.kernel.install_actor(typ)
 }
 
-pub fn balance_of(context: Context<'_, impl Kernel>, actor_id: u64) -> Result<sys::TokenAmount> {
+pub fn balance_of(context: Context<'_, impl ActorOps>, actor_id: u64) -> Result<sys::TokenAmount> {
     let balance = context.kernel.balance_of(actor_id)?;
     balance
         .try_into()

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -9,8 +9,7 @@ use fvm_shared::crypto::signature::{
 use num_traits::FromPrimitive;
 
 use super::Context;
-use crate::kernel::{ClassifyResult, Result};
-use crate::Kernel;
+use crate::kernel::{ClassifyResult, CryptoOps, Result};
 
 /// Verifies that a signature is valid for an address and plaintext.
 ///
@@ -19,7 +18,7 @@ use crate::Kernel;
 ///  - -1: verification failed.
 #[allow(clippy::too_many_arguments)]
 pub fn verify_signature(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl CryptoOps>,
     sig_type: u32,
     sig_off: u32,
     sig_len: u32,
@@ -42,7 +41,7 @@ pub fn verify_signature(
 }
 
 pub fn recover_secp_public_key(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl CryptoOps>,
     hash_off: u32,
     sig_off: u32,
 ) -> Result<[u8; SECP_PUB_LEN]> {
@@ -66,7 +65,7 @@ pub fn recover_secp_public_key(
 /// Hashes input data using the specified hash function, writing the digest into the provided
 /// buffer.
 pub fn hash(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl CryptoOps>,
     hash_code: u64,
     data_off: u32, // input
     data_len: u32,

--- a/fvm/src/syscalls/debug.rs
+++ b/fvm/src/syscalls/debug.rs
@@ -1,10 +1,9 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use crate::kernel::{ClassifyResult, Result};
+use crate::kernel::{ClassifyResult, DebugOps, Result};
 use crate::syscalls::context::Context;
-use crate::Kernel;
 
-pub fn log(context: Context<'_, impl Kernel>, msg_off: u32, msg_len: u32) -> Result<()> {
+pub fn log(context: Context<'_, impl DebugOps>, msg_off: u32, msg_len: u32) -> Result<()> {
     // No-op if disabled.
     if !context.kernel.debug_enabled() {
         return Ok(());
@@ -16,7 +15,7 @@ pub fn log(context: Context<'_, impl Kernel>, msg_off: u32, msg_len: u32) -> Res
     Ok(())
 }
 
-pub fn enabled(context: Context<'_, impl Kernel>) -> Result<i32> {
+pub fn enabled(context: Context<'_, impl DebugOps>) -> Result<i32> {
     Ok(if context.kernel.debug_enabled() {
         0
     } else {
@@ -25,7 +24,7 @@ pub fn enabled(context: Context<'_, impl Kernel>) -> Result<i32> {
 }
 
 pub fn store_artifact(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl DebugOps>,
     name_off: u32,
     name_len: u32,
     data_off: u32,

--- a/fvm/src/syscalls/event.rs
+++ b/fvm/src/syscalls/event.rs
@@ -4,8 +4,7 @@
 use anyhow::Context as _;
 
 use super::Context;
-use crate::kernel::{ClassifyResult, Result};
-use crate::Kernel;
+use crate::kernel::{ClassifyResult, EventOps, Result};
 
 /// Emits an actor event. The event is split into three raw byte buffers that have
 /// been written to Wasm memory. This is done so that the FVM can accurately charge
@@ -25,7 +24,7 @@ use crate::Kernel;
 /// Calling this syscall may immediately halt execution with an out of gas error,
 /// if such condition arises.
 pub fn emit_event(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl EventOps>,
     event_off: u32,
     event_len: u32,
     key_off: u32,

--- a/fvm/src/syscalls/gas.rs
+++ b/fvm/src/syscalls/gas.rs
@@ -4,11 +4,10 @@ use std::str;
 
 use super::Context;
 use crate::gas::Gas;
-use crate::kernel::{ClassifyResult, Result};
-use crate::Kernel;
+use crate::kernel::{ClassifyResult, GasOps, Result};
 
 pub fn charge_gas(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl GasOps>,
     name_off: u32,
     name_len: u32,
     compute: u64,
@@ -22,6 +21,6 @@ pub fn charge_gas(
         .map(|_| ())
 }
 
-pub fn available(context: Context<'_, impl Kernel>) -> Result<u64> {
+pub fn available(context: Context<'_, impl GasOps>) -> Result<u64> {
     Ok(context.kernel.gas_available().round_down())
 }

--- a/fvm/src/syscalls/ipld.rs
+++ b/fvm/src/syscalls/ipld.rs
@@ -3,10 +3,12 @@
 use fvm_shared::sys;
 
 use super::Context;
-use crate::kernel::Result;
-use crate::Kernel;
+use crate::kernel::{IpldBlockOps, Result};
 
-pub fn block_open(context: Context<'_, impl Kernel>, cid: u32) -> Result<sys::out::ipld::IpldOpen> {
+pub fn block_open(
+    context: Context<'_, impl IpldBlockOps>,
+    cid: u32,
+) -> Result<sys::out::ipld::IpldOpen> {
     let cid = context.memory.read_cid(cid)?;
     let (id, stat) = context.kernel.block_open(&cid)?;
     Ok(sys::out::ipld::IpldOpen {
@@ -17,7 +19,7 @@ pub fn block_open(context: Context<'_, impl Kernel>, cid: u32) -> Result<sys::ou
 }
 
 pub fn block_create(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl IpldBlockOps>,
     codec: u64,
     data_off: u32,
     data_len: u32,
@@ -27,7 +29,7 @@ pub fn block_create(
 }
 
 pub fn block_link(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl IpldBlockOps>,
     id: u32,
     hash_fun: u64,
     hash_len: u32,
@@ -45,7 +47,7 @@ pub fn block_link(
 }
 
 pub fn block_read(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl IpldBlockOps>,
     id: u32,
     offset: u32,
     obuf_off: u32,
@@ -55,7 +57,10 @@ pub fn block_read(
     context.kernel.block_read(id, offset, data)
 }
 
-pub fn block_stat(context: Context<'_, impl Kernel>, id: u32) -> Result<sys::out::ipld::IpldStat> {
+pub fn block_stat(
+    context: Context<'_, impl IpldBlockOps>,
+    id: u32,
+) -> Result<sys::out::ipld::IpldStat> {
     context
         .kernel
         .block_stat(id)

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -7,7 +7,10 @@ use wasmtime::{AsContextMut, ExternType, Global, Linker, Memory, Module, Val};
 use crate::call_manager::{backtrace, CallManager};
 use crate::gas::{Gas, GasInstant, GasTimer};
 use crate::kernel::filecoin::DefaultFilecoinKernel;
-use crate::kernel::{ExecutionError, SyscallHandler};
+use crate::kernel::{
+    ActorOps, CryptoOps, DebugOps, EventOps, ExecutionError, GasOps, IpldBlockOps, MessageOps,
+    NetworkOps, RandomnessOps, SelfOps, SyscallHandler,
+};
 
 use crate::machine::limiter::MemoryLimiter;
 use crate::{DefaultKernel, Kernel};
@@ -238,7 +241,17 @@ use self::bind::BindSyscall;
 
 impl<K> SyscallHandler<K> for DefaultKernel<K::CallManager>
 where
-    K: Kernel,
+    K: Kernel
+        + ActorOps
+        + IpldBlockOps
+        + CryptoOps
+        + DebugOps
+        + EventOps
+        + GasOps
+        + MessageOps
+        + NetworkOps
+        + RandomnessOps
+        + SelfOps,
 {
     fn bind_syscalls(
         &self,

--- a/fvm/src/syscalls/network.rs
+++ b/fvm/src/syscalls/network.rs
@@ -3,14 +3,14 @@
 use fvm_shared::sys::out::network::NetworkContext;
 
 use super::Context;
-use crate::kernel::{Kernel, Result};
+use crate::kernel::{NetworkOps, Result};
 
-pub fn context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<NetworkContext> {
+pub fn context(context: Context<'_, impl NetworkOps>) -> crate::kernel::Result<NetworkContext> {
     context.kernel.network_context()
 }
 
 pub fn tipset_cid(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl NetworkOps>,
     epoch: i64,
     obuf_off: u32,
     obuf_len: u32,

--- a/fvm/src/syscalls/rand.rs
+++ b/fvm/src/syscalls/rand.rs
@@ -3,15 +3,14 @@
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
 
 use super::Context;
-use crate::kernel::Result;
-use crate::Kernel;
+use crate::kernel::{RandomnessOps, Result};
 
 /// Gets 32 bytes of randomness from the ticket chain.
 /// The supplied output buffer must have at least 32 bytes of capacity.
 /// If this syscall succeeds, exactly 32 bytes will be written starting at the
 /// supplied offset.
 pub fn get_chain_randomness(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl RandomnessOps>,
     round: i64, // ChainEpoch
 ) -> Result<[u8; RANDOMNESS_LENGTH]> {
     context.kernel.get_randomness_from_tickets(round)
@@ -22,7 +21,7 @@ pub fn get_chain_randomness(
 /// If this syscall succeeds, exactly 32 bytes will be written starting at the
 /// supplied offset.
 pub fn get_beacon_randomness(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl RandomnessOps>,
     round: i64, // ChainEpoch
 ) -> Result<[u8; RANDOMNESS_LENGTH]> {
     context.kernel.get_randomness_from_beacon(round)

--- a/fvm/src/syscalls/sself.rs
+++ b/fvm/src/syscalls/sself.rs
@@ -4,14 +4,14 @@ use anyhow::Context as _;
 use fvm_shared::sys;
 
 use super::Context;
-use crate::kernel::{ClassifyResult, Kernel, Result};
+use crate::kernel::{ClassifyResult, Result, SelfOps};
 
 /// Returns the root CID of the actor's state by writing it in the specified buffer.
 ///
 /// The returned u32 represents the _actual_ length of the CID. If the supplied
 /// buffer is smaller, no value will have been written. The caller must retry
 /// with a larger buffer.
-pub fn root(context: Context<'_, impl Kernel>, obuf_off: u32, obuf_len: u32) -> Result<u32> {
+pub fn root(context: Context<'_, impl SelfOps>, obuf_off: u32, obuf_len: u32) -> Result<u32> {
     context.memory.check_bounds(obuf_off, obuf_len)?;
 
     let root = context.kernel.root()?;
@@ -19,13 +19,13 @@ pub fn root(context: Context<'_, impl Kernel>, obuf_off: u32, obuf_len: u32) -> 
     context.memory.write_cid(&root, obuf_off, obuf_len)
 }
 
-pub fn set_root(context: Context<'_, impl Kernel>, cid_off: u32) -> Result<()> {
+pub fn set_root(context: Context<'_, impl SelfOps>, cid_off: u32) -> Result<()> {
     let cid = context.memory.read_cid(cid_off)?;
     context.kernel.set_root(cid)?;
     Ok(())
 }
 
-pub fn current_balance(context: Context<'_, impl Kernel>) -> Result<sys::TokenAmount> {
+pub fn current_balance(context: Context<'_, impl SelfOps>) -> Result<sys::TokenAmount> {
     let balance = context.kernel.current_balance()?;
     balance
         .try_into()
@@ -33,7 +33,7 @@ pub fn current_balance(context: Context<'_, impl Kernel>) -> Result<sys::TokenAm
         .or_fatal()
 }
 
-pub fn self_destruct(context: Context<'_, impl Kernel>, burn_unspent: u32) -> Result<()> {
+pub fn self_destruct(context: Context<'_, impl SelfOps>, burn_unspent: u32) -> Result<()> {
     context.kernel.self_destruct(burn_unspent > 0)?;
     Ok(())
 }

--- a/fvm/src/syscalls/vm.rs
+++ b/fvm/src/syscalls/vm.rs
@@ -5,7 +5,7 @@ use fvm_shared::sys::out::vm::MessageContext;
 
 use super::error::Abort;
 use super::Context;
-use crate::kernel::Kernel;
+use crate::kernel::MessageOps;
 
 /// The maximum message length included in the backtrace. Given 1024 levels, this gives us a total
 /// maximum of around 1MiB for debugging.
@@ -13,7 +13,7 @@ const MAX_MESSAGE_LEN: usize = 1024;
 
 // NOTE: this won't clobber the last syscall error because it directly returns a "trap".
 pub fn exit(
-    context: Context<'_, impl Kernel>,
+    context: Context<'_, impl Sized>, // "impl Sized" means "any struct"
     code: u32,
     blk: u32,
     message_off: u32,
@@ -52,6 +52,8 @@ pub fn exit(
     Abort::Exit(code, message, blk)
 }
 
-pub fn message_context(context: Context<'_, impl Kernel>) -> crate::kernel::Result<MessageContext> {
+pub fn message_context(
+    context: Context<'_, impl MessageOps>,
+) -> crate::kernel::Result<MessageContext> {
     context.kernel.msg_context()
 }

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -170,7 +170,6 @@ where
 #[delegate(NetworkOps)]
 #[delegate(RandomnessOps)]
 #[delegate(SelfOps)]
-#[delegate(LimiterOps)]
 pub struct TestKernel<K = DefaultFilecoinKernel<DefaultKernel<DefaultCallManager<TestMachine>>>>(
     pub K,
 );
@@ -182,6 +181,7 @@ where
     K: Kernel<CallManager = C>,
 {
     type CallManager = K::CallManager;
+    type Limiter = K::Limiter;
 
     fn into_inner(self) -> (Self::CallManager, BlockRegistry)
     where
@@ -236,6 +236,10 @@ where
 
     fn upgrade_actor<KK>(&mut self, new_code_cid: Cid, params_id: BlockId) -> Result<CallResult> {
         self.0.upgrade_actor::<Self>(new_code_cid, params_id)
+    }
+
+    fn limiter_mut(&mut self) -> &mut Self::Limiter {
+        self.0.limiter_mut()
     }
 }
 


### PR DESCRIPTION
This change has two parts:

1. Remove most (all except gas) "ops" from the base kernel trait, allowing kernels to implement only some operations.
2. Make syscalls declare the ops they actually need instead of depending on the entire kernel.

This should make it possible to implement custom kernels that expose fewer operations.

It also removes the `LimiterOps` trait as that's not really an "op".