### PR TITLE
feat: cleanup Linker API

### DIFF
--- a/fvm/src/engine/mod.rs
+++ b/fvm/src/engine/mod.rs
@@ -514,10 +514,10 @@ impl Engine {
                 .expect("invalid instance cache entry"),
             Vacant(e) => &mut *e
                 .insert({
-                    let mut linker = wasmtime::Linker::new(&self.inner.engine);
-                    linker.allow_shadowing(true);
-                    K::link_syscalls(Linker::from_wasmtime(&mut linker)).map_err(Abort::Fatal)?;
-                    Box::new(Cache { linker })
+                    let mut linker = Linker(wasmtime::Linker::new(&self.inner.engine));
+                    linker.0.allow_shadowing(true);
+                    K::link_syscalls(&mut linker).map_err(Abort::Fatal)?;
+                    Box::new(Cache { linker: linker.0 })
                 })
                 .downcast_mut()
                 .expect("invalid instance cache entry"),

--- a/fvm/src/engine/mod.rs
+++ b/fvm/src/engine/mod.rs
@@ -18,8 +18,8 @@ use fvm_wasm_instrument::gas_metering::GAS_COUNTER_NAME;
 use num_traits::Zero;
 use wasmtime::OptLevel::Speed;
 use wasmtime::{
-    Global, GlobalType, InstanceAllocationStrategy, Linker, Memory, MemoryType, Module, Mutability,
-    Val, ValType,
+    Global, GlobalType, InstanceAllocationStrategy, Memory, MemoryType, Module, Mutability, Val,
+    ValType,
 };
 
 use crate::gas::{Gas, GasTimer, WasmGasPrices};
@@ -28,6 +28,7 @@ use crate::machine::{Machine, NetworkConfig};
 use crate::syscalls::error::Abort;
 use crate::syscalls::{
     charge_for_exec, charge_for_init, record_init_time, update_gas_available, InvocationData,
+    Linker,
 };
 use crate::Kernel;
 
@@ -497,7 +498,7 @@ impl Engine {
     /// linker, syscalls, etc.
     ///
     /// This returns an `Abort` as it may need to execute initialization code, charge gas, etc.
-    pub fn instantiate<K: Kernel>(
+    pub(crate) fn instantiate<K: Kernel>(
         &self,
         store: &mut wasmtime::Store<InvocationData<K>>,
         k: &Cid,
@@ -513,9 +514,9 @@ impl Engine {
                 .expect("invalid instance cache entry"),
             Vacant(e) => &mut *e
                 .insert({
-                    let mut linker = Linker::new(&self.inner.engine);
+                    let mut linker = wasmtime::Linker::new(&self.inner.engine);
                     linker.allow_shadowing(true);
-                    K::bind_syscalls(&mut linker).map_err(Abort::Fatal)?;
+                    K::link_syscalls(Linker::from_wasmtime(&mut linker)).map_err(Abort::Fatal)?;
                     Box::new(Cache { linker })
                 })
                 .downcast_mut()
@@ -595,7 +596,7 @@ impl Engine {
     }
 
     /// Construct a new wasmtime "store" from the given kernel.
-    pub fn new_store<K: Kernel>(&self, mut kernel: K) -> wasmtime::Store<InvocationData<K>> {
+    pub(crate) fn new_store<K: Kernel>(&self, mut kernel: K) -> wasmtime::Store<InvocationData<K>> {
         // Take a new instance and put it into a drop-guard that removes the reservation when
         // we're done.
         #[must_use]

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use ambassador::delegatable_trait;
 use fvm_shared::event::StampedEvent;
-use wasmtime::Linker;
 
 use crate::call_manager::CallManager;
 use crate::machine::limiter::MemoryLimiter;
 use crate::machine::Machine;
-use crate::syscalls::InvocationData;
+use crate::syscalls::Linker;
 
 mod blocks;
 mod error;
@@ -95,7 +94,7 @@ pub trait Kernel: GasOps + SyscallHandler<Self> + 'static {
 }
 
 pub trait SyscallHandler<K>: Sized {
-    fn bind_syscalls(linker: &mut Linker<InvocationData<K>>) -> anyhow::Result<()>;
+    fn link_syscalls(linker: &mut Linker<K>) -> anyhow::Result<()>;
 }
 
 /// Network-related operations.

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -3,9 +3,9 @@
 use anyhow::{anyhow, Context as _};
 use fvm_shared::{sys, ActorID};
 
-use super::bind::ControlFlow;
 use super::error::Abort;
 use super::Context;
+use super::ControlFlow;
 use crate::kernel::{ActorOps, CallResult, ClassifyResult, Result};
 use crate::{syscall_error, Kernel};
 

--- a/fvm/src/syscalls/linker.rs
+++ b/fvm/src/syscalls/linker.rs
@@ -13,7 +13,6 @@ use crate::call_manager::backtrace;
 use crate::kernel::{self, ExecutionError, Kernel, SyscallError};
 
 /// A "linker" for exposing syscalls to wasm modules.
-#[repr(transparent)]
 pub struct Linker<K>(pub(crate) wasmtime::Linker<InvocationData<K>>);
 
 impl<K> Linker<K> {

--- a/fvm/src/syscalls/linker.rs
+++ b/fvm/src/syscalls/linker.rs
@@ -14,7 +14,7 @@ use crate::kernel::{self, ExecutionError, Kernel, SyscallError};
 
 /// A "linker" for exposing syscalls to wasm modules.
 #[repr(transparent)]
-pub struct Linker<K>(wasmtime::Linker<InvocationData<K>>);
+pub struct Linker<K>(pub(crate) wasmtime::Linker<InvocationData<K>>);
 
 impl<K> Linker<K> {
     /// Link a syscall.
@@ -39,13 +39,6 @@ impl<K> Linker<K> {
     ) -> anyhow::Result<&mut Self> {
         syscall.link(self, module, name)?;
         Ok(self)
-    }
-
-    /// Wrap a wasmtime Linker in our newtype. We use a newtype to hide the underlying
-    /// implementation.
-    pub(crate) fn from_wasmtime(l: &mut wasmtime::Linker<InvocationData<K>>) -> &mut Self {
-        // SAFETY: We're transmuting to a transparent wrapper type.
-        unsafe { &mut *(l as *mut _ as *mut _) }
     }
 }
 

--- a/fvm/src/syscalls/linker.rs
+++ b/fvm/src/syscalls/linker.rs
@@ -4,7 +4,7 @@ use std::mem;
 
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::sys::SyscallSafe;
-use wasmtime::{Caller, Linker, WasmTy};
+use wasmtime::{Caller, WasmTy};
 
 use super::context::Memory;
 use super::error::Abort;
@@ -12,22 +12,12 @@ use super::{charge_for_exec, update_gas_available, Context, InvocationData};
 use crate::call_manager::backtrace;
 use crate::kernel::{self, ExecutionError, Kernel, SyscallError};
 
-/// Binds syscalls to a linker, converting the returned error according to the syscall convention:
-///
-/// 1. If the error is a syscall error, it's returned as the first return value.
-/// 2. If the error is a fatal error, a Trap is returned.
-pub trait BindSyscall<Args, Ret, Func> {
-    /// Bind a syscall to the linker.
-    ///
-    /// 1. The return type will be automatically adjusted to return `Result<u32, Trap>` where
-    /// `u32` is the error code.
-    /// 2. If the return type is non-empty (i.e., not `()`), an out-pointer will be prepended to the
-    /// arguments for the return-value.
-    ///
-    /// By example:
-    ///
-    /// - `fn(u32) -> kernel::Result<()>` will become `fn(u32) -> Result<u32, Trap>`.
-    /// - `fn(u32) -> kernel::Result<i64>` will become `fn(u32, u32) -> Result<u32, Trap>`.
+/// A "linker" for exposing syscalls to wasm modules.
+#[repr(transparent)]
+pub struct Linker<K>(wasmtime::Linker<InvocationData<K>>);
+
+impl<K> Linker<K> {
+    /// Link a syscall.
     ///
     /// # Example
     ///
@@ -41,19 +31,53 @@ pub trait BindSyscall<Args, Ret, Func> {
     /// let mut linker = wasmtime::Linker::new(&engine);
     /// linker.bind("my_module", "zero", my_module::zero);
     /// ```
-    fn bind(
+    pub fn link_syscall<Args, Ret>(
         &mut self,
         module: &'static str,
         name: &'static str,
-        syscall: Func,
-    ) -> anyhow::Result<&mut Self>;
+        syscall: impl Syscall<K, Args, Ret>,
+    ) -> anyhow::Result<&mut Self> {
+        syscall.link(self, module, name)?;
+        Ok(self)
+    }
+
+    /// Wrap a wasmtime Linker in our newtype. We use a newtype to hide the underlying
+    /// implementation.
+    pub(crate) fn from_wasmtime(l: &mut wasmtime::Linker<InvocationData<K>>) -> &mut Self {
+        // SAFETY: We're transmuting to a transparent wrapper type.
+        unsafe { &mut *(l as *mut _ as *mut _) }
+    }
 }
 
-/// ControlFlow is a general-purpose enum allowing us to pass syscall error up the
-/// stack to the actor and treat error handling there (decide when to abort, etc).
+/// A [`Syscall`] is a function in the form `fn(Context<'_, K>, I...) -> R` where:
+///
+/// - `K` is the kernel type. Constrain this to the precise kernel operations you need, or even
+///    a specific kernel implementation.
+/// - `I...`, the syscall parameters, are 0-8 types, each one of [`u32`], [`u64`], [`i32`], or
+///    [`i64`].
+/// - `R` is a type implementing [`IntoControlFlow`]. This is usually one of:
+///     - [`kernel::Result<T>`] or [`ControlFlow<T>`] where `T`, the return value type, is
+///       [`SyscallSafe`].
+///     - [`Abort`] for syscalls that only abort (revert) the currently running actor.
+///
+/// You generally shouldn't implement this trait yourself.
+pub trait Syscall<K, Args, Ret>: Send + Sync + 'static {
+    /// Link this syscall with the specified linker, module name, and function name.
+    fn link(
+        self,
+        linker: &mut Linker<K>,
+        module: &'static str,
+        name: &'static str,
+    ) -> anyhow::Result<()>;
+}
+
+/// ControlFlow is a general-purpose enum for returning a control-flow decision from a syscall.
 pub enum ControlFlow<T> {
+    /// Return a value to the actor.
     Return(T),
+    /// Fail with the specified syscall error.
     Error(SyscallError),
+    /// Abort the running actor (exit, out of gas, or fatal error).
     Abort(Abort),
 }
 
@@ -67,9 +91,8 @@ impl<T> From<ExecutionError> for ControlFlow<T> {
     }
 }
 
-/// The helper trait used by `BindSyscall` to convert kernel results with execution errors into
-/// results that can be handled by wasmtime. See the documentation on `BindSyscall` for details.
-#[doc(hidden)]
+/// The helper trait used by `Syscall` to convert kernel results with execution errors into
+/// results that can be handled by the wasm vm. See the documentation on [`Syscall`] for details.
 pub trait IntoControlFlow: Sized {
     type Value: SyscallSafe;
     fn into_control_flow(self) -> ControlFlow<Self::Value>;
@@ -78,7 +101,6 @@ pub trait IntoControlFlow: Sized {
 /// An uninhabited type. We use this in `abort` to make sure there's no way to return without
 /// returning an error.
 #[derive(Copy, Clone)]
-#[doc(hidden)]
 pub enum Never {}
 unsafe impl SyscallSafe for Never {}
 
@@ -137,32 +159,32 @@ macro_rules! charge_syscall_gas {
 }
 
 // Unfortunately, we can't implement this for _all_ functions. So we implement it for functions of up to 6 arguments.
-macro_rules! impl_bind_syscalls {
+macro_rules! impl_syscall {
     ($($t:ident)*) => {
         #[allow(non_snake_case)]
-        impl<$($t,)* Ret, K, Func> BindSyscall<($($t,)*), Ret, Func> for Linker<InvocationData<K>>
+        impl<$($t,)* Ret, K, Func> Syscall<K, ($($t,)*), Ret> for Func
         where
             K: Kernel,
             Func: Fn(Context<'_, K> $(, $t)*) -> Ret + Send + Sync + 'static,
             Ret: IntoControlFlow,
            $($t: WasmTy+SyscallSafe,)*
         {
-            fn bind(
-                &mut self,
+            fn link(
+                self,
+                linker: &mut Linker<K>,
                 module: &'static str,
                 name: &'static str,
-                syscall: Func,
-            ) -> anyhow::Result<&mut Self> {
+            ) -> anyhow::Result<()> {
                 if mem::size_of::<Ret::Value>() == 0 {
                     // If we're returning a zero-sized "value", we return no value therefore and expect no out pointer.
-                    self.func_wrap(module, name, move |mut caller: Caller<'_, InvocationData<K>> $(, $t: $t)*| {
+                    linker.0.func_wrap(module, name, move |mut caller: Caller<'_, InvocationData<K>> $(, $t: $t)*| {
                         charge_for_exec(&mut caller)?;
 
                         let (mut memory, data) = memory_and_data(&mut caller);
                         charge_syscall_gas!(data.kernel);
 
                         let ctx = Context{kernel: &mut data.kernel, memory: &mut memory};
-                        let out = syscall(ctx $(, $t)*).into_control_flow();
+                        let out = self(ctx $(, $t)*).into_control_flow();
 
                         let result = match out {
                             ControlFlow::Return(_) => {
@@ -182,10 +204,10 @@ macro_rules! impl_bind_syscalls {
                         update_gas_available(&mut caller)?;
 
                         result
-                    })
+                    })?;
                 } else {
                     // If we're returning an actual value, we need to write it back into the wasm module's memory.
-                    self.func_wrap(module, name, move |mut caller: Caller<'_, InvocationData<K>>, ret: u32 $(, $t: $t)*| {
+                    linker.0.func_wrap(module, name, move |mut caller: Caller<'_, InvocationData<K>>, ret: u32 $(, $t: $t)*| {
                         charge_for_exec(&mut caller)?;
 
                         let (mut memory, data) = memory_and_data(&mut caller);
@@ -200,7 +222,7 @@ macro_rules! impl_bind_syscalls {
                         }
 
                         let ctx = Context{kernel: &mut data.kernel, memory: &mut memory};
-                        let result = match syscall(ctx $(, $t)*).into_control_flow() {
+                        let result = match self(ctx $(, $t)*).into_control_flow() {
                             ControlFlow::Return(value) => {
                                 log::trace!("syscall {}::{}: ok", module, name);
                                 unsafe {
@@ -223,19 +245,20 @@ macro_rules! impl_bind_syscalls {
                         update_gas_available(&mut caller)?;
 
                         result
-                    })
+                    })?;
                 }
+                Ok(())
             }
         }
     }
 }
 
-impl_bind_syscalls!();
-impl_bind_syscalls!(A);
-impl_bind_syscalls!(A B);
-impl_bind_syscalls!(A B C);
-impl_bind_syscalls!(A B C D);
-impl_bind_syscalls!(A B C D E);
-impl_bind_syscalls!(A B C D E F);
-impl_bind_syscalls!(A B C D E F G);
-impl_bind_syscalls!(A B C D E F G H);
+impl_syscall!();
+impl_syscall!(A);
+impl_syscall!(A B);
+impl_syscall!(A B C);
+impl_syscall!(A B C D);
+impl_syscall!(A B C D E);
+impl_syscall!(A B C D E F);
+impl_syscall!(A B C D E F G);
+impl_syscall!(A B C D E F G H);

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::{anyhow, Context as _};
 use num_traits::Zero;
-use wasmtime::{AsContextMut, ExternType, Global, Linker, Module, Val};
+use wasmtime::{AsContextMut, ExternType, Global, Module, Val};
 
 use crate::call_manager::backtrace;
 use crate::gas::{Gas, GasInstant, GasTimer};
@@ -18,7 +18,6 @@ use crate::{DefaultKernel, Kernel};
 pub(crate) mod error;
 
 mod actor;
-pub mod bind;
 mod context;
 mod crypto;
 mod debug;
@@ -26,6 +25,7 @@ mod event;
 mod filecoin;
 mod gas;
 mod ipld;
+mod linker;
 mod network;
 mod rand;
 mod send;
@@ -34,9 +34,12 @@ mod vm;
 
 pub use context::{Context, Memory};
 pub use error::Abort;
+pub use linker::{ControlFlow, Linker};
+
+pub use linker::{IntoControlFlow, Syscall};
 
 /// Invocation data attached to a wasm "store" and available to the syscall binding.
-pub struct InvocationData<K> {
+pub(crate) struct InvocationData<K> {
     /// The kernel on which this actor is being executed.
     pub kernel: K,
 
@@ -66,7 +69,7 @@ pub struct InvocationData<K> {
 
 /// Updates the global available gas in the Wasm module after a syscall, to account for any
 /// gas consumption that happened on the host side.
-pub fn update_gas_available(
+pub(crate) fn update_gas_available(
     ctx: &mut impl AsContextMut<Data = InvocationData<impl Kernel>>,
 ) -> Result<(), Abort> {
     let mut ctx = ctx.as_context_mut();
@@ -96,7 +99,7 @@ pub fn update_gas_available(
 }
 
 /// Updates the FVM-side gas tracker with newly accrued execution gas charges.
-pub fn charge_for_exec<K: Kernel>(
+pub(crate) fn charge_for_exec<K: Kernel>(
     ctx: &mut impl AsContextMut<Data = InvocationData<K>>,
 ) -> Result<(), Abort> {
     let mut ctx = ctx.as_context_mut();
@@ -149,7 +152,7 @@ pub fn charge_for_exec<K: Kernel>(
         .map_err(Abort::from_error_as_fatal)?;
 
     // It should be okay to record time associated with Wasm execution because `charge_for_exec` is
-    // called before syscalls `impl_bind_syscalls`, so the syscall timings are going to be
+    // called before syscalls `impl_link_syscalls`, so the syscall timings are going to be
     // interleaved, rather than nested inside it. But we also have to make sure to reset the timer
     // after each syscall, when Wasm resumes, which happens in `update_gas_available`.
     t.stop_with(data.last_charge_time);
@@ -171,7 +174,7 @@ pub fn charge_for_exec<K: Kernel>(
 /// The Wasm instrumentation machinery via [fvm_wasm_instrument::gas_metering::MemoryGrowCost]
 /// only charges for growing the memory _beyond_ the initial amount. It's up to us to make sure
 /// the minimum memory is properly charged for.
-pub fn charge_for_init<K: Kernel>(
+pub(crate) fn charge_for_init<K: Kernel>(
     ctx: &mut impl AsContextMut<Data = InvocationData<K>>,
     module: &Module,
 ) -> crate::kernel::Result<GasTimer> {
@@ -195,7 +198,7 @@ pub fn charge_for_init<K: Kernel>(
 ///
 /// In practice this includes all the time elapsed since the `InvocationData` was created,
 /// ie. this is the first time we'll use the `last_charge_time`.
-pub fn record_init_time<K: Kernel>(
+pub(crate) fn record_init_time<K: Kernel>(
     ctx: &mut impl AsContextMut<Data = InvocationData<K>>,
     timer: GasTimer,
 ) {
@@ -237,8 +240,6 @@ fn min_table_elements(module: &Module) -> Option<u32> {
     }
 }
 
-use self::bind::BindSyscall;
-
 impl<K> SyscallHandler<K> for DefaultKernel<K::CallManager>
 where
     K: Kernel
@@ -253,77 +254,77 @@ where
         + RandomnessOps
         + SelfOps,
 {
-    fn bind_syscalls(linker: &mut wasmtime::Linker<InvocationData<K>>) -> anyhow::Result<()> {
-        linker.bind("vm", "exit", vm::exit)?;
-        linker.bind("vm", "message_context", vm::message_context)?;
+    fn link_syscalls(linker: &mut Linker<K>) -> anyhow::Result<()> {
+        linker.link_syscall("vm", "exit", vm::exit)?;
+        linker.link_syscall("vm", "message_context", vm::message_context)?;
 
-        linker.bind("network", "context", network::context)?;
-        linker.bind("network", "tipset_cid", network::tipset_cid)?;
+        linker.link_syscall("network", "context", network::context)?;
+        linker.link_syscall("network", "tipset_cid", network::tipset_cid)?;
 
-        linker.bind("ipld", "block_open", ipld::block_open)?;
-        linker.bind("ipld", "block_create", ipld::block_create)?;
-        linker.bind("ipld", "block_read", ipld::block_read)?;
-        linker.bind("ipld", "block_stat", ipld::block_stat)?;
-        linker.bind("ipld", "block_link", ipld::block_link)?;
+        linker.link_syscall("ipld", "block_open", ipld::block_open)?;
+        linker.link_syscall("ipld", "block_create", ipld::block_create)?;
+        linker.link_syscall("ipld", "block_read", ipld::block_read)?;
+        linker.link_syscall("ipld", "block_stat", ipld::block_stat)?;
+        linker.link_syscall("ipld", "block_link", ipld::block_link)?;
 
-        linker.bind("self", "root", sself::root)?;
-        linker.bind("self", "set_root", sself::set_root)?;
-        linker.bind("self", "current_balance", sself::current_balance)?;
-        linker.bind("self", "self_destruct", sself::self_destruct)?;
+        linker.link_syscall("self", "root", sself::root)?;
+        linker.link_syscall("self", "set_root", sself::set_root)?;
+        linker.link_syscall("self", "current_balance", sself::current_balance)?;
+        linker.link_syscall("self", "self_destruct", sself::self_destruct)?;
 
-        linker.bind("actor", "resolve_address", actor::resolve_address)?;
-        linker.bind(
+        linker.link_syscall("actor", "resolve_address", actor::resolve_address)?;
+        linker.link_syscall(
             "actor",
             "lookup_delegated_address",
             actor::lookup_delegated_address,
         )?;
-        linker.bind("actor", "get_actor_code_cid", actor::get_actor_code_cid)?;
-        linker.bind("actor", "next_actor_address", actor::next_actor_address)?;
-        linker.bind("actor", "create_actor", actor::create_actor)?;
+        linker.link_syscall("actor", "get_actor_code_cid", actor::get_actor_code_cid)?;
+        linker.link_syscall("actor", "next_actor_address", actor::next_actor_address)?;
+        linker.link_syscall("actor", "create_actor", actor::create_actor)?;
         if cfg!(feature = "upgrade-actor") {
             // We disable/enable with the feature, but we always compile this code to ensure we don't
             // accidentally break it.
-            linker.bind("actor", "upgrade_actor", actor::upgrade_actor)?;
+            linker.link_syscall("actor", "upgrade_actor", actor::upgrade_actor)?;
         }
-        linker.bind(
+        linker.link_syscall(
             "actor",
             "get_builtin_actor_type",
             actor::get_builtin_actor_type,
         )?;
-        linker.bind(
+        linker.link_syscall(
             "actor",
             "get_code_cid_for_type",
             actor::get_code_cid_for_type,
         )?;
-        linker.bind("actor", "balance_of", actor::balance_of)?;
+        linker.link_syscall("actor", "balance_of", actor::balance_of)?;
 
         // Only wire this syscall when M2 native is enabled.
         if cfg!(feature = "m2-native") {
-            linker.bind("actor", "install_actor", actor::install_actor)?;
+            linker.link_syscall("actor", "install_actor", actor::install_actor)?;
         }
 
-        linker.bind("crypto", "verify_signature", crypto::verify_signature)?;
-        linker.bind(
+        linker.link_syscall("crypto", "verify_signature", crypto::verify_signature)?;
+        linker.link_syscall(
             "crypto",
             "recover_secp_public_key",
             crypto::recover_secp_public_key,
         )?;
-        linker.bind("crypto", "hash", crypto::hash)?;
+        linker.link_syscall("crypto", "hash", crypto::hash)?;
 
-        linker.bind("event", "emit_event", event::emit_event)?;
+        linker.link_syscall("event", "emit_event", event::emit_event)?;
 
-        linker.bind("rand", "get_chain_randomness", rand::get_chain_randomness)?;
-        linker.bind("rand", "get_beacon_randomness", rand::get_beacon_randomness)?;
+        linker.link_syscall("rand", "get_chain_randomness", rand::get_chain_randomness)?;
+        linker.link_syscall("rand", "get_beacon_randomness", rand::get_beacon_randomness)?;
 
-        linker.bind("gas", "charge", gas::charge_gas)?;
-        linker.bind("gas", "available", gas::available)?;
+        linker.link_syscall("gas", "charge", gas::charge_gas)?;
+        linker.link_syscall("gas", "available", gas::available)?;
 
         // Ok, this singled-out syscall should probably be in another category.
-        linker.bind("send", "send", send::send)?;
+        linker.link_syscall("send", "send", send::send)?;
 
-        linker.bind("debug", "log", debug::log)?;
-        linker.bind("debug", "enabled", debug::enabled)?;
-        linker.bind("debug", "store_artifact", debug::store_artifact)?;
+        linker.link_syscall("debug", "log", debug::log)?;
+        linker.link_syscall("debug", "enabled", debug::enabled)?;
+        linker.link_syscall("debug", "store_artifact", debug::store_artifact)?;
 
         Ok(())
     }
@@ -343,39 +344,39 @@ where
         + RandomnessOps
         + SelfOps,
 {
-    fn bind_syscalls(linker: &mut Linker<InvocationData<K>>) -> anyhow::Result<()> {
-        DefaultKernel::<K::CallManager>::bind_syscalls(linker)?;
+    fn link_syscalls(linker: &mut Linker<K>) -> anyhow::Result<()> {
+        DefaultKernel::<K::CallManager>::link_syscalls(linker)?;
 
         // Bind the circulating supply call.
-        linker.bind(
+        linker.link_syscall(
             "network",
             "total_fil_circ_supply",
             filecoin::total_fil_circ_supply,
         )?;
 
         // Now bind the crypto syscalls.
-        linker.bind(
+        linker.link_syscall(
             "crypto",
             "compute_unsealed_sector_cid",
             filecoin::compute_unsealed_sector_cid,
         )?;
-        linker.bind("crypto", "verify_post", filecoin::verify_post)?;
-        linker.bind(
+        linker.link_syscall("crypto", "verify_post", filecoin::verify_post)?;
+        linker.link_syscall(
             "crypto",
             "verify_consensus_fault",
             filecoin::verify_consensus_fault,
         )?;
-        linker.bind(
+        linker.link_syscall(
             "crypto",
             "verify_aggregate_seals",
             filecoin::verify_aggregate_seals,
         )?;
-        linker.bind(
+        linker.link_syscall(
             "crypto",
             "verify_replica_update",
             filecoin::verify_replica_update,
         )?;
-        linker.bind("crypto", "batch_verify_seals", filecoin::batch_verify_seals)?;
+        linker.link_syscall("crypto", "batch_verify_seals", filecoin::batch_verify_seals)?;
 
         Ok(())
     }

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -5,20 +5,19 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;
 use fvm::kernel::filecoin::{DefaultFilecoinKernel, FilecoinKernel};
-use fvm::syscalls::InvocationData;
 
 use fvm::call_manager::{CallManager, DefaultCallManager};
 use fvm::gas::price_list_by_network_version;
 use fvm::machine::limiter::MemoryLimiter;
 use fvm::machine::{DefaultMachine, Machine, MachineContext, Manifest, NetworkConfig};
 use fvm::state_tree::StateTree;
+use fvm::syscalls::Linker;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, ReplicaUpdateInfo, SealVerifyInfo,
 };
-use wasmtime::Linker;
 
 // We have glob imports here because delegation doesn't work well without it.
 use fvm::kernel::prelude::*;
@@ -238,8 +237,8 @@ impl Kernel for TestKernel {
 }
 
 impl SyscallHandler<TestKernel> for TestKernel {
-    fn bind_syscalls(linker: &mut Linker<InvocationData<TestKernel>>) -> anyhow::Result<()> {
-        InnerTestKernel::bind_syscalls(linker)
+    fn link_syscalls(linker: &mut Linker<TestKernel>) -> anyhow::Result<()> {
+        InnerTestKernel::link_syscalls(linker)
     }
 }
 


### PR DESCRIPTION
This cleans up and hides the implementation details of our syscall binding API.

Previously, we passed a wasmtime linker to the `SyscallHandler`. Unfortunately:

1. This exposed implementation details (wasmtime, the InvocationData object type, etc.).
2. The user had to import the `BindSyscall` trait to bind syscalls.

I've changed this by:

1. Replacing the `BindSyscall` trait (previously implemented on the "linker") with a `Syscall` trait implemented on all valid "syscall" functions.
2. Exposing an opaque `Linker` type with a `link_syscall` method instead of exposing the wasmtime linker directly. This lets us change/augment this type later.

I've also renamed "bind" to "link" in most places for consistency.