### PR TITLE
chore: release fvm 4.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.2",
+ "fvm_shared 4.1.3",
  "libfuzzer-sys",
  "multihash 0.18.1",
  "rand",
@@ -1775,8 +1775,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
 ]
 
 [[package]]
@@ -1812,8 +1812,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
 ]
 
 [[package]]
@@ -1822,8 +1822,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1834,8 +1834,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
  "serde",
  "serde_tuple",
 ]
@@ -1845,8 +1845,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
 ]
 
 [[package]]
@@ -1857,8 +1857,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
  "libipld",
  "num-derive 0.4.1",
  "num-traits",
@@ -1870,8 +1870,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
  "log",
  "serde",
  "serde_tuple",
@@ -1881,8 +1881,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
 ]
 
 [[package]]
@@ -1893,8 +1893,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
  "serde",
  "serde_tuple",
 ]
@@ -1904,8 +1904,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
  "minicov",
 ]
 
@@ -1913,16 +1913,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
 ]
 
 [[package]]
@@ -1931,8 +1931,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
 ]
 
 [[package]]
@@ -1941,16 +1941,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
 ]
 
 [[package]]
@@ -1959,8 +1959,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -1971,8 +1971,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
  "serde",
  "serde_tuple",
 ]
@@ -1983,8 +1983,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
  "serde",
  "serde_tuple",
 ]
@@ -2312,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2327,7 +2327,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.1.2",
+ "fvm_shared 4.1.3",
  "lazy_static",
  "log",
  "minstant",
@@ -2358,7 +2358,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.2",
+ "fvm_shared 4.1.3",
  "hex",
 ]
 
@@ -2411,7 +2411,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.2",
+ "fvm_shared 4.1.3",
  "itertools 0.11.0",
  "ittapi-rs",
  "lazy_static",
@@ -2432,7 +2432,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.1.2",
+ "fvm_shared 4.1.3",
  "num-derive 0.4.1",
  "num-traits",
  "serde",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2455,8 +2455,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.2",
- "fvm_shared 4.1.2",
+ "fvm_sdk 4.1.3",
+ "fvm_shared 4.1.3",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2719,11 +2719,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.2",
+ "fvm_shared 4.1.3",
  "lazy_static",
  "log",
  "num-traits",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2770,7 +2770,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.2",
+ "fvm_shared 4.1.3",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.3",
+ "fvm_shared 4.2.0",
  "libfuzzer-sys",
  "multihash 0.18.1",
  "rand",
@@ -1775,8 +1775,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
 ]
 
 [[package]]
@@ -1812,8 +1812,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
 ]
 
 [[package]]
@@ -1822,8 +1822,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1834,8 +1834,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
  "serde",
  "serde_tuple",
 ]
@@ -1845,8 +1845,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
 ]
 
 [[package]]
@@ -1857,8 +1857,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
  "libipld",
  "num-derive 0.4.1",
  "num-traits",
@@ -1870,8 +1870,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
  "log",
  "serde",
  "serde_tuple",
@@ -1881,8 +1881,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
 ]
 
 [[package]]
@@ -1893,8 +1893,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
  "serde",
  "serde_tuple",
 ]
@@ -1904,8 +1904,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
  "minicov",
 ]
 
@@ -1913,16 +1913,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
 ]
 
 [[package]]
@@ -1931,8 +1931,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
 ]
 
 [[package]]
@@ -1941,16 +1941,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
 ]
 
 [[package]]
@@ -1959,8 +1959,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -1971,8 +1971,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
  "serde",
  "serde_tuple",
 ]
@@ -1983,8 +1983,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
  "serde",
  "serde_tuple",
 ]
@@ -2312,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.1.3"
+version = "4.2.0"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2327,7 +2327,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.1.3",
+ "fvm_shared 4.2.0",
  "lazy_static",
  "log",
  "minstant",
@@ -2358,7 +2358,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.3",
+ "fvm_shared 4.2.0",
  "hex",
 ]
 
@@ -2411,7 +2411,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.3",
+ "fvm_shared 4.2.0",
  "itertools 0.11.0",
  "ittapi-rs",
  "lazy_static",
@@ -2432,7 +2432,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.1.3",
+ "fvm_shared 4.2.0",
  "num-derive 0.4.1",
  "num-traits",
  "serde",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.1.3"
+version = "4.2.0"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2455,8 +2455,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.1.3",
- "fvm_shared 4.1.3",
+ "fvm_sdk 4.2.0",
+ "fvm_shared 4.2.0",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2719,11 +2719,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.1.3"
+version = "4.2.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.3",
+ "fvm_shared 4.2.0",
  "lazy_static",
  "log",
  "num-traits",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.1.3"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2770,7 +2770,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.1.3",
+ "fvm_shared 4.2.0",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.1.2"
+version = "4.1.3"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -74,9 +74,9 @@ minstant = "0.1.3"
 coverage-helper = "0.2.0"
 
 # workspace
