### PR TITLE
feat: FIP-0079: syscall for aggregated bls verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        name: [build, check-m2-native, check-clippy, test-fvm, test, integration, conformance, calibration]
+        name: [build, check-m2-native, check-clippy, check-clippy-verify-signature, test-fvm, test, integration, conformance, calibration]
         include:
           - name: build
             key: v3
@@ -47,11 +47,11 @@ jobs:
             command: clippy
             # we disable default features because rust will otherwise unify them and turn on opencl in CI.
             args: --all --all-targets --no-default-features
-          - name: check-clippy(no-verify-signature)
+          - name: check-clippy-verify-signature
             key: v3
             command: clippy
             # we disable default features because rust will otherwise unify them and turn on opencl in CI.
-            args: --all --all-targets --no-default-features --features no-verify-signature
+            args: --all --all-targets --no-default-features --features verify-signature
           - name: test-fvm
             key: v3-cov
             push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
             command: clippy
             # we disable default features because rust will otherwise unify them and turn on opencl in CI.
             args: --all --all-targets --no-default-features
+          - name: check-clippy(no-verify-signature)
+            key: v3
+            command: clippy
+            # we disable default features because rust will otherwise unify them and turn on opencl in CI.
+            args: --all --all-targets --no-default-features --features no-verify-signature
           - name: test-fvm
             key: v3-cov
             push: true

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -48,7 +48,7 @@ fvm = { path = ".", features = ["testing"], default-features = false }
 coverage-helper = { workspace = true }
 
 [features]
-default = ["opencl"]
+default = ["opencl", "verify-signature"]
 opencl = ["filecoin-proofs-api/opencl"]
 cuda = ["filecoin-proofs-api/cuda"]
 cuda-supraseal = ["filecoin-proofs-api/cuda-supraseal"]
@@ -58,7 +58,7 @@ m2-native = []
 upgrade-actor = []
 gas_calibration = []
 nv23-dev = []
-# Use this feature to remove `verify_signature` syscall that is supposed to be removed by FIP-0079,
+# Use this feature to keep `verify_signature` syscall that is supposed to be removed by FIP-0079,
 # The current implementation keeps it by default for backward compatibility reason.
 # See <https://github.com/filecoin-project/ref-fvm/issues/2001>
-no-verify-signature = []
+verify-signature = []

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -58,3 +58,7 @@ m2-native = []
 upgrade-actor = []
 gas_calibration = []
 nv23-dev = []
+# Use this feature to remove `verify_signature` syscall that is supposed to be removed by FIP-0079,
+# The current implementation keeps it by default for backward compatibility reason.
+# See <https://github.com/filecoin-project/ref-fvm/issues/2001>
+no-verify-signature = []

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -7,6 +7,7 @@ use std::ops::Mul;
 
 use anyhow::Context;
 use fvm_shared::clock::ChainEpoch;
