### PR TITLE
refactor: move send/upgrade out of the kernel

### DIFF
--- a/fvm/src/kernel/filecoin.rs
+++ b/fvm/src/kernel/filecoin.rs
@@ -97,8 +97,8 @@ pub trait FilecoinKernel: Kernel {
 #[delegate(NetworkOps, where = "C: CallManager")]
 #[delegate(RandomnessOps, where = "C: CallManager")]
 #[delegate(SelfOps, where = "C: CallManager")]
-#[delegate(SendOps<K>, generics = "K", where = "C: CallManager, K: FilecoinKernel")]
-#[delegate(UpgradeOps<K>, generics = "K", where = "C: CallManager, K: FilecoinKernel")]
+#[delegate(SendOps<K>, generics = "K", where = "K: FilecoinKernel")]
+#[delegate(UpgradeOps<K>, generics = "K", where = "K: FilecoinKernel")]
 pub struct DefaultFilecoinKernel<C>(pub DefaultKernel<C>);
 
 impl<C> FilecoinKernel for DefaultFilecoinKernel<C>

--- a/fvm/src/kernel/filecoin.rs
+++ b/fvm/src/kernel/filecoin.rs
@@ -97,6 +97,8 @@ pub trait FilecoinKernel: Kernel {
 #[delegate(NetworkOps, where = "C: CallManager")]
 #[delegate(RandomnessOps, where = "C: CallManager")]
 #[delegate(SelfOps, where = "C: CallManager")]
+#[delegate(SendOps<K>, generics = "K", where = "C: CallManager, K: FilecoinKernel")]
+#[delegate(UpgradeOps<K>, generics = "K", where = "C: CallManager, K: FilecoinKernel")]
 pub struct DefaultFilecoinKernel<C>(pub DefaultKernel<C>);
 
 impl<C> FilecoinKernel for DefaultFilecoinKernel<C>
@@ -258,27 +260,6 @@ where
 
     fn machine(&self) -> &<Self::CallManager as CallManager>::Machine {
         self.0.machine()
-    }
-
-    fn send<K: Kernel<CallManager = C>>(
-        &mut self,
-        recipient: &Address,
-        method: u64,
-        params: BlockId,
-        value: &TokenAmount,
-        gas_limit: Option<Gas>,
-        flags: SendFlags,
-    ) -> Result<CallResult> {
-        self.0
-            .send::<Self>(recipient, method, params, value, gas_limit, flags)
-    }
-
-    fn upgrade_actor<K: Kernel<CallManager = Self::CallManager>>(
-        &mut self,
-        new_code_cid: Cid,
-        params_id: BlockId,
-    ) -> Result<CallResult> {
-        self.0.upgrade_actor::<Self>(new_code_cid, params_id)
     }
 
     fn new(

--- a/fvm/src/syscalls/actor.rs
+++ b/fvm/src/syscalls/actor.rs
@@ -6,6 +6,7 @@ use fvm_shared::{sys, ActorID};
 use super::error::Abort;
 use super::Context;
 use super::ControlFlow;
+use crate::kernel::UpgradeOps;
 use crate::kernel::{ActorOps, CallResult, ClassifyResult, Result};
 use crate::{syscall_error, Kernel};
 
@@ -111,8 +112,8 @@ pub fn create_actor(
     context.kernel.create_actor(typ, actor_id, addr)
 }
 
-pub fn upgrade_actor<K: Kernel>(
-    context: Context<'_, K>,
+pub fn upgrade_actor(
+    context: Context<'_, impl UpgradeOps + Kernel>,
     new_code_cid_off: u32,
     params_id: u32,
 ) -> ControlFlow<sys::out::send::Send> {
@@ -121,7 +122,7 @@ pub fn upgrade_actor<K: Kernel>(
         Err(err) => return err.into(),
     };
 
-    match context.kernel.upgrade_actor::<K>(cid, params_id) {
+    match context.kernel.upgrade_actor(cid, params_id) {
         Ok(CallResult {
             block_id,
             block_stat,

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -9,7 +9,7 @@ use crate::gas::{Gas, GasInstant, GasTimer, WasmGasPrices};
 use crate::kernel::filecoin::{DefaultFilecoinKernel, FilecoinKernel};
 use crate::kernel::{
     ActorOps, CryptoOps, DebugOps, EventOps, ExecutionError, IpldBlockOps, MessageOps, NetworkOps,
-    RandomnessOps, SelfOps, SyscallHandler,
+    RandomnessOps, SelfOps, SendOps, SyscallHandler, UpgradeOps,
 };
 
 use crate::machine::limiter::MemoryLimiter;
@@ -257,6 +257,8 @@ where
     K: Kernel
         + ActorOps
         + IpldBlockOps
+        + SendOps
+        + UpgradeOps
         + CryptoOps
         + DebugOps
         + EventOps
@@ -345,6 +347,8 @@ impl<K> SyscallHandler<K> for DefaultFilecoinKernel<K::CallManager>
 where
     K: FilecoinKernel
         + ActorOps
+        + SendOps
+        + UpgradeOps
         + IpldBlockOps
         + CryptoOps
         + DebugOps

--- a/fvm/src/syscalls/send.rs
+++ b/fvm/src/syscalls/send.rs
@@ -7,14 +7,13 @@ use fvm_shared::sys::{self, SendFlags};
 
 use super::Context;
 use crate::gas::Gas;
-use crate::kernel::{CallResult, ClassifyResult, Result};
-use crate::Kernel;
+use crate::kernel::{CallResult, ClassifyResult, Kernel, Result, SendOps};
 
 /// Send a message to another actor. The result is placed as a CBOR-encoded
 /// receipt in the block registry, and can be retrieved by the returned BlockId.
 #[allow(clippy::too_many_arguments)]
-pub fn send<K: Kernel>(
-    context: Context<'_, K>,
+pub fn send(
+    context: Context<'_, impl SendOps + Kernel>,
     recipient_off: u32,
     recipient_len: u32,
     method: u64,
@@ -43,7 +42,7 @@ pub fn send<K: Kernel>(
         exit_code,
     } = context
         .kernel
-        .send::<K>(&recipient, method, params_id, &value, gas_limit, flags)?;
+        .send(&recipient, method, params_id, &value, gas_limit, flags)?;
 
     Ok(sys::out::send::Send {
         exit_code: exit_code.value(),

--- a/testing/conformance/src/vm.rs
+++ b/testing/conformance/src/vm.rs
@@ -169,6 +169,8 @@ type InnerTestKernel = DefaultFilecoinKernel<DefaultCallManager<TestMachine>>;
 #[delegate(NetworkOps)]
 #[delegate(RandomnessOps)]
 #[delegate(SelfOps)]
+#[delegate(SendOps<K>, generics = "K", where = "K: FilecoinKernel")]
+#[delegate(UpgradeOps<K>, generics = "K", where = "K: FilecoinKernel")]
 pub struct TestKernel(pub InnerTestKernel);
 
 impl TestKernel {
@@ -213,27 +215,6 @@ impl Kernel for TestKernel {
 
     fn machine(&self) -> &<Self::CallManager as CallManager>::Machine {
         self.0.machine()
-    }
-
-    fn send<KK>(
-        &mut self,
-        recipient: &Address,
-        method: u64,
-        params: BlockId,
-        value: &TokenAmount,
-        gas_limit: Option<Gas>,
-        flags: SendFlags,
-    ) -> Result<CallResult> {
-        // Note that KK, the type of the kernel to crate for the receiving actor, is ignored,
-        // and Self is passed as the type parameter for the nested call.
-        // If we could find the correct bound to specify KK for the call, we would.
-        // This restricts the ability for the TestKernel to itself be wrapped by another kernel type.
-        self.0
-            .send::<Self>(recipient, method, params, value, gas_limit, flags)
-    }
-
-    fn upgrade_actor<KK>(&mut self, new_code_cid: Cid, params_id: BlockId) -> Result<CallResult> {
-        self.0.upgrade_actor::<Self>(new_code_cid, params_id)
     }
 
     fn limiter_mut(&mut self) -> &mut Self::Limiter {


### PR DESCRIPTION
Make them higher-level ops like everything else. I considered combining them into a single "call op" however, not all users may want to implement actor upgrading.

I've also moved the generic from the methods to the trait itself. This resolves anorth's comment on the `TestKernel` by allowing additional bounds to be specified by the _implementer_, instead of having all the bounds encoded on the trait itself:

> Note that KK, the type of the kernel to crate for the receiving actor, is ignored, and Self is passed as the type parameter for the nested call. If we could find the correct bound to specify KK for the call, we would. This restricts the ability for the TestKernel to itself be wrapped by another kernel type.