### PR TITLE
refactor: remove GasOps from the Kernel

### DIFF
--- a/fvm/src/engine/mod.rs
+++ b/fvm/src/engine/mod.rs
@@ -572,6 +572,7 @@ impl Engine {
             last_memory_bytes: memory_bytes,
             last_charge_time: GasTimer::start(),
             memory: self.inner.dummy_memory,
+            wasm_prices: self.inner.config.wasm_prices,
         };
 
         let mut store = wasmtime::Store::new(&self.inner.engine, id);

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -269,6 +269,14 @@ where
     fn limiter_mut(&mut self) -> &mut Self::Limiter {
         self.call_manager.limiter_mut()
     }
+
+    fn gas_available(&self) -> Gas {
+        self.call_manager.gas_tracker().gas_available()
+    }
+
+    fn charge_gas(&self, name: &str, compute: Gas) -> Result<GasTimer> {
+        self.call_manager.gas_tracker().charge_gas(name, compute)
+    }
 }
 
 impl<C> DefaultKernel<C>
@@ -625,27 +633,6 @@ where
         )?;
 
         t.record(Ok(hasher.digest(data)))
-    }
-}
-
-impl<C> GasOps for DefaultKernel<C>
-where
-    C: CallManager,
-{
-    fn gas_used(&self) -> Gas {
-        self.call_manager.gas_tracker().gas_used()
-    }
-
-    fn gas_available(&self) -> Gas {
-        self.call_manager.gas_tracker().gas_available()
-    }
-
-    fn charge_gas(&self, name: &str, compute: Gas) -> Result<GasTimer> {
-        self.call_manager.gas_tracker().charge_gas(name, compute)
-    }
-
-    fn price_list(&self) -> &PriceList {
-        self.call_manager.price_list()
     }
 }
 

--- a/fvm/src/kernel/filecoin.rs
+++ b/fvm/src/kernel/filecoin.rs
@@ -93,7 +93,6 @@ pub trait FilecoinKernel: Kernel {
 #[delegate(CryptoOps, where = "C: CallManager")]
 #[delegate(DebugOps, where = "C: CallManager")]
 #[delegate(EventOps, where = "C: CallManager")]
-#[delegate(GasOps, where = "C: CallManager")]
 #[delegate(MessageOps, where = "C: CallManager")]
 #[delegate(NetworkOps, where = "C: CallManager")]
 #[delegate(RandomnessOps, where = "C: CallManager")]
@@ -303,7 +302,15 @@ where
     }
 
     fn limiter_mut(&mut self) -> &mut Self::Limiter {
-        self.0.call_manager.limiter_mut()
+        self.0.limiter_mut()
+    }
+
+    fn gas_available(&self) -> Gas {
+        self.0.gas_available()
+    }
+
+    fn charge_gas(&self, name: &str, compute: Gas) -> Result<GasTimer> {
+        self.0.charge_gas(name, compute)
     }
 }
 

--- a/fvm/src/syscalls/gas.rs
+++ b/fvm/src/syscalls/gas.rs
@@ -4,10 +4,11 @@ use std::str;
 
 use super::Context;
 use crate::gas::Gas;
-use crate::kernel::{ClassifyResult, GasOps, Result};
+use crate::kernel::{ClassifyResult, Result};
+use crate::Kernel;
 
 pub fn charge_gas(
-    context: Context<'_, impl GasOps>,
+    context: Context<'_, impl Kernel>,
     name_off: u32,
     name_len: u32,
     compute: u64,
@@ -21,6 +22,6 @@ pub fn charge_gas(
         .map(|_| ())
 }
 
-pub fn available(context: Context<'_, impl GasOps>) -> Result<u64> {
+pub fn available(context: Context<'_, impl Kernel>) -> Result<u64> {
     Ok(context.kernel.gas_available().round_down())
 }


### PR DESCRIPTION
It's not really a proper "ops" trait, it's more "basic functionality".

Additionally, the concept of a global price list is going to go away as we make the kernel more pluggable.

1. Move `GasOps::gas_available`/`GasOps::charge_gas` to the main `Kernel` trait as all kernels require them.
2. Remove `GasOps::gas_used`, it's only used for testing.
3. Remove `GasOps::price_list`. We're still exposing it on the CallManager, but one step at a time).