### PR TITLE
fix: revert backtrace frame from entrypoint to method

### DIFF
--- a/fvm/src/call_manager/backtrace.rs
+++ b/fvm/src/call_manager/backtrace.rs
@@ -4,11 +4,9 @@ use std::fmt::Display;
 
 use fvm_shared::address::Address;
 use fvm_shared::error::{ErrorNumber, ExitCode};
-use fvm_shared::ActorID;
+use fvm_shared::{ActorID, MethodNum};
 
 use crate::kernel::SyscallError;
-
-use super::Entrypoint;
 
 /// A call backtrace records the actors an error was propagated through, from
 /// the moment it was emitted. The original error is the _cause_. Backtraces are
@@ -78,8 +76,8 @@ impl Backtrace {
 pub struct Frame {
     /// The actor that exited with this code.
     pub source: ActorID,
-    /// The entrypoint that was invoked.
-    pub entrypoint: Entrypoint,
+    /// The method that was invoked.
+    pub method: MethodNum,
     /// The exit code.
     pub code: ExitCode,
     /// The abort message.
@@ -92,7 +90,7 @@ impl Display for Frame {
             f,
             "{} (method {}) -- {} ({})",
             Address::new_id(self.source),
-            self.entrypoint,
+            self.method,
             &self.message,
             self.code,
         )

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -859,16 +859,21 @@ where
                     };
 
                     if !code.is_success() {
-                        if let Some(err) = last_error {
-                            cm.backtrace.begin(err);
-                        }
+                        // Only record backtrace frames for explicit messages sent by the user. We
+                        // may want to record frames for failed upgrades, but that complicates
+                        // things a bit and I'd like to keep this API the same for now.
+                        if let &Entrypoint::Invoke(method) = &entrypoint {
+                            if let Some(err) = last_error {
+                                cm.backtrace.begin(err);
+                            }
 
-                        cm.backtrace.push_frame(Frame {
-                            source: to,
-                            entrypoint,
-                            message,
-                            code,
-                        });
+                            cm.backtrace.push_frame(Frame {
+                                source: to,
+                                method,
+                                message,
+                                code,
+                            });
+                        }
                     }
 
                     res


### PR DESCRIPTION
This is a pretty public API (information gets displayed to the user) and I'd rather not go about changing it at the moment. We'll probably bring this back eventually, but I'm trying to cut a release and integrate with the FFI with minimal outward-facing changes.