### PR TITLE
refactor: simplify the DefaultFilecoinKernel generics

### DIFF
--- a/fvm/src/kernel/filecoin.rs
+++ b/fvm/src/kernel/filecoin.rs
@@ -88,24 +88,22 @@ pub trait FilecoinKernel: Kernel {
 }
 
 #[derive(Delegate)]
-#[delegate(IpldBlockOps)]
-#[delegate(ActorOps)]
-#[delegate(CryptoOps)]
-#[delegate(DebugOps)]
-#[delegate(EventOps)]
-#[delegate(GasOps)]
-#[delegate(MessageOps)]
-#[delegate(NetworkOps)]
-#[delegate(RandomnessOps)]
-#[delegate(SelfOps)]
-pub struct DefaultFilecoinKernel<K>(pub K)
-where
-    K: Kernel;
+#[delegate(IpldBlockOps, where = "C: CallManager")]
+#[delegate(ActorOps, where = "C: CallManager")]
+#[delegate(CryptoOps, where = "C: CallManager")]
+#[delegate(DebugOps, where = "C: CallManager")]
+#[delegate(EventOps, where = "C: CallManager")]
+#[delegate(GasOps, where = "C: CallManager")]
+#[delegate(MessageOps, where = "C: CallManager")]
+#[delegate(NetworkOps, where = "C: CallManager")]
+#[delegate(RandomnessOps, where = "C: CallManager")]
+#[delegate(SelfOps, where = "C: CallManager")]
+pub struct DefaultFilecoinKernel<C>(pub DefaultKernel<C>);
 
-impl<C> FilecoinKernel for DefaultFilecoinKernel<DefaultKernel<C>>
+impl<C> FilecoinKernel for DefaultFilecoinKernel<C>
 where
     C: CallManager,
-    DefaultFilecoinKernel<DefaultKernel<C>>: Kernel,
+    DefaultFilecoinKernel<C>: Kernel,
 {
     fn compute_unsealed_sector_cid(
         &self,
@@ -245,7 +243,7 @@ where
     }
 }
 
-impl<C> Kernel for DefaultFilecoinKernel<DefaultKernel<C>>
+impl<C> Kernel for DefaultFilecoinKernel<C>
 where
     C: CallManager,
 {

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -54,11 +54,11 @@ mod test {
 
     use crate::call_manager::DefaultCallManager;
     use crate::engine::EnginePool;
+    use crate::executor;
     use crate::externs::{Chain, Consensus, Externs, Rand};
     use crate::kernel::filecoin::DefaultFilecoinKernel;
     use crate::machine::{DefaultMachine, Manifest, NetworkConfig};
     use crate::state_tree::StateTree;
-    use crate::{executor, DefaultKernel};
 
     struct DummyExterns;
 
@@ -125,8 +125,9 @@ mod test {
 
         let machine = DefaultMachine::new(&mc, bs, DummyExterns).unwrap();
         let engine = EnginePool::new_default((&mc.network).into()).unwrap();
-        let _ = executor::DefaultExecutor::<
-            DefaultFilecoinKernel<DefaultKernel<DefaultCallManager<_>>>,
-        >::new(engine, Box::new(machine));
+        let _ = executor::DefaultExecutor::<DefaultFilecoinKernel<DefaultCallManager<_>>>::new(
+            engine,
+            Box::new(machine),
+        );
     }
 }

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -329,13 +329,12 @@ where
     }
 }
 
-impl<C> SyscallHandler<DefaultFilecoinKernel<DefaultKernel<C>>>
-    for DefaultFilecoinKernel<DefaultKernel<C>>
+impl<C> SyscallHandler<DefaultFilecoinKernel<C>> for DefaultFilecoinKernel<C>
 where
     C: CallManager,
 {
     fn bind_syscalls(
-        linker: &mut Linker<InvocationData<DefaultFilecoinKernel<DefaultKernel<C>>>>,
+        linker: &mut Linker<InvocationData<DefaultFilecoinKernel<C>>>,
     ) -> anyhow::Result<()> {
         DefaultKernel::<C>::bind_syscalls(linker)?;
 

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -23,7 +23,6 @@ use wasmtime::Linker;
 // We have glob imports here because delegation doesn't work well without it.
 use fvm::kernel::prelude::*;
 use fvm::kernel::Result;
-use fvm::DefaultKernel;
 
 use crate::externs::TestExterns;
 use crate::vector::{MessageVector, Variant};
@@ -170,9 +169,7 @@ where
 #[delegate(NetworkOps)]
 #[delegate(RandomnessOps)]
 #[delegate(SelfOps)]
-pub struct TestKernel<K = DefaultFilecoinKernel<DefaultKernel<DefaultCallManager<TestMachine>>>>(
-    pub K,
-);
+pub struct TestKernel<K = DefaultFilecoinKernel<DefaultCallManager<TestMachine>>>(pub K);
 
 impl<M, C, K> Kernel for TestKernel<K>
 where

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -9,7 +9,7 @@ use fvm::externs::Externs;
 use fvm::kernel::filecoin::DefaultFilecoinKernel;
 use fvm::machine::{DefaultMachine, Machine, MachineContext, NetworkConfig};
 use fvm::state_tree::{ActorState, StateTree};
-use fvm::{init_actor, system_actor, DefaultKernel};
+use fvm::{init_actor, system_actor};
 use fvm_ipld_blockstore::{Block, Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::{ser, CborStore};
 use fvm_shared::address::{Address, Protocol};
@@ -36,7 +36,7 @@ lazy_static! {
 pub trait Store: Blockstore + Sized + 'static {}
 
 pub type IntegrationExecutor<B, E> =
-    DefaultExecutor<DefaultFilecoinKernel<DefaultKernel<DefaultCallManager<DefaultMachine<B, E>>>>>;
+    DefaultExecutor<DefaultFilecoinKernel<DefaultCallManager<DefaultMachine<B, E>>>>;
 
 pub type Account = (ActorID, Address);
 
@@ -298,7 +298,7 @@ where
         let machine = DefaultMachine::new(&mc, blockstore, externs)?;
 
         let executor = DefaultExecutor::<
-            DefaultFilecoinKernel<DefaultKernel<DefaultCallManager<DefaultMachine<B, E>>>>,
+            DefaultFilecoinKernel<DefaultCallManager<DefaultMachine<B, E>>>,
         >::new(engine, machine)?;
 
         self.executor = Some(executor);


### PR DESCRIPTION
It's not _actually_ generic over the inner kernel type (only works for
the `DefaultKernel`), so we might as well simplify that.

I.e., was:

    DefaultFilecoinKernel<DefaultKernel<impl CallManager>>

Now:

    DefaultFilecoinKernel<impl CallManager>