### PR TITLE
refactor: make `bind_syscalls` an associated function

### DIFF
--- a/fvm/src/engine/mod.rs
+++ b/fvm/src/engine/mod.rs
@@ -515,13 +515,7 @@ impl Engine {
                 .insert({
                     let mut linker = Linker::new(&self.inner.engine);
                     linker.allow_shadowing(true);
-
-                    store
-                        .data()
-                        .kernel
-                        .bind_syscalls(&mut linker)
-                        .map_err(Abort::Fatal)?;
-
+                    K::bind_syscalls(&mut linker).map_err(Abort::Fatal)?;
                     Box::new(Cache { linker })
                 })
                 .downcast_mut()

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -95,7 +95,7 @@ pub trait Kernel: GasOps + SyscallHandler<Self> + 'static {
 }
 
 pub trait SyscallHandler<K: Kernel>: Sized {
-    fn bind_syscalls(&self, linker: &mut Linker<InvocationData<K>>) -> anyhow::Result<()>;
+    fn bind_syscalls(linker: &mut Linker<InvocationData<K>>) -> anyhow::Result<()>;
 }
 
 /// Network-related operations.

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -253,10 +253,7 @@ where
         + RandomnessOps
         + SelfOps,
 {
-    fn bind_syscalls(
-        &self,
-        linker: &mut wasmtime::Linker<InvocationData<K>>,
-    ) -> anyhow::Result<()> {
+    fn bind_syscalls(linker: &mut wasmtime::Linker<InvocationData<K>>) -> anyhow::Result<()> {
         linker.bind("vm", "exit", vm::exit)?;
         linker.bind("vm", "message_context", vm::message_context)?;
 
@@ -338,10 +335,9 @@ where
     C: CallManager,
 {
     fn bind_syscalls(
-        &self,
         linker: &mut Linker<InvocationData<DefaultFilecoinKernel<DefaultKernel<C>>>>,
     ) -> anyhow::Result<()> {
-        self.0.bind_syscalls(linker)?;
+        DefaultKernel::<C>::bind_syscalls(linker)?;
 
         // Bind the circulating supply call.
         linker.bind(

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -249,10 +249,7 @@ where
     C: CallManager<Machine = TestMachine<M>>,
     K: Kernel<CallManager = C>,
 {
-    fn bind_syscalls(
-        &self,
-        _linker: &mut Linker<InvocationData<TestKernel<K>>>,
-    ) -> anyhow::Result<()> {
+    fn bind_syscalls(_linker: &mut Linker<InvocationData<TestKernel<K>>>) -> anyhow::Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
The result of this function is cached and not tied to any given kernel. It shouldn't have access to a particular kernel's state because the "result" of calling this function will be used with multiple kernels (of the same type).