### PR TITLE
fix: bind syscalls in conformance tests

### DIFF
--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -94,7 +94,7 @@ pub trait Kernel: GasOps + SyscallHandler<Self> + 'static {
     fn limiter_mut(&mut self) -> &mut Self::Limiter;
 }
 
-pub trait SyscallHandler<K: Kernel>: Sized {
+pub trait SyscallHandler<K>: Sized {
     fn bind_syscalls(linker: &mut Linker<InvocationData<K>>) -> anyhow::Result<()>;
 }
 


### PR DESCRIPTION
Unfortunately, I had to drop the generics to prevent some circular type constraint evaluation issues. This is likely because:

1. `SyscallHandler` is generic over "self".
2. `SyscallHandler<Self>` is only implemented if `Self: FilecoinKernel`.
3. `FilecoinKernel` is only implemented if `Self: SyscallHandler<Self>`.

Rust _can_ figure all of this out if we specify concrete types, but it can't yet prove this generically.

NOTE: Ideally tests would catch this, but we don't yet have conformance tests for v4.