### PR TITLE
Backport FVMv4 tracing changes to v3

### DIFF
--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -660,7 +660,10 @@ where
             .ok_or_else(|| syscall_error!(NotFound; "actor does not exist: {}", to))?;
 
         if self.machine.context().tracing {
-            self.trace(ExecutionEvent::InvokeActor(state.code));
+            self.trace(ExecutionEvent::InvokeActor {
+                id: to,
+                state: state.clone(),
+            });
         }
 
         // Transfer, if necessary.

--- a/fvm/src/trace/mod.rs
+++ b/fvm/src/trace/mod.rs
@@ -8,7 +8,7 @@ use fvm_shared::{ActorID, MethodNum};
 
 use crate::gas::GasCharge;
 use crate::kernel::SyscallError;
-use crate::Cid;
+use crate::state_tree::ActorState;
 
 /// Execution Trace, only for informational and debugging purposes.
 pub type ExecutionTrace = Vec<ExecutionEvent>;
@@ -33,6 +33,9 @@ pub enum ExecutionEvent {
     },
     CallReturn(ExitCode, Option<IpldBlock>),
     CallError(SyscallError),
-    /// Emitted every time we successfully invoke an actor
-    InvokeActor(Cid),
+    /// Emitted every time an actor is successfully invoked.
+    InvokeActor {
+        id: ActorID,
+        state: ActorState,
+    },
 }


### PR DESCRIPTION
FVMv3 exposed actor code-CIDs in traces, but v4 now exposes the entire invoked actor. This patch backports the FVMv4 logic to v3.

However, note: this change is slightly simplified. FVMv3 has a bug where we might include _multiple_ invoke events for the same actor if, e.g., we had to implicitly create it. This was fixed in FVMv4 but that fix has _not_ been backported. In practice, this shouldn't cause any issues in FVMv3 as long as the _last_ invoke event is used (which is how the filecoin-ffi library handles this).