### PR TITLE
chore: release fvm 4.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.0",
+ "fvm_shared 4.1.1",
  "libfuzzer-sys",
  "multihash 0.18.1",
  "rand",
@@ -1786,8 +1786,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
 ]
 
 [[package]]
@@ -1823,8 +1823,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
 ]
 
 [[package]]
@@ -1833,8 +1833,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1845,8 +1845,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
  "serde",
  "serde_tuple",
 ]
@@ -1856,8 +1856,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
 ]
 
 [[package]]
@@ -1868,8 +1868,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
  "libipld",
  "num-derive 0.4.1",
  "num-traits",
@@ -1881,8 +1881,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
  "log",
  "serde",
  "serde_tuple",
@@ -1892,8 +1892,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
 ]
 
 [[package]]
@@ -1904,8 +1904,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
  "serde",
  "serde_tuple",
 ]
@@ -1915,8 +1915,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
  "minicov",
 ]
 
@@ -1924,16 +1924,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
 ]
 
 [[package]]
@@ -1942,8 +1942,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
 ]
 
 [[package]]
@@ -1952,16 +1952,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
 ]
 
 [[package]]
@@ -1970,8 +1970,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -1982,8 +1982,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
  "serde",
  "serde_tuple",
 ]
@@ -1994,8 +1994,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
  "serde",
  "serde_tuple",
 ]
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2339,7 +2339,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.1.0",
+ "fvm_shared 4.1.1",
  "lazy_static",
  "log",
  "minstant",
@@ -2372,7 +2372,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.0",
+ "fvm_shared 4.1.1",
  "hex",
 ]
 
@@ -2425,7 +2425,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.0",
+ "fvm_shared 4.1.1",
  "itertools 0.11.0",
  "ittapi-rs",
  "lazy_static",
@@ -2447,7 +2447,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.1.0",
+ "fvm_shared 4.1.1",
  "num-derive 0.4.1",
  "num-traits",
  "serde",
@@ -2456,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2470,8 +2470,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.0",
- "fvm_shared 4.1.0",
+ "fvm_sdk 4.1.1",
+ "fvm_shared 4.1.1",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2734,12 +2734,12 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "byteorder",
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.0",
+ "fvm_shared 4.1.1",
  "lazy_static",
  "log",
  "num-traits",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2785,7 +2785,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.0",
+ "fvm_shared 4.1.1",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.1.0"
+version = "4.1.1"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -74,9 +74,9 @@ quickcheck_macros = "1.0.0"
 minstant = "0.1.3"
 
 # workspace
-fvm = { path = "fvm", version = "~4.1.0", default-features = false }
-fvm_shared = { path = "shared", version = "~4.1.0", default-features = false }
-fvm_sdk = { path = "sdk", version = "~4.1.0" }
+fvm = { path = "fvm", version = "~4.1.1", default-features = false }
+fvm_shared = { path = "shared", version = "~4.1.1", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.1.1" }
 fvm_ipld_amt = { path = "ipld/amt", version = "0.6.2" }
 fvm_ipld_hamt = { path = "ipld/hamt", version = "0.9.0" }
 fvm_ipld_kamt = { path = "ipld/kamt", version = "0.3.0" }
@@ -84,7 +84,7 @@ fvm_ipld_car = { path = "ipld/car", version = "0.7.1" }
 fvm_ipld_blockstore = { path = "ipld/blockstore", version = "0.2.0" }
 fvm_ipld_bitfield = { path = "ipld/bitfield", version = "0.6.0" }
 fvm_ipld_encoding = { path = "ipld/encoding", version = "0.4.0" }
-fvm_integration_tests = { path = "testing/integration", version = "~4.1.0" }
+fvm_integration_tests = { path = "testing/integration", version = "~4.1.1" }
 fvm_gas_calibration_shared = { path = "testing/calibration/shared" }
 fvm_test_actors = { path = "testing/test_actors" }
 

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.1.1 [2023-01-25]
+
+Enable nv22 support by default.
+
 ## 4.1.0 [2023-01-24]
 
 - Default the concurrency of the `ThreadedExecutor` to the available parallelism instead of 8.

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 4.1.1 [2023-01-25]
+
+Enable nv22 support by default.
+
 ## 4.1.0 [2023-01-24]
 
 - Add a syscall to upgrade the running actor's code-CID (behind the "actor-upgrade" feature flag).

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 4.1.1 [2023-01-25]
+
+Enable nv22 support by default.
+
 ## 4.1.0 [2023-01-24]
 
 - Pretty-print addresses when debug-formatting, instead of printing the raw bytes as a vector.


### PR DESCRIPTION
Enables nv22 support by default.