### PR TITLE
chore: release fvm, fvm_sdk, and fvm_shared v4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.0.0",
+ "fvm_shared 4.1.0",
  "libfuzzer-sys",
  "multihash 0.18.1",
  "rand",
@@ -1425,7 +1425,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "num-derive 0.3.3",
  "num-traits",
  "serde",
@@ -1458,7 +1458,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "log",
  "num-derive 0.3.3",
  "num-traits",
@@ -1478,7 +1478,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "lazy_static",
  "log",
  "num-derive 0.3.3",
@@ -1497,7 +1497,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "hex-literal",
  "log",
  "multihash 0.18.1",
@@ -1516,7 +1516,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "hex-literal",
  "num-derive 0.3.3",
  "num-traits",
@@ -1536,7 +1536,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_kamt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "hex",
  "hex-literal",
  "log",
@@ -1559,7 +1559,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "log",
  "num-derive 0.3.3",
  "num-traits",
@@ -1580,7 +1580,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "integer-encoding 3.0.4",
  "libipld-core 0.13.1",
  "log",
@@ -1605,7 +1605,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -1628,7 +1628,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "indexmap 1.9.3",
  "integer-encoding 3.0.4",
  "num-derive 0.3.3",
@@ -1647,7 +1647,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "num-derive 0.3.3",
  "num-traits",
  "serde",
@@ -1670,7 +1670,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "indexmap 1.9.3",
  "integer-encoding 3.0.4",
  "lazy_static",
@@ -1688,7 +1688,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "lazy_static",
  "log",
  "num-derive 0.3.3",
@@ -1706,7 +1706,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "num-derive 0.3.3",
  "num-traits",
  "serde",
@@ -1726,7 +1726,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "lazy_static",
  "log",
  "num-derive 0.3.3",
@@ -1741,7 +1741,7 @@ source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#7
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "hex",
  "serde",
  "uint",
@@ -1762,8 +1762,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
- "fvm_sdk 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.0.0",
+ "fvm_shared 4.0.0",
  "integer-encoding 3.0.4",
  "itertools 0.10.5",
  "log",
@@ -1786,8 +1786,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
 ]
 
 [[package]]
@@ -1823,8 +1823,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
 ]
 
 [[package]]
@@ -1833,8 +1833,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1845,8 +1845,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
  "serde",
  "serde_tuple",
 ]
@@ -1856,8 +1856,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
 ]
 
 [[package]]
@@ -1868,8 +1868,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
  "libipld",
  "num-derive 0.4.1",
  "num-traits",
@@ -1881,8 +1881,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
  "log",
  "serde",
  "serde_tuple",
@@ -1892,8 +1892,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
 ]
 
 [[package]]
@@ -1904,8 +1904,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
  "serde",
  "serde_tuple",
 ]
@@ -1915,8 +1915,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
  "minicov",
 ]
 
@@ -1924,16 +1924,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
 ]
 
 [[package]]
@@ -1942,8 +1942,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
 ]
 
 [[package]]
@@ -1952,16 +1952,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
 ]
 
 [[package]]
@@ -1970,8 +1970,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -1982,8 +1982,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
  "serde",
  "serde_tuple",
 ]
@@ -1994,8 +1994,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
  "serde",
  "serde_tuple",
 ]
@@ -2151,8 +2151,8 @@ dependencies = [
  "frc42_hasher",
  "frc42_macros",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.0.0",
+ "fvm_shared 4.0.0",
  "thiserror",
 ]
 
@@ -2162,8 +2162,8 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a35e7214108f81cefc17b0466be01279f384faf913918a12dbc8528bb758a4"
 dependencies = [
- "fvm_sdk 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.0.0",
+ "fvm_shared 4.0.0",
  "thiserror",
 ]
 
@@ -2192,8 +2192,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
- "fvm_sdk 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.0.0",
+ "fvm_shared 4.0.0",
  "integer-encoding 4.0.0",
  "num-traits",
  "serde",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2339,7 +2339,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.0.0",
+ "fvm_shared 4.1.0",
  "lazy_static",
  "log",
  "minstant",
@@ -2372,7 +2372,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.0.0",
+ "fvm_shared 4.1.0",
  "hex",
 ]
 
@@ -2399,8 +2399,8 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.0.0",
+ "fvm_shared 4.0.0",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -2425,7 +2425,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.0.0",
+ "fvm_shared 4.1.0",
  "itertools 0.11.0",
  "ittapi-rs",
  "lazy_static",
