### PR TITLE
chore: remove ahash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -3111,7 +3110,6 @@ dependencies = [
 name = "ipld_amt_fuzz"
 version = "0.0.0"
 dependencies = [
- "ahash",
  "arbitrary",
  "cid 0.10.1",
  "fvm_ipld_amt 0.6.2",
@@ -3124,7 +3122,6 @@ dependencies = [
 name = "ipld_hamt-fuzz"
 version = "0.0.0"
 dependencies = [
- "ahash",
  "arbitrary",
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_hamt 0.9.0",
@@ -3135,7 +3132,6 @@ dependencies = [
 name = "ipld_kamt-fuzz"
 version = "0.0.0"
 dependencies = [
- "ahash",
  "arbitrary",
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_kamt 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ wasmtime-runtime = { version = "12.0.2", default-features = false }
 # misc
 libfuzzer-sys = "0.4"
 arbitrary = "1.3.0"
-ahash = "0.8.7"
 itertools = "0.11.0"
 once_cell = "1.18.0"
 unsigned-varint = "0.7.2"

--- a/ipld/amt/fuzz/Cargo.toml
+++ b/ipld/amt/fuzz/Cargo.toml
@@ -11,7 +11,6 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
-ahash = { workspace = true }
 itertools = { workspace = true }
 
 cid = { workspace = true, features = ["serde-codec", "arb", "std"] }

--- a/ipld/amt/fuzz/fuzz_targets/equivalence.rs
+++ b/ipld/amt/fuzz/fuzz_targets/equivalence.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![no_main]
+use std::collections::HashMap;
+
 use arbitrary::Arbitrary;
 use cid::Cid;
 use fvm_ipld_amt::Amt;
@@ -22,10 +24,10 @@ enum Method {
     Remove,
     Get,
 }
-fn execute(ops: Vec<Operation>) -> (Cid, ahash::AHashMap<u64, u64>) {
+fn execute(ops: Vec<Operation>) -> (Cid, HashMap<u64, u64>) {
     let db = fvm_ipld_blockstore::MemoryBlockstore::default();
     let mut amt = Amt::new(&db);
-    let mut elements = ahash::AHashMap::new();
+    let mut elements = HashMap::new();
 
     for (i, Operation { idx, method, flush }) in ops.into_iter().enumerate() {
         let idx = idx as u64;

--- a/ipld/hamt/fuzz/Cargo.toml
+++ b/ipld/hamt/fuzz/Cargo.toml
@@ -11,7 +11,6 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
-ahash = { workspace = true }
 
 fvm_ipld_hamt = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/ipld/hamt/fuzz/fuzz_targets/common.rs
+++ b/ipld/hamt/fuzz/fuzz_targets/common.rs
@@ -2,6 +2,8 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::collections::HashMap;
+
 use arbitrary::Arbitrary;
 use fvm_ipld_hamt::{Config, Hamt};
 
@@ -21,7 +23,7 @@ pub enum Method {
 pub fn run(flush_rate: u8, operations: Vec<Operation>, conf: Config) {
     let db = fvm_ipld_blockstore::MemoryBlockstore::default();
     let mut hamt = Hamt::<_, _, _>::new_with_config(&db, conf);
-    let mut elements = ahash::AHashMap::new();
+    let mut elements = HashMap::new();
 
     let flush_rate = (flush_rate as usize).saturating_add(5);
     for (i, Operation { key, method }) in operations.into_iter().enumerate() {

--- a/ipld/kamt/fuzz/Cargo.toml
+++ b/ipld/kamt/fuzz/Cargo.toml
@@ -11,7 +11,6 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
-ahash = { workspace = true }
 
 fvm_ipld_kamt = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/ipld/kamt/fuzz/fuzz_targets/common.rs
+++ b/ipld/kamt/fuzz/fuzz_targets/common.rs
@@ -2,6 +2,8 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::collections::HashMap;
+
 use arbitrary::Arbitrary;
 use fvm_ipld_kamt::id::Identity;
 use fvm_ipld_kamt::{Config, Kamt};
@@ -22,7 +24,7 @@ pub enum Method {
 pub fn run(flush_rate: u8, operations: Vec<Operation>, conf: Config) {
     let db = fvm_ipld_blockstore::MemoryBlockstore::default();
     let mut kamt = Kamt::<_, u64, u64, Identity>::new_with_config(&db, conf);
-    let mut elements = ahash::AHashMap::new();
+    let mut elements = HashMap::new();
 
     let flush_rate = (flush_rate as usize).saturating_add(5);
     for (i, Operation { key, method }) in operations.into_iter().enumerate() {


### PR DESCRIPTION
We don't really have a good reason to use it, so we might as well stick
to the standard `HashMap`.