### PR TITLE
chore: deprecate for_each_while to match for_each

### DIFF
--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -462,6 +462,7 @@ where
 
     /// Iterates over each value in the Amt and runs a function on the values, for as long as that
     /// function keeps returning `true`.
+    #[deprecated = "use `.iter()` instead"]
     pub fn for_each_while<F>(&self, mut f: F) -> Result<(), Error>
     where
         F: FnMut(u64, &V) -> anyhow::Result<bool>,


### PR DESCRIPTION
This'll be a bit annoying for users as they'll need to switch immediately to avoid warnings, but the switch will be easy (and they can always ignore the warning).