@@ -2447,7 +2447,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.0.0",
+ "fvm_shared 4.1.0",
  "num-derive 0.4.1",
  "num-traits",
  "serde",
@@ -2456,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2470,8 +2470,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.0.0",
- "fvm_shared 4.0.0",
+ "fvm_sdk 4.1.0",
+ "fvm_shared 4.1.0",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2719,10 +2719,12 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258cfc9a2e5dcb28ffcadd4abed504893996d31238488a07ef7d2a6a6e80e1ec"
 dependencies = [
  "byteorder",
  "cid 0.10.1",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 4.0.0",
  "lazy_static",
  "log",
@@ -2732,52 +2734,16 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258cfc9a2e5dcb28ffcadd4abed504893996d31238488a07ef7d2a6a6e80e1ec"
+version = "4.1.0"
 dependencies = [
  "byteorder",
  "cid 0.10.1",
- "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.4.0",
+ "fvm_shared 4.1.0",
  "lazy_static",
  "log",
  "num-traits",
  "thiserror",
-]
-
-[[package]]
-name = "fvm_shared"
-version = "4.0.0"
-dependencies = [
- "anyhow",
- "arbitrary",
- "bitflags 2.4.1",
- "blake2b_simd",
- "bls-signatures",
- "cid 0.10.1",
- "data-encoding",
- "data-encoding-macro",
- "filecoin-proofs-api",
- "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.0.0",
- "lazy_static",
- "libsecp256k1",
- "multihash 0.18.1",
- "num-bigint",
- "num-derive 0.4.1",
- "num-integer",
- "num-traits",
- "quickcheck",
- "quickcheck_macros",
- "rand",
- "rand_chacha",
- "rusty-fork",
- "serde",
- "serde_json",
- "serde_tuple",
- "thiserror",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -2800,6 +2766,40 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+ "serde_tuple",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "fvm_shared"
+version = "4.1.0"
+dependencies = [
+ "anyhow",
+ "arbitrary",
+ "bitflags 2.4.1",
+ "blake2b_simd",
+ "bls-signatures",
+ "cid 0.10.1",
+ "data-encoding",
+ "data-encoding-macro",
+ "filecoin-proofs-api",
+ "fvm_ipld_encoding 0.4.0",
+ "fvm_shared 4.1.0",
+ "lazy_static",
+ "libsecp256k1",
+ "multihash 0.18.1",
+ "num-bigint",
+ "num-derive 0.4.1",
+ "num-integer",
+ "num-traits",
+ "quickcheck",
+ "quickcheck_macros",
+ "rand",
+ "rand_chacha",
+ "rusty-fork",
+ "serde",
+ "serde_json",
  "serde_tuple",
  "thiserror",
  "unsigned-varint",
@@ -5029,7 +5029,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
- "fvm_shared 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.0.0",
  "num-derive 0.3.3",
  "num-traits",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.0.0"
+version = "4.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,32 +4,40 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
-Default the concurrency of the `ThreadedExecutor` to the available parallelism instead of 8.
+## 4.1.0 [2023-01-24]
 
-## 4.0.0 (2023-10-31)
+- Default the concurrency of the `ThreadedExecutor` to the available parallelism instead of 8.
+- Support custom syscalls (only needed for non-Filecoin users).
+    - Filecoin now uses the `FilecoinKernel`, not the `DefaultKernel`. The `DefaultKernel` no longer implements Filecoin specific features.
+    - The `Kernel` trait now inherits from the `SyscallHandler` trait, allowing kernel's to decide how they want to expose themselves to actors via syscalls.
+- Many internal architecture cleanups with respect to the Kernel and syscall bindings.
+- Added the current actor state to the execution trace (in the `Invoke` event).
+- Add a syscall (enabled with the "upgrade-actor" feature flag) that lets actors "swap-out" their code-CID.
+
+## 4.0.0 [2023-10-31]
 
 Final release, no changes.
 
-## 4.0.0-alpha.4 (2023-09-28)
+## 4.0.0-alpha.4 [2023-09-28]
 
 - Add back some proof types that were mistakenly removed, and fix some of the constants.
 
-## 4.0.0-alpha.3 (2023-09-27)
+## 4.0.0-alpha.3 [2023-09-27]
 
 - Remove support for v1 proofs.
 - Make it possible to construct a GasDuration (and make it possible to refer to the GasDuration type).
 
-## 4.0.0-alpha.2 (2023-09-21)
+## 4.0.0-alpha.2 [2023-09-21]
 
 - Update to wasmtime 12.0.2 (bug fix release)
 - Drop support for versions prior to nv21.
 - Implement FIP-0071, FIP-0072, FIP-0073, FIP-0075
 
-## 4.0.0-alpha.1 (2023-09-20)
+## 4.0.0-alpha.1 [2023-09-20]
 
 Unreleased. This release simply marks the change-over to v4.
 
-## 3.8.0 (2023-09-06)
+## 3.8.0 [2023-09-06]
 
 - Upgrade wasmtime to v12. Unlike prior wasmtime upgrades, this shouldn't be a breaking change as it now mangles its symbols.
 - BREAKING: Upgrade the proofs API to v16.

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -9,7 +9,7 @@ Changes to the reference FVM implementation.
 - Default the concurrency of the `ThreadedExecutor` to the available parallelism instead of 8.
 - Support custom syscalls (only needed for non-Filecoin users).
     - Filecoin now uses the `FilecoinKernel`, not the `DefaultKernel`. The `DefaultKernel` no longer implements Filecoin specific features.
-    - The `Kernel` trait now inherits from the `SyscallHandler` trait, allowing kernel's to decide how they want to expose themselves to actors via syscalls.
+    - The `Kernel` trait now inherits from the `SyscallHandler` trait, allowing kernels to decide how they want to expose themselves to actors via syscalls.
 - Many internal architecture cleanups with respect to the Kernel and syscall bindings.
 - Added the current actor state to the execution trace (in the `Invoke` event).
 - Add a syscall (enabled with the "upgrade-actor" feature flag) that lets actors "swap-out" their code-CID.

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,23 +2,28 @@
 
 ## [Unreleased]
 
-## 4.0.0 (2023-10-31)
+## 4.1.0 [2023-01-24]
+
+- Add a syscall to upgrade the running actor's code-CID (behind the "actor-upgrade" feature flag).
+- Export the `fvm_syscalls` macro for defining syscall bindings (needed for custom syscall implementers).
+
+## 4.0.0 [2023-10-31]
 
 Final release, no changes.
 
-## 4.0.0-alpha.4 (2023-09-28)
+## 4.0.0-alpha.4 [2023-09-28]
 
 - Add back some proof types that were mistakenly removed, and fix some of the constants.
 
-## 4.0.0-alpha.3 (2023-09-27)
+## 4.0.0-alpha.3 [2023-09-27]
 
 - Remove support for v1 proofs.
 
-## 4.0.0-alpha.2 (2023-09-21)
+## 4.0.0-alpha.2 [2023-09-21]
 
 - Implement FIP-0071, FIP-0072, FIP-0073, FIP-0075
 
-## 4.0.0-alpha.1 (2023-09-20)
+## 4.0.0-alpha.1 [2023-09-20]
 
 Unreleased. This release simply marks the change-over to v4.
 

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,27 +2,33 @@
 
 ## [Unreleased]
 
-## 4.0.0 (2023-10-31)
+## 4.1.0 [2023-01-24]
+
+- Pretty-print addresses when debug-formatting, instead of printing the raw bytes as a vector.
+- Move the `ActorState` struct to this crate (from the `fvm` crate).
+- Add an `upgrade` module to this crate to support the new (disabled by default) actor-upgrade syscall.
+
+## 4.0.0 [2023-10-31]
 
 Final release, no changes.
 
-## 4.0.0-alpha.4 (2023-09-28)
+## 4.0.0-alpha.4 [2023-09-28]
 
 - Add back some proof types that were mistakenly removed, and fix some of the constants.
 
-## 4.0.0-alpha.3 (2023-09-27)
+## 4.0.0-alpha.3 [2023-09-27]
 
 - Remove support for v1 proofs.
 
-## 4.0.0-alpha.2 (2023-09-21)
+## 4.0.0-alpha.2 [2023-09-21]
 
 - Implement FIP-0071, FIP-0072, FIP-0073, FIP-0075
 
-## 4.0.0-alpha.1 (2023-09-20)
+## 4.0.0-alpha.1 [2023-09-20]
 
 Unreleased. This release simply marks the change-over to v4.
 
-## 3.6.0 (2023-09-06)
+## 3.6.0 [2023-09-06]
 
 - BREAKING: Upgrade the proofs API to v16.
 - BREAKING (linking): upgrade blstrs to v0.7 and


### PR DESCRIPTION
This is a v4.1 because it's not a network-breaking change.