-fvm = { path = "fvm", version = "~4.1.2", default-features = false }
-fvm_shared = { path = "shared", version = "~4.1.2", default-features = false }
-fvm_sdk = { path = "sdk", version = "~4.1.2" }
+fvm = { path = "fvm", version = "~4.1.3", default-features = false }
+fvm_shared = { path = "shared", version = "~4.1.3", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.1.3" }
 fvm_ipld_amt = { path = "ipld/amt", version = "0.6.2" }
 fvm_ipld_hamt = { path = "ipld/hamt", version = "0.9.0" }
 fvm_ipld_kamt = { path = "ipld/kamt", version = "0.3.0" }
@@ -84,7 +84,7 @@ fvm_ipld_car = { path = "ipld/car", version = "0.7.1" }
 fvm_ipld_blockstore = { path = "ipld/blockstore", version = "0.2.0" }
 fvm_ipld_bitfield = { path = "ipld/bitfield", version = "0.6.0" }
 fvm_ipld_encoding = { path = "ipld/encoding", version = "0.4.0" }
-fvm_integration_tests = { path = "testing/integration", version = "~4.1.2" }
+fvm_integration_tests = { path = "testing/integration", version = "~4.1.3" }
 fvm_gas_calibration_shared = { path = "testing/calibration/shared" }
 fvm_test_actors = { path = "testing/test_actors" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.1.3"
+version = "4.2.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -74,9 +74,9 @@ minstant = "0.1.3"
 coverage-helper = "0.2.0"
 
 # workspace
-fvm = { path = "fvm", version = "~4.1.3", default-features = false }
-fvm_shared = { path = "shared", version = "~4.1.3", default-features = false }
-fvm_sdk = { path = "sdk", version = "~4.1.3" }
+fvm = { path = "fvm", version = "~4.2.0", default-features = false }
+fvm_shared = { path = "shared", version = "~4.2.0", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.2.0" }
 fvm_ipld_amt = { path = "ipld/amt", version = "0.6.2" }
 fvm_ipld_hamt = { path = "ipld/hamt", version = "0.9.0" }
 fvm_ipld_kamt = { path = "ipld/kamt", version = "0.3.0" }
@@ -84,7 +84,7 @@ fvm_ipld_car = { path = "ipld/car", version = "0.7.1" }
 fvm_ipld_blockstore = { path = "ipld/blockstore", version = "0.2.0" }
 fvm_ipld_bitfield = { path = "ipld/bitfield", version = "0.6.0" }
 fvm_ipld_encoding = { path = "ipld/encoding", version = "0.4.0" }
-fvm_integration_tests = { path = "testing/integration", version = "~4.1.3" }
+fvm_integration_tests = { path = "testing/integration", version = "~4.2.0" }
 fvm_gas_calibration_shared = { path = "testing/calibration/shared" }
 fvm_test_actors = { path = "testing/test_actors" }
 

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -6,10 +6,10 @@ Changes to the reference FVM implementation.
 
 ## 4.2.0 [2023-04-29]
 
-- chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/fvm/pull/1993)
-- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/fvm/pull/2000)
-- feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/fvm/pull/1989)
-- feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/fvm/pull/1984)
+- chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/ref-fvm/pull/1993)
+- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/ref-fvm/pull/2000)
+- feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/ref-fvm/pull/1989)
+- feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/ref-fvm/pull/1984)
 
 ## 4.1.2 [2023-01-31]
 

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,13 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.1.3 [2023-04-29]
+
+- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/fvm/pull/2000)
+- chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/fvm/pull/1993)
+- feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/fvm/pull/1989)
+- feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/fvm/pull/1984)
+
 ## 4.1.2 [2023-01-31]
 
 feat: allow CBOR events

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,10 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
-## 4.1.3 [2023-04-29]
+## 4.2.0 [2023-04-29]
 
-- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/fvm/pull/2000)
 - chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/fvm/pull/1993)
+- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/fvm/pull/2000)
 - feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/fvm/pull/1989)
 - feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/fvm/pull/1984)
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## [Unreleased]
 
-## 4.1.3 [2023-04-29]
+## 4.2.0 [2023-04-29]
 
-- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/fvm/pull/2000)
 - chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/fvm/pull/1993)
+- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/fvm/pull/2000)
 - feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/fvm/pull/1989)
 - feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/fvm/pull/1984)
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## 4.1.3 [2023-04-29]
+
+- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/fvm/pull/2000)
+- chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/fvm/pull/1993)
+- feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/fvm/pull/1989)
+- feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/fvm/pull/1984)
+
 ## 4.1.2 [2023-01-31]
 
 feat: allow CBOR events

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ## 4.2.0 [2023-04-29]
 
-- chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/fvm/pull/1993)
-- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/fvm/pull/2000)
-- feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/fvm/pull/1989)
-- feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/fvm/pull/1984)
+- chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/ref-fvm/pull/1993)
+- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/ref-fvm/pull/2000)
+- feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/ref-fvm/pull/1989)
+- feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/ref-fvm/pull/1984)
 
 ## 4.1.2 [2023-01-31]
 

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## [Unreleased]
 
-## 4.1.3 [2023-04-29]
+## 4.2.0 [2023-04-29]
 
-- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/fvm/pull/2000)
 - chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/fvm/pull/1993)
+- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/fvm/pull/2000)
 - feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/fvm/pull/1989)
 - feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/fvm/pull/1984)
 

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## 4.1.3 [2023-04-29]
+
+- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/fvm/pull/2000)
+- chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/fvm/pull/1993)
+- feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/fvm/pull/1989)
+- feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/fvm/pull/1984)
+
 ## 4.1.2 [2023-01-31]
 
 feat: allow CBOR events

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ## 4.2.0 [2023-04-29]
 
-- chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/fvm/pull/1993)
-- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/fvm/pull/2000)
-- feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/fvm/pull/1989)
-- feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/fvm/pull/1984)
+- chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/ref-fvm/pull/1993)
+- Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/ref-fvm/pull/2000)
+- feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/ref-fvm/pull/1989)
+- feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/ref-fvm/pull/1984)
 
 ## 4.1.2 [2023-01-31]
 


### PR DESCRIPTION
Bump FVM-release to unblock the nv23-skeleton: https://github.com/filecoin-project/filecoin-ffi/pull/452#issuecomment-2063465057