### PR TITLE
feat: record the entire actor state on invoke

### DIFF
--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -1,13 +1,12 @@
-use cid::Cid;
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::ActorID;
+use fvm_shared::state::ActorState;
+use fvm_shared::{ActorID, MethodNum};
 
-use crate::call_manager::Entrypoint;
 use crate::gas::GasCharge;
 use crate::kernel::SyscallError;
 
@@ -26,7 +25,7 @@ pub enum ExecutionEvent {
     Call {
         from: ActorID,
         to: Address,
-        entrypoint: Entrypoint,
+        method: MethodNum,
         params: Option<IpldBlock>,
         value: TokenAmount,
         gas_limit: u64,
@@ -34,6 +33,9 @@ pub enum ExecutionEvent {
     },
     CallReturn(ExitCode, Option<IpldBlock>),
     CallError(SyscallError),
-    /// Emitted every time we successfully invoke an actor
-    InvokeActor(Cid),
+    /// Emitted every time an actor is successfully invoked.
+    InvokeActor {
+        id: ActorID,
+        state: ActorState,
+    },
 }


### PR DESCRIPTION
This change has two parts:

1. Record the _entire_ actor state on invoke. This will let us accurately determine the state, address, etc. of an actor at the time of invocation even if the transaction is later reverted.
2. Stop tracing non-"send" events. Specifically:
    - I've stopped tracing upgrades. They're not traditional "calls" and we'll want to handle them differently anyways.
    - Previously, we were tracing InvokeActor events for implicit constructor calls and upgrades. I've removed those as well as I want all InvokeActor events to be paired with some other event.

This should finally give us enough information in Lotus to accurately translate an FVM trace into an EVM trace. Furthermore, the extra state we're recording in the InvokeActor event will be useful for debugging.