### PR TITLE
feat: kamt: deprecate kamt for_each

### DIFF
--- a/ipld/kamt/benches/kamt_benchmark.rs
+++ b/ipld/kamt/benches/kamt_benchmark.rs
@@ -118,6 +118,7 @@ fn for_each(c: &mut Criterion) {
     c.bench_function("KAMT for_each function", |b| {
         b.iter(|| {
             let a = BKamt::load_with_config(&cid, &db, TEST_CONFIG).unwrap();
+            #[allow(deprecated)]
             black_box(a).for_each(|_k, _v: &BenchData| Ok(())).unwrap();
         })
     });

--- a/ipld/kamt/src/kamt.rs
+++ b/ipld/kamt/src/kamt.rs
@@ -348,6 +348,7 @@ where
     /// assert_eq!(total, 3);
     /// ```
     #[inline]
+    #[deprecated = "use `.iter()` instead"]
     pub fn for_each<F>(&self, mut f: F) -> Result<(), Error>
     where
         V: DeserializeOwned,

--- a/ipld/kamt/tests/kamt_tests.rs
+++ b/ipld/kamt/tests/kamt_tests.rs
@@ -140,6 +140,7 @@ fn for_each(factory: KamtFactory) {
     // Iterating through kamt with dirty caches.
     let mut sum = 0;
     let expected_sum = 199 * 200 / 2;
+    #[allow(deprecated)]
     kamt.for_each(|k, v| {
         assert_eq!(*k as i32, *v);
         sum += v;
@@ -154,6 +155,7 @@ fn for_each(factory: KamtFactory) {
 
     // Iterating through kamt with no cache.
     let mut sum = 0;
+    #[allow(deprecated)]
     kamt.for_each(|_, v| {
         sum += v;
         Ok(())
@@ -163,6 +165,7 @@ fn for_each(factory: KamtFactory) {
 
     // Iterating through kamt with cached nodes.
     let mut sum = 0;
+    #[allow(deprecated)]
     kamt.for_each(|_, v| {
         sum += v;
         Ok(())


### PR DESCRIPTION
I was going to leave this and deprecate it later, but we're making other braking changes anyways (to the error type).