### PR TITLE
feat: fvm: remove once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,7 +2353,6 @@ dependencies = [
  "minstant",
  "multihash 0.18.1",
  "num-traits",
- "once_cell",
  "pretty_assertions",
  "quickcheck",
  "rand",

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -32,7 +32,6 @@ log = { workspace = true }
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
 rand = { workspace = true }
 quickcheck = { workspace = true, optional = true }
-once_cell = { workspace = true }
 minstant = { workspace = true }
 blake2b_simd = { workspace = true }
 byteorder = { workspace = true }

--- a/fvm/src/gas/timer.rs
+++ b/fvm/src/gas/timer.rs
@@ -1,14 +1,13 @@
 use std::fmt;
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use minstant::Instant;
-use once_cell::sync::OnceCell;
 
 /// Shared reference between the duration and the timer.
-type DurationCell = Arc<OnceCell<Duration>>;
+type DurationCell = Arc<OnceLock<Duration>>;
 
 /// Data structure to encapsulate the optional duration which is set by the `GasTimer`.
 ///
@@ -115,7 +114,7 @@ impl GasTimer {
         }
     }
 
-    fn set_elapsed(elapsed: Arc<OnceCell<Duration>>, start: GasInstant) {
+    fn set_elapsed(elapsed: Arc<OnceLock<Duration>>, start: GasInstant) {
         elapsed
             .set(start.elapsed())
             .expect("GasCharge::elapsed already set!")


### PR DESCRIPTION
We still need this crate in the IPLD datastructures because we use
`get_or_try_init`, but we don't need it in the FVM proper.