### PR TITLE
fix: build: use path dependencies for "self" imports

### DIFF
--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -48,7 +48,7 @@ static_assertions = "1.1.0"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"
-fvm = { workspace = true, features = ["testing"], default-features = false }
+fvm = { path = ".", features = ["testing"], default-features = false }
 
 [features]
 default = ["opencl"]

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -41,7 +41,7 @@ rand = { workspace = true }
 serde_json = { workspace = true }
 multihash = { workspace = true, features = ["multihash-impl", "sha2", "sha3", "ripemd"] }
 quickcheck_macros = { workspace = true }
-fvm_shared = { workspace = true, features = ["arb"] }
+fvm_shared = { path = ".", features = ["arb"] }
 rand_chacha = { workspace = true }
 rusty-fork = { version = "0.3.0", default-features = false }
 


### PR DESCRIPTION
When importing "self" as a dev-dependency (used to specify additional features when testing), we need to _not_ specify a version. Otherwise, cargo gets touchy when we try to publish because, obviously, that version hasn't yet been released (BECAUSE WE'RE CURRENTLY RELEASING IT!).