### PR TITLE
feat: kamt: remove "ignore dead links" feature

### DIFF
--- a/ipld/kamt/Cargo.toml
+++ b/ipld/kamt/Cargo.toml
@@ -19,10 +19,6 @@ fvm_ipld_encoding = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 forest_hash_utils = "0.1"
 
-[features]
-# This feature should just be used for testing (ignoring links that don't exist in store)
-ignore-dead-links = []
-
 [dev-dependencies]
 hex = { workspace = true }
 criterion = { workspace = true }

--- a/ipld/kamt/src/iter.rs
+++ b/ipld/kamt/src/iter.rs
@@ -65,11 +65,7 @@ where
                                 if let Some(node) = store.get_cbor::<Node<K, V, H, N>>(cid)? {
                                     node
                                 } else {
-                                    #[cfg(not(feature = "ignore-dead-links"))]
                                     return Err(Error::CidNotFound(cid.to_string()));
-
-                                    #[cfg(feature = "ignore-dead-links")]
-                                    continue;
                                 };
 
                             // Ignore error intentionally, the cache value will always be the same
@@ -122,10 +118,7 @@ where
                     } else {
                         let node = match self.store.get_cbor::<Node<K, V, H, N>>(cid) {
                             Ok(Some(node)) => node,
-                            #[cfg(not(feature = "ignore-dead-links"))]
                             Ok(None) => return Some(Err(Error::CidNotFound(cid.to_string()))),
-                            #[cfg(feature = "ignore-dead-links")]
-                            Ok(None) => continue,
                             Err(err) => return Some(Err(err.into())),
                         };
 

--- a/ipld/kamt/src/node.rs
+++ b/ipld/kamt/src/node.rs
@@ -217,11 +217,7 @@ where
                     let node: Box<Node<K, V, H, N>> = if let Some(node) = store.get_cbor(cid)? {
                         node
                     } else {
-                        #[cfg(not(feature = "ignore-dead-links"))]
                         return Err(Error::CidNotFound(cid.to_string()));
-
-                        #[cfg(feature = "ignore-dead-links")]
-                        return Ok(None);
                     };
                     // Intentionally ignoring error, cache will always be the same.
                     cache.get_or_init(|| node)


### PR DESCRIPTION
It was unused and we've removed it from the HAMT as well.