### PR TITLE
chore: fvm: remove another lazy_static

### DIFF
--- a/ipld/blockstore/src/block.rs
+++ b/ipld/blockstore/src/block.rs
@@ -1,10 +1,12 @@
+use std::fmt;
+
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use cid::multihash::{self, MultihashDigest};
 use cid::Cid;
 
 /// Block represents a typed (i.e., with codec) IPLD block.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct Block<D>
 where
     D: AsRef<[u8]> + ?Sized,
@@ -17,7 +19,7 @@ impl<D> Block<D>
 where
     D: AsRef<[u8]> + ?Sized,
 {
-    pub fn new(codec: u64, data: D) -> Self
+    pub const fn new(codec: u64, data: D) -> Self
     where
         Self: Sized,
         D: Sized,
@@ -32,6 +34,31 @@ where
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.data.as_ref().len()
+    }
+}
+
+// Manually implement PartialEq/Eq so we can compare across blocks with different backing buffers.
+impl<D1, D2> PartialEq<Block<D2>> for Block<D1>
+where
+    D1: AsRef<[u8]>,
+    D2: AsRef<[u8]>,
+{
+    fn eq(&self, other: &Block<D2>) -> bool {
+        self.codec == other.codec && self.data.as_ref() == other.data.as_ref()
+    }
+}
+impl<D> Eq for Block<D> where D: AsRef<[u8]> {}
+
+// Manually implement debug so we get the same result regardless of the backing buff for data.
+impl<D> fmt::Debug for Block<D>
+where
+    D: AsRef<[u8]>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Block")
+            .field("codec", &self.codec)
+            .field("data", &self.data.as_ref())
+            .finish()
     }
 }
 


### PR DESCRIPTION
We can pre-compute the "empty" block and avoid a lazy static. It matters less here because we're not inside an actor (so we'd only compute this once on start anyways, but I'm trying to reduce our usage of lazy_static to the minimum.