### PR TITLE
feat: cleanup Engine API

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -707,7 +707,7 @@ where
         // listed the manifest, and therefore preloaded during system initialization.
         #[cfg(feature = "m2-native")]
         self.engine
-            .prepare_actor_code(&state.code, self.blockstore())
+            .preload(&state.code, self.blockstore())
             .map_err(
                 |_| syscall_error!(NotFound; "actor code cid does not exist {}", &state.code),
             )?;

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -307,7 +307,7 @@ where
             // This interface works for now because we know all actor CIDs
             // ahead of time, but with user-supplied code, we won't have that
             // guarantee.
-            engine_pool.acquire().preload(
+            engine_pool.acquire().preload_all(
                 machine.blockstore(),
                 machine.builtin_actors().builtin_actor_codes(),
             )?;

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -827,7 +827,7 @@ where
         let size = self
             .call_manager
             .engine()
-            .preload(self.call_manager.blockstore(), &[code_id])
+            .preload_all(self.call_manager.blockstore(), &[code_id])
             .context("failed to install actor")
             .or_illegal_argument()?;
 

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -124,7 +124,7 @@ mod test {
             .for_epoch(0, 0, root);
 
         let machine = DefaultMachine::new(&mc, bs, DummyExterns).unwrap();
-        let engine = EnginePool::new_default((&mc.network).into()).unwrap();
+        let engine = EnginePool::new((&mc.network).into()).unwrap();
         let _ = executor::DefaultExecutor::<DefaultFilecoinKernel<DefaultCallManager<_>>>::new(
             engine,
             Box::new(machine),

--- a/testing/conformance/benches/bench_drivers.rs
+++ b/testing/conformance/benches/bench_drivers.rs
@@ -55,7 +55,7 @@ pub fn bench_vector_variant(
                 // to do this explicitly.
                 engine
                     .acquire()
-                    .preload(
+                    .preload_all(
                         machine.blockstore(),
                         machine.builtin_actors().builtin_actor_codes(),
                     )

--- a/testing/conformance/src/driver.rs
+++ b/testing/conformance/src/driver.rs
@@ -233,7 +233,7 @@ pub fn run_variant(
     // this explicitly.
     engine
         .acquire()
-        .preload(
+        .preload_all(
             machine.blockstore(),
             machine.builtin_actors().builtin_actor_codes(),
         )

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -292,8 +292,8 @@ where
         // Custom configuration.
         configure_mc(&mut mc);
 
-        let engine = EnginePool::new_default((&mc.network.clone()).into())?;
-        engine.acquire().preload(&blockstore, &self.code_cids)?;
+        let engine = EnginePool::new((&mc.network.clone()).into())?;
+        engine.acquire().preload_all(&blockstore, &self.code_cids)?;
 
         let machine = DefaultMachine::new(&mc, blockstore, externs)?;
 


### PR DESCRIPTION
1. Hide all wasmtime specific parts.
2. Unexport functions that don't need to be a part of the public API.
3. Rename functions for consistency.
4. Delete some unused code.