+#[cfg(feature = "verify-signature")]
 use fvm_shared::crypto::signature::SignatureType;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::{
@@ -102,6 +103,7 @@ lazy_static! {
         address_lookup: Gas::new(1_050_000),
         address_assignment: Gas::new(1_000_000),
 
+        #[cfg(feature = "verify-signature")]
         sig_cost: total_enum_map!{
             SignatureType {
                 Secp256k1 => ScalingCost {
@@ -404,6 +406,7 @@ pub struct PriceList {
     pub(crate) actor_create_storage: Gas,
 
     /// Gas cost for verifying a cryptographic signature.
+    #[cfg(feature = "verify-signature")]
     pub(crate) sig_cost: HashMap<SignatureType, ScalingCost>,
 
     /// Gas cost for recovering secp256k1 signer public key
@@ -599,6 +602,7 @@ impl PriceList {
     }
 
     /// Returns gas required for signature verification.
+    #[cfg(feature = "verify-signature")]
     #[inline]
     pub fn on_verify_signature(&self, sig_type: SignatureType, data_len: usize) -> GasCharge {
         let cost = self.sig_cost[&sig_type];

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -573,7 +573,7 @@ impl<C> CryptoOps for DefaultKernel<C>
 where
     C: CallManager,
 {
-    #[cfg(not(feature = "no-verify-signature"))]
+    #[cfg(feature = "verify-signature")]
     fn verify_signature(
         &self,
         sig_type: SignatureType,

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -232,6 +232,22 @@ pub trait CryptoOps {
         plaintext: &[u8],
     ) -> Result<bool>;
 
+    /// Verifies a BLS aggregate signature. In the case where there is one signer/signed plaintext,
+    /// this is equivalent to verifying a non-aggregated BLS signature.
+    ///
+    /// Returns:
+    /// - `Ok(true)` on a valid signature.
+    /// - `Ok(false)` on an invalid signature or if the signature or public keys' bytes represent an
+    ///    invalid curve point.
+    /// - `Err(IllegalArgument)` if `pub_keys.len() != plaintexts.len()`.
+    fn verify_bls_aggregate(
+        &self,
+        aggregate_sig: &[u8; fvm_shared::crypto::signature::BLS_SIG_LEN],
+        pub_keys: &[[u8; fvm_shared::crypto::signature::BLS_PUB_LEN]],
+        plaintexts_concat: &[u8],
+        plaintext_lens: &[u32],
+    ) -> Result<bool>;
+
     /// Given a message hash and its signature, recovers the public key of the signer.
     fn recover_secp_public_key(
         &self,

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -220,7 +220,7 @@ pub trait ActorOps {
     fn balance_of(&self, actor_id: ActorID) -> Result<TokenAmount>;
 }
 
-#[cfg(not(feature = "no-verify-signature"))]
+#[cfg(feature = "verify-signature")]
 /// Cryptographic primitives provided by the kernel.
 #[delegatable_trait]
 pub trait CryptoOps {
@@ -263,7 +263,7 @@ pub trait CryptoOps {
     fn hash(&self, code: u64, data: &[u8]) -> Result<Multihash>;
 }
 
-#[cfg(feature = "no-verify-signature")]
+#[cfg(not(feature = "verify-signature"))]
 /// Cryptographic primitives provided by the kernel.
 #[delegatable_trait]
 pub trait CryptoOps {

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -4,12 +4,15 @@ use std::cmp;
 
 use anyhow::Context as _;
 use fvm_shared::crypto::signature::{
-    SignatureType, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
+    SignatureType, BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
 };
 use num_traits::FromPrimitive;
 
 use super::Context;
-use crate::kernel::{ClassifyResult, CryptoOps, Result};
+use crate::{
+    kernel::{ClassifyResult, CryptoOps, Result},
+    syscall_error,
+};
 
 /// Verifies that a signature is valid for an address and plaintext.
 ///
@@ -37,6 +40,54 @@ pub fn verify_signature(
     context
         .kernel
         .verify_signature(sig_type, sig_bytes, &addr, plaintext)
+        .map(|v| if v { 0 } else { -1 })
+}
+
+/// Verifies that a bls aggregate signature is valid for a list of public keys and plaintexts.
+///
+/// The return i32 indicates the status code of the verification:
+///  - 0: verification ok.
+///  - -1: verification failed.
+#[allow(clippy::too_many_arguments)]
+pub fn verify_bls_aggregate(
+    context: Context<'_, impl CryptoOps>,
+    num_signers: u32,
+    sig_off: u32,
+    pub_keys_off: u32,
+    plaintexts_off: u32,
+    plaintext_lens_off: u32,
+) -> Result<i32> {
+    // Check that the provided number of signatures aggregated does not cause `u32` overflow.
+    let pub_keys_len = num_signers
+        .checked_mul(BLS_PUB_LEN as u32)
+        .ok_or(syscall_error!(
+            IllegalArgument;
+            "number of signatures aggregated ({num_signers}) exceeds limit"
+        ))?;
+
+    let sig: &[u8; BLS_SIG_LEN] = context
+        .memory
+        .try_slice(sig_off, BLS_SIG_LEN as u32)?
+        .try_into()
+        .expect("bls signature bytes slice-to-array conversion should not fail");
+
+    let pub_keys: &[[u8; BLS_PUB_LEN]] = context.memory.try_chunks(pub_keys_off, pub_keys_len)?;
+
+    let plaintext_lens: &[u32] = context
+        .memory
+        .try_slice(plaintext_lens_off, num_signers * 4)
+        .map(|bytes| {
+            let ptr = bytes.as_ptr() as *const u32;
+            unsafe { std::slice::from_raw_parts(ptr, num_signers as usize) }
+        })?;
+
+    let plaintexts_concat = context
+        .memory
+        .try_slice(plaintexts_off, plaintext_lens.iter().sum())?;
+
+    context
+        .kernel
+        .verify_bls_aggregate(sig, pub_keys, plaintexts_concat, plaintext_lens)
         .map(|v| if v { 0 } else { -1 })
 }
 

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use std::cmp;
 
-use anyhow::Context as _;
 use fvm_shared::crypto::signature::{
-    SignatureType, BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
+    BLS_PUB_LEN, BLS_SIG_LEN, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
 };
-use num_traits::FromPrimitive;
 
 use super::Context;
 use crate::{
@@ -14,6 +12,7 @@ use crate::{
     syscall_error,
 };
 
+#[cfg(not(feature = "no-verify-signature"))]
 /// Verifies that a signature is valid for an address and plaintext.
 ///
 /// The return i32 indicates the status code of the verification:
@@ -30,6 +29,10 @@ pub fn verify_signature(
     plaintext_off: u32,
     plaintext_len: u32,
 ) -> Result<i32> {
+    use anyhow::Context as _;
+    use fvm_shared::crypto::signature::SignatureType;
+    use num_traits::FromPrimitive;
+
     let sig_type = SignatureType::from_u32(sig_type)
         .with_context(|| format!("unknown signature type {}", sig_type))
         .or_illegal_argument()?;

--- a/fvm/src/syscalls/crypto.rs
+++ b/fvm/src/syscalls/crypto.rs
@@ -12,7 +12,7 @@ use crate::{
     syscall_error,
 };
 
-#[cfg(not(feature = "no-verify-signature"))]
+#[cfg(feature = "verify-signature")]
 /// Verifies that a signature is valid for an address and plaintext.
 ///
 /// The return i32 indicates the status code of the verification:

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -315,7 +315,7 @@ where
         if cfg!(feature = "m2-native") {
             linker.link_syscall("actor", "install_actor", actor::install_actor)?;
         }
-
+        #[cfg(not(feature = "no-verify-signature"))]
         linker.link_syscall("crypto", "verify_signature", crypto::verify_signature)?;
         linker.link_syscall(
             "crypto",

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -319,6 +319,11 @@ where
         linker.link_syscall("crypto", "verify_signature", crypto::verify_signature)?;
         linker.link_syscall(
             "crypto",
+            "verify_bls_aggregate",
+            crypto::verify_bls_aggregate,
+        )?;
+        linker.link_syscall(
+            "crypto",
             "recover_secp_public_key",
             crypto::recover_secp_public_key,
         )?;

--- a/fvm/src/syscalls/mod.rs
+++ b/fvm/src/syscalls/mod.rs
@@ -315,7 +315,7 @@ where
         if cfg!(feature = "m2-native") {
             linker.link_syscall("actor", "install_actor", actor::install_actor)?;
         }
-        #[cfg(not(feature = "no-verify-signature"))]
+        #[cfg(feature = "verify-signature")]
         linker.link_syscall("crypto", "verify_signature", crypto::verify_signature)?;
         linker.link_syscall(
             "crypto",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -24,3 +24,7 @@ fvm_ipld_encoding = { workspace = true }
 default = []
 m2-native = []
 upgrade-actor = []
+# Use this feature to remove `verify_signature` syscall that is supposed to be removed by FIP-0079,
+# The current implementation keeps it by default for backward compatibility reason.
+# See <https://github.com/filecoin-project/ref-fvm/issues/2001>
+no-verify-signature = []

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -21,10 +21,10 @@ fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 
 [features]
-default = []
+default = ["verify-signature"]
 m2-native = []
 upgrade-actor = []
-# Use this feature to remove `verify_signature` syscall that is supposed to be removed by FIP-0079,
+# Use this feature to keep `verify_signature` syscall that is supposed to be removed by FIP-0079,
 # The current implementation keeps it by default for backward compatibility reason.
 # See <https://github.com/filecoin-project/ref-fvm/issues/2001>
-no-verify-signature = []
+verify-signature = []

--- a/sdk/src/crypto.rs
+++ b/sdk/src/crypto.rs
@@ -21,7 +21,7 @@ use num_traits::FromPrimitive;
 
 use crate::{status_code_to_bool, sys, SyscallResult};
 
-#[cfg(not(feature = "no-verify-signature"))]
+#[cfg(feature = "verify-signature")]
 /// Verifies that a signature is valid for an address and plaintext.
 ///
 /// NOTE: This only supports f1 and f3 addresses.
@@ -47,7 +47,7 @@ pub fn verify_signature(
     }
 }
 
-#[cfg(feature = "no-verify-signature")]
+#[cfg(not(feature = "verify-signature"))]
 /// Verifies that a signature is valid for an address and plaintext.
 ///
 /// NOTE: This only supports f1 and f3 addresses.

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -28,6 +28,7 @@ super::fvm_syscalls! {
     /// | Error               | Reason                                               |
     /// |---------------------|------------------------------------------------------|
     /// | [`IllegalArgument`] | signature, address, or plaintext buffers are invalid |
+    #[cfg(not(feature = "no-verify-signature"))]
     pub fn verify_signature(
         sig_type: u32,
         sig_off: *const u8,

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -28,7 +28,7 @@ super::fvm_syscalls! {
     /// | Error               | Reason                                               |
     /// |---------------------|------------------------------------------------------|
     /// | [`IllegalArgument`] | signature, address, or plaintext buffers are invalid |
-    #[cfg(not(feature = "no-verify-signature"))]
+    #[cfg(feature = "verify-signature")]
     pub fn verify_signature(
         sig_type: u32,
         sig_off: *const u8,

--- a/sdk/src/sys/crypto.rs
+++ b/sdk/src/sys/crypto.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 //! Syscalls for cryptographic operations.
 
-use fvm_shared::crypto::signature::SECP_PUB_LEN;
+use fvm_shared::crypto::signature::{BLS_PUB_LEN, SECP_PUB_LEN};
 #[doc(inline)]
 pub use fvm_shared::sys::out::crypto::*;
 
@@ -36,6 +36,45 @@ super::fvm_syscalls! {
         addr_len: u32,
         plaintext_off: *const u8,
         plaintext_len: u32,
+    ) -> Result<i32>;
+
+    /// Verifies that a BLS aggregate signature is valid for a list of signers' BLS public keys and
+    /// and the digest of each signer's plaintext.
+    ///
+    /// # Arguments
+    ///
+    /// - `num_signers` - the number of signatures aggregated; for non-aggregate signatures `num_signers = 1`.
+    /// - `sig_off` - a pointer to the first byte of the signature being verified.
+    /// - `pub_keys_off` - a pointer to the first public key in an array containing each signer's public
+    /// key.
+    /// - `plaintexts_off` - a pointer to the first byte in an array containing each plaintext's bytes,
+    /// i.e. plaintexts must be allocated contiguously in memory (equivalent to the memory layout of an
+    /// array containing the concatenated plaintexts' bytes).
+    /// - `plaintext_lens_off` - a pointer to the first element of an array containing each plaintext's
+    /// byte length (each plaintexrt's byte length is represented as a `u32`).
+    ///
+    /// # Returns
+    ///
+    /// - `Err(IllegalArgument)`:
+    ///     - any pointer and byte length pair are an invalid location in their Wasm module's memory.
+    ///
+    /// - `Ok(-1)`:
+    ///     - the signature is an invalid G2 compressed curve point.
+    ///     - any public key is an invalid G1 compressed curve point.
+    ///     - there are duplicate plaintexts.
+    ///     - any public key in is the G1 identity/zero point.
+    ///     - the signature is invalid for the provided public keys and plaintexts.
+    ///
+    /// - `Ok(0)`:
+    ///    - the provided signature is valid for the provided signers' public keys and plaintexts.
+    ///    - the number of signers is zero
+    ///
+    pub fn verify_bls_aggregate(
+        num_signers: u32,
+        sig_off: *const u8,
+        pub_keys_off: *const [u8; BLS_PUB_LEN],
+        plaintexts_off: *const u8,
+        plaintext_lens_off: *const u32,
     ) -> Result<i32>;
 
     /// Recovers the signer public key from a signed message hash and its signature.

--- a/testing/calibration/shared/src/lib.rs
+++ b/testing/calibration/shared/src/lib.rs
@@ -15,6 +15,8 @@ pub enum Method {
     OnBlock,
     /// Try (and fail) to verify random data with a public key and signature.
     OnVerifySignature,
+    /// Try to validate BLS aggregates (correctly).
+    OnVerifyBlsAggregate,
     /// Try (and fail) to recovery a public key from a signature, using random data.
     OnRecoverSecpPublicKey,
     /// Measure sends
@@ -51,6 +53,14 @@ pub struct OnVerifySignatureParams {
     /// valid signatures inside the contract because the libs we use don't compile to Wasm.
     pub signature: Vec<u8>,
     pub seed: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct OnVerifyBlsAggregateParams {
+    pub iterations: usize,
+    pub signature: Vec<u8>,
+    pub keys: Vec<Vec<u8>>,
+    pub messages: Vec<Vec<u8>>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 authors = ["Protocol Labs", "Filecoin Core Devs", "Polyphene"]
 
 [dependencies]
-fvm = { workspace = true, default-features = false, features = ["testing", "upgrade-actor"] }
+fvm = { workspace = true, default-features = false, features = ["testing", "upgrade-actor", "verify-signature"] }
 fvm_shared = { workspace = true, features = ["testing"] }
 fvm_ipld_car = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -22,8 +22,8 @@ use fvm_shared::version::NetworkVersion;
 use fvm_test_actors::wasm_bin::{
     ADDRESS_ACTOR_BINARY, CREATE_ACTOR_BINARY, CUSTOM_SYSCALL_ACTOR_BINARY, EXIT_DATA_ACTOR_BINARY,
     HELLO_WORLD_ACTOR_BINARY, IPLD_ACTOR_BINARY, OOM_ACTOR_BINARY, READONLY_ACTOR_BINARY,
-    SSELF_ACTOR_BINARY, STACK_OVERFLOW_ACTOR_BINARY, SYSCALL_ACTOR_BINARY, UPGRADE_ACTOR_BINARY,
-    UPGRADE_RECEIVE_ACTOR_BINARY,
+    SSELF_ACTOR_BINARY, STACK_OVERFLOW_ACTOR_BINARY, SYSCALL_ACTOR_BINARY,
+    SYSCALL_ACTOR_BINARY_FIP0079, UPGRADE_ACTOR_BINARY, UPGRADE_RECEIVE_ACTOR_BINARY,
 };
 use num_traits::Zero;
 
@@ -140,6 +140,20 @@ fn ipld() {
 
 #[test]
 fn syscalls() {
+    syscalls_inner(SYSCALL_ACTOR_BINARY)
+}
+
+#[test]
+fn syscalls_fip_0079() {
+    syscalls_inner(SYSCALL_ACTOR_BINARY_FIP0079)
+}
+
+#[test]
+fn syscalls_wasm_properly_imported() {
+    assert_ne!(SYSCALL_ACTOR_BINARY, SYSCALL_ACTOR_BINARY_FIP0079)
+}
+
+fn syscalls_inner(wasm_bin: &[u8]) {
     // Instantiate tester
     let mut tester = new_tester(
         NV_FOR_TEST,
@@ -150,8 +164,6 @@ fn syscalls() {
 
     let sender: [Account; 1] = tester.create_accounts().unwrap();
     tester.set_account_sequence(sender[0].0, 100).unwrap();
-
-    let wasm_bin = SYSCALL_ACTOR_BINARY;
 
     // Set actor state
     let actor_state = State::default();

--- a/testing/test_actors/actors/fil-gas-calibration-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-gas-calibration-actor/src/actor.rs
@@ -49,6 +49,7 @@ fn dispatch(method: Method, params_ptr: u32) -> Result<()> {
         Method::OnHashing => dispatch_to(on_hashing, params_ptr),
         Method::OnBlock => dispatch_to(on_block, params_ptr),
         Method::OnVerifySignature => dispatch_to(on_verify_signature, params_ptr),
+        Method::OnVerifyBlsAggregate => dispatch_to(on_verify_bls_aggregate, params_ptr),
         Method::OnRecoverSecpPublicKey => dispatch_to(on_recover_secp_public_key, params_ptr),
         Method::OnSend => dispatch_to(on_send, params_ptr),
         Method::OnEvent => dispatch_to(on_event, params_ptr),
@@ -118,6 +119,16 @@ fn on_verify_signature(p: OnVerifySignatureParams) -> Result<()> {
         fvm_sdk::crypto::verify_signature(&sig, &p.signer, &data)?;
     }
 
+    Ok(())
+}
+
+fn on_verify_bls_aggregate(p: OnVerifyBlsAggregateParams) -> Result<()> {
+    let sig = p.signature.try_into().unwrap();
+    let keys: Vec<_> = p.keys.iter().map(|k| (&**k).try_into().unwrap()).collect();
+    let messages: Vec<_> = p.messages.iter().map(|m| &**m).collect();
+    for _ in 0..p.iterations {
+        fvm_sdk::crypto::verify_bls_aggregate(&sig, &keys, &messages)?;
+    }
     Ok(())
 }
 

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -17,3 +17,4 @@ crate-type = ["cdylib"] ## cdylib is necessary for Wasm build
 
 [features]
 coverage = ["minicov"]
+no-verify-signature = ["fvm_sdk/no-verify-signature"]

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -17,4 +17,4 @@ crate-type = ["cdylib"] ## cdylib is necessary for Wasm build
 
 [features]
 coverage = ["minicov"]
-no-verify-signature = ["fvm_sdk/no-verify-signature"]
+verify-signature = ["fvm_sdk/verify-signature"]

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { workspace = true }
-fvm_sdk = { workspace = true }
+fvm_sdk = { workspace = true, default-features = false }
 fvm_shared = { workspace = true }
 multihash = { workspace = true, features = ["sha3", "sha2", "ripemd"] }
 minicov = {version = "0.3", optional = true}

--- a/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
@@ -98,7 +98,7 @@ fn test_secp_signature() {
     // test that calling sdk::sys::crypto::verify_signature with invalid parameters result
     // in correct error value
     //
-    #[cfg(not(feature = "no-verify-signature"))]
+    #[cfg(feature = "verify-signature")]
     unsafe {
         let sig_type = signature.signature_type();
         let sig_bytes = signature.bytes();

--- a/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
@@ -98,6 +98,7 @@ fn test_secp_signature() {
     // test that calling sdk::sys::crypto::verify_signature with invalid parameters result
     // in correct error value
     //
+    #[cfg(not(feature = "no-verify-signature"))]
     unsafe {
         let sig_type = signature.signature_type();
         let sig_bytes = signature.bytes();

--- a/testing/test_actors/build.rs
+++ b/testing/test_actors/build.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread;
 
 const ACTORS: &[(&str, &str)] = &[
@@ -55,7 +55,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // Cargo build command for all actors at once.
-    let mut cmd = Command::new(cargo);
+    let mut cmd = Command::new(cargo.clone());
     cmd.arg("build")
         .args(ACTORS.iter().map(|(_, pkg)| "-p=".to_owned() + pkg))
         .arg(format!("--target={WASM_TARGET}"))
@@ -76,8 +76,77 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:warning=cmd={:?}", &cmd);
 
     // Launch the command.
-    let mut child = cmd.spawn().expect("failed to launch cargo build");
+    let child = cmd.spawn().expect("failed to launch cargo build");
+    let result = wait_cmd_and_print_output(child)?;
+    if !result.success() {
+        return Err("actor build failed".into());
+    }
 
+    let wasm_bin_file =
+        File::create(out_dir.join("wasm_bin.rs")).expect("failed to create manifest");
+    let mut wasm_bin_file = BufWriter::new(wasm_bin_file);
+    for (var, pkg) in ACTORS {
+        let bin = bundle_dir
+            .join(WASM_TARGET)
+            .join("wasm")
+            .join(format!("{pkg}.wasm"));
+        let moved_bin = bundle_dir.join(format!("{var}.wasm"));
+        std::fs::rename(bin, &moved_bin).unwrap();
+        writeln!(
+            &mut wasm_bin_file,
+            "pub const {var}: &[u8] = include_bytes!({moved_bin:?});"
+        )
+        .expect("failed to write to manifest");
+    }
+
+    // Generate syscall actor with no-verify-signature feature.
+    {
+        let (var, pkg) = ("SYSCALL_ACTOR_BINARY_FIP0079", "fil_syscall_actor");
+        let mut cmd = Command::new(cargo);
+        cmd.arg("build")
+            .arg(format!("-p={pkg}"))
+            // .arg(format!("--features=no-verify-signature"))
+            .arg(format!("--target={WASM_TARGET}"))
+            .arg("--profile=wasm")
+            .arg("--locked")
+            .arg("--manifest-path=".to_owned() + manifest_path.to_str().unwrap())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            // We are supposed to only generate artifacts under OUT_DIR,
+            // so set OUT_DIR as the target directory for this build.
+            .env("CARGO_TARGET_DIR", &bundle_dir)
+            // As we are being called inside a build-script, this env variable is set. However, we set
+            // our own `RUSTFLAGS` and thus, we need to remove this. Otherwise cargo favors this
+            // env variable.
+            .env_remove("CARGO_ENCODED_RUSTFLAGS");
+
+        // Print out the command line we're about to run.
+        println!("cargo:warning=cmd={:?}", &cmd);
+
+        // Launch the command.
+        let child = cmd.spawn().expect("failed to launch cargo build");
+        let result = wait_cmd_and_print_output(child)?;
+        if !result.success() {
+            return Err("actor build failed".into());
+        }
+        let bin = bundle_dir
+            .join(WASM_TARGET)
+            .join("wasm")
+            .join(format!("{pkg}.wasm"));
+        let moved_bin = bundle_dir.join(format!("{var}.wasm"));
+        std::fs::rename(bin, &moved_bin).unwrap();
+        writeln!(
+            &mut wasm_bin_file,
+            "pub const {var}: &[u8] = include_bytes!({moved_bin:?});"
+        )
+        .expect("failed to write to manifest");
+    }
+
+    wasm_bin_file.flush().expect("failed to flush manifest");
+    Ok(())
+}
+
+fn wait_cmd_and_print_output(mut child: Child) -> Result<ExitStatus, Box<dyn Error>> {
     // Pipe the output as cargo warnings. Unfortunately this is the only way to
     // get cargo build to print the output.
     let stdout = child.stdout.take().expect("no stdout");
@@ -97,24 +166,5 @@ fn main() -> Result<(), Box<dyn Error>> {
     j2.join().unwrap();
 
     let result = child.wait().expect("failed to wait for build to finish");
-    if !result.success() {
-        return Err("actor build failed".into());
-    }
-
-    let wasm_bin_file =
-        File::create(out_dir.join("wasm_bin.rs")).expect("failed to create manifest");
-    let mut wasm_bin_file = BufWriter::new(wasm_bin_file);
-    for (var, pkg) in ACTORS {
-        let bin = bundle_dir
-            .join(WASM_TARGET)
-            .join("wasm")
-            .join(format!("{pkg}.wasm"));
-        writeln!(
-            &mut wasm_bin_file,
-            "pub const {var}: &[u8] = include_bytes!({bin:?});"
-        )
-        .expect("failed to write to manifest");
-    }
-    wasm_bin_file.flush().expect("failed to flush manifest");
-    Ok(())
+    Ok(result)
 }

--- a/testing/test_actors/build.rs
+++ b/testing/test_actors/build.rs
@@ -99,13 +99,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         .expect("failed to write to manifest");
     }
 
-    // Generate syscall actor with no-verify-signature feature.
+    // Generate syscall actor with verify-signature feature.
     {
         let (var, pkg) = ("SYSCALL_ACTOR_BINARY_FIP0079", "fil_syscall_actor");
         let mut cmd = Command::new(cargo);
         cmd.arg("build")
             .arg(format!("-p={pkg}"))
-            // .arg(format!("--features=no-verify-signature"))
+            .arg("--features=verify-signature")
             .arg(format!("--target={WASM_TARGET}"))
             .arg("--profile=wasm")
             .arg("--locked")


### PR DESCRIPTION
This PR tries to implement https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0079.md without breaking FVM backward compatibility. 

(NOTE: This PR is largely based on https://github.com/filecoin-project/ref-fvm/pull/1914)

Closes https://github.com/filecoin-project/ref-fvm/issues/2001

Changes:
- Add `verify_bls_aggregate` syscall
- Add cargo feature `verify-signature` that keeps `verify_signature` syscall for backward compatibility
- Add integration test for the `verify-signature` feature
- Update CI to build and check the `verify-signature` feature