### PR TITLE
Put upgrade/install behind feature flags again

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -24,3 +24,4 @@ fvm_ipld_encoding = { workspace = true }
 [features]
 default = []
 m2-native = []
+upgrade-actor = []

--- a/sdk/src/sys/actor.rs
+++ b/sdk/src/sys/actor.rs
@@ -161,6 +161,7 @@ super::fvm_syscalls! {
     /// | [`IllegalArgument`]   | invalid code cid buffer.                                        |
     /// | [`Forbidden`]         | the actor is not allowed to upgrade (e.g., due to re-entrency). |
     /// | [`ReadOnly`]          | the actor is executing in read-only mode.                       |
+    #[cfg(feature = "upgrade-actor")]
     pub fn upgrade_actor(
         new_code_cid_off: *const u8,
         params: u32,
@@ -168,6 +169,7 @@ super::fvm_syscalls! {
 
     /// Installs and ensures actor code is valid and loaded.
     /// **Privileged:** May only be called by the init actor.
+    #[cfg(feature = "m2-native")]
     pub fn install_actor(cid_off: *const u8) -> Result<()>;
 
     /// Gets the balance of the specified actor.

--- a/testing/test_actors/actors/fil-upgrade-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-upgrade-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { workspace = true }
+fvm_sdk = { workspace = true, features = ["upgrade-actor"]}
 fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 cid = { workspace = true }

--- a/testing/test_actors/actors/fil-upgrade-receive-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-upgrade-receive-actor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { workspace = true }
+fvm_sdk = { workspace = true, features = ["upgrade-actor"] }
 fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 cid = { workspace = true }


### PR DESCRIPTION
We now _compile_ with these features enabled (but not available to running actors) in the FVM itself, but it's better to leave them out of the SDK so we don't accidentally try to use them.