### PR TITLE
feat: cleanup & document the context API

### DIFF
--- a/fvm/src/syscalls/context.rs
+++ b/fvm/src/syscalls/context.rs
@@ -111,8 +111,8 @@ impl Memory {
 
     /// Write a CID to actor memory at the given offset.
     ///
-    /// If the CID's length exceeds the specified length, this function will with
-    /// [`ErrorNumber::BufferTooSmall`]. For all other failures (e.g., memory out of bounds errors),
+    /// If the CID's length exceeds the specified length, this method returns an
+    /// [`ErrorNumber::BufferTooSmall`] error. For all other failures (e.g., memory out of bounds errors),
     /// this method returns an [`ErrorNumber::IllegalArgument`] error.
     pub fn write_cid(&mut self, k: &Cid, offset: u32, len: u32) -> Result<u32> {
         let out = self.try_slice_mut(offset, len)?;

--- a/fvm/src/syscalls/filecoin.rs
+++ b/fvm/src/syscalls/filecoin.rs
@@ -1,9 +1,9 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::panic;
 
 use fvm_ipld_encoding::de::DeserializeOwned;
 use fvm_shared::error::ErrorNumber;
-// Copyright 2021-2023 Protocol Labs
-// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_shared::sector::WindowPoStVerifyInfo;
 
 use super::context::Memory;

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::{anyhow, Context as _};
 use num_traits::Zero;
-use wasmtime::{AsContextMut, ExternType, Global, Linker, Memory, Module, Val};
+use wasmtime::{AsContextMut, ExternType, Global, Linker, Module, Val};
 
 use crate::call_manager::backtrace;
 use crate::gas::{Gas, GasInstant, GasTimer};
@@ -32,7 +32,7 @@ mod send;
 mod sself;
 mod vm;
 
-pub use context::Context;
+pub use context::{Context, Memory};
 pub use error::Abort;
 
 /// Invocation data attached to a wasm "store" and available to the syscall binding.
@@ -61,7 +61,7 @@ pub struct InvocationData<K> {
     pub last_charge_time: GasInstant,
 
     /// The invocation's imported "memory".
-    pub memory: Memory,
+    pub memory: wasmtime::Memory,
 }
 
 /// Updates the global available gas in the Wasm module after a syscall, to account for any


### PR DESCRIPTION
We're now exposing this to users so we need to clean this up a bit:

1. Document it.
2. Remove `Memory::read_cbor` from the public API, it's not safe (time-wise) to call on untrusted memory.