### PR TITLE
fix: build: add versions to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,18 +74,18 @@ quickcheck_macros = "1.0.0"
 minstant = "0.1.3"
 
 # workspace
-fvm = { path = "fvm", default-features = false }
-fvm_shared = { path = "shared",  default-features = false }
-fvm_sdk = { path = "sdk" }
-fvm_ipld_amt = { path = "ipld/amt" }
-fvm_ipld_hamt = { path = "ipld/hamt" }
-fvm_ipld_kamt = { path = "ipld/kamt" }
-fvm_ipld_car = { path = "ipld/car" }
-fvm_ipld_blockstore = { path = "ipld/blockstore" }
-fvm_ipld_bitfield = { path = "ipld/bitfield" }
-fvm_ipld_encoding = { path = "ipld/encoding" }
+fvm = { path = "fvm", version = "~4.1.0", default-features = false }
+fvm_shared = { path = "shared", version = "~4.1.0", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.1.0" }
+fvm_ipld_amt = { path = "ipld/amt", versino = "0.6.2" }
+fvm_ipld_hamt = { path = "ipld/hamt", version = "0.9.0" }
+fvm_ipld_kamt = { path = "ipld/kamt", version = "0.3.0" }
+fvm_ipld_car = { path = "ipld/car", version = "0.7.1" }
+fvm_ipld_blockstore = { path = "ipld/blockstore", version = "0.2.0" }
+fvm_ipld_bitfield = { path = "ipld/bitfield", version = "0.6.0" }
+fvm_ipld_encoding = { path = "ipld/encoding", version = "0.4.0" }
+fvm_integration_tests = { path = "testing/integration", version = "~4.1.0" }
 fvm_gas_calibration_shared = { path = "testing/calibration/shared" }
-fvm_integration_tests = { path = "testing/integration" }
 fvm_test_actors = { path = "testing/test_actors" }
 
 [profile.actor]


### PR DESCRIPTION
Unfortunately, cargo requires these to publish (for now).