### PR TITLE
chore: upgrade rust toolchain to 1.78.0

### DIFF
--- a/ipld/encoding/src/bytes.rs
+++ b/ipld/encoding/src/bytes.rs
@@ -28,9 +28,9 @@ pub mod strict_bytes {
             S: Serializer;
     }
 
-    impl<T: ?Sized> Serialize for T
+    impl<T> Serialize for T
     where
-        T: AsRef<[u8]>,
+        T: AsRef<[u8]> + ?Sized,
     {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where

--- a/ipld/encoding/src/raw.rs
+++ b/ipld/encoding/src/raw.rs
@@ -75,9 +75,9 @@ impl serde::ser::Serializer for Serializer {
         Err(Error::KindNotSupported)
     }
 
-    fn serialize_some<T: ?Sized>(self, _: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, _: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         Err(Error::KindNotSupported)
     }
@@ -95,18 +95,14 @@ impl serde::ser::Serializer for Serializer {
         Err(Error::KindNotSupported)
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
-        self,
-        _: &'static str,
-        _: &T,
-    ) -> Result<Self::Ok, Self::Error>
+    fn serialize_newtype_struct<T>(self, _: &'static str, _: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         Err(Error::KindNotSupported)
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _: &'static str,
         _: u32,
@@ -114,7 +110,7 @@ impl serde::ser::Serializer for Serializer {
         _: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         Err(Error::KindNotSupported)
     }

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -246,10 +246,10 @@ where
     /// assert_eq!(map.get(&2).unwrap(), None);
     /// ```
     #[inline]
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Result<Option<&V>, Error>
+    pub fn get<Q>(&self, k: &Q) -> Result<Option<&V>, Error>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
         V: DeserializeOwned,
     {
         match self.root.get(k, self.store.borrow(), &self.conf)? {
@@ -278,10 +278,10 @@ where
     /// assert_eq!(map.contains_key(&2).unwrap(), false);
     /// ```
     #[inline]
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> Result<bool, Error>
+    pub fn contains_key<Q>(&self, k: &Q) -> Result<bool, Error>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         Ok(self.root.get(k, self.store.borrow(), &self.conf)?.is_some())
     }
@@ -306,10 +306,10 @@ where
     /// assert_eq!(map.delete(&1).unwrap(), Some((1, "a".to_string())));
     /// assert_eq!(map.delete(&1).unwrap(), None);
     /// ```
-    pub fn delete<Q: ?Sized>(&mut self, k: &Q) -> Result<Option<(K, V)>, Error>
+    pub fn delete<Q>(&mut self, k: &Q) -> Result<Option<(K, V)>, Error>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         let deleted = self.root.remove_entry(k, self.store.borrow(), &self.conf)?;
 
@@ -410,7 +410,7 @@ where
     /// assert_eq!(next_key.unwrap(), numbers[2]);
     /// ```
     #[inline]
-    pub fn for_each_ranged<Q: ?Sized, F>(
+    pub fn for_each_ranged<Q, F>(
         &self,
         starting_key: Option<&Q>,
         max: Option<usize>,
@@ -418,7 +418,7 @@ where
     ) -> Result<(usize, Option<K>), Error>
     where
         K: Borrow<Q> + Clone,
-        Q: Eq + Hash,
+        Q: Eq + Hash + ?Sized,
         V: DeserializeOwned,
         F: FnMut(&K, &V) -> anyhow::Result<()>,
     {
@@ -510,11 +510,11 @@ where
     ///
     /// # anyhow::Ok(())
     /// ```
-    pub fn iter_from<Q: ?Sized>(&self, key: &Q) -> Result<IterImpl<BS, V, K, H, Ver>, Error>
+    pub fn iter_from<Q>(&self, key: &Q) -> Result<IterImpl<BS, V, K, H, Ver>, Error>
     where
         H: HashAlgorithm,
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         IterImpl::new_from(&self.store, &self.root, key, &self.conf)
     }

--- a/ipld/hamt/src/hash_algorithm.rs
+++ b/ipld/hamt/src/hash_algorithm.rs
@@ -10,9 +10,9 @@ use crate::{Hash, HashedKey};
 
 /// Algorithm used as the hasher for the Hamt.
 pub trait HashAlgorithm {
-    fn hash<X: ?Sized>(key: &X) -> HashedKey
+    fn hash<X>(key: &X) -> HashedKey
     where
-        X: Hash;
+        X: Hash + ?Sized;
 }
 
 /// Type is needed because the Sha256 hasher does not implement `std::hash::Hasher`
@@ -35,9 +35,9 @@ impl Hasher for Sha2HasherWrapper {
 pub enum Sha256 {}
 
 impl HashAlgorithm for Sha256 {
-    fn hash<X: ?Sized>(key: &X) -> HashedKey
+    fn hash<X>(key: &X) -> HashedKey
     where
-        X: Hash,
+        X: Hash + ?Sized,
     {
         let mut hasher = Sha2HasherWrapper::default();
         key.hash(&mut hasher);

--- a/ipld/hamt/src/iter.rs
+++ b/ipld/hamt/src/iter.rs
@@ -43,7 +43,7 @@ where
         }
     }
 
-    pub(crate) fn new_from<Q: ?Sized>(
+    pub(crate) fn new_from<Q>(
         store: &'a BS,
         root: &'a Node<K, V, H, Ver>,
         key: &Q,
@@ -52,7 +52,7 @@ where
     where
         H: HashAlgorithm,
         K: Borrow<Q> + PartialOrd,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         let hashed_key = H::hash(key);
         let mut hash = HashBits::new(&hashed_key);

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -178,7 +178,7 @@ where
     }
 
     #[inline]
-    pub fn get<Q: ?Sized, S: Blockstore>(
+    pub fn get<Q, S: Blockstore>(
         &self,
         k: &Q,
         store: &S,
@@ -186,13 +186,13 @@ where
     ) -> Result<Option<&V>, Error>
     where
         K: Borrow<Q>,
-        Q: Eq + Hash,
+        Q: Eq + Hash + ?Sized,
     {
         Ok(self.search(k, store, conf)?.map(|kv| kv.value()))
     }
 
     #[inline]
-    pub fn remove_entry<Q: ?Sized, S>(
+    pub fn remove_entry<Q, S>(
         &mut self,
         k: &Q,
         store: &S,
@@ -200,7 +200,7 @@ where
     ) -> Result<Option<(K, V)>, Error>
     where
         K: Borrow<Q>,
-        Q: Eq + Hash,
+        Q: Eq + Hash + ?Sized,
         S: Blockstore,
     {
         let hash = H::hash(k);
@@ -212,7 +212,7 @@ where
     }
 
     /// Search for a key.
-    fn search<Q: ?Sized, S: Blockstore>(
+    fn search<Q, S: Blockstore>(
         &self,
         q: &Q,
         store: &S,
@@ -220,13 +220,13 @@ where
     ) -> Result<Option<&KeyValuePair<K, V>>, Error>
     where
         K: Borrow<Q>,
-        Q: Eq + Hash,
+        Q: Eq + Hash + ?Sized,
     {
         let hash = H::hash(q);
         self.get_value(&mut HashBits::new(&hash), conf, 0, q, store)
     }
 
-    fn get_value<Q: ?Sized, S: Blockstore>(
+    fn get_value<Q, S: Blockstore>(
         &self,
         hashed_key: &mut HashBits,
         conf: &Config,
@@ -236,7 +236,7 @@ where
     ) -> Result<Option<&KeyValuePair<K, V>>, Error>
     where
         K: Borrow<Q>,
-        Q: Eq + Hash,
+        Q: Eq + Hash + ?Sized,
     {
         let idx = hashed_key.next(conf.bit_width)?;
 
@@ -390,7 +390,7 @@ where
     }
 
     /// Internal method to delete entries.
-    fn rm_value<Q: ?Sized, S: Blockstore>(
+    fn rm_value<Q, S: Blockstore>(
         &mut self,
         hashed_key: &mut HashBits,
         conf: &Config,
@@ -400,7 +400,7 @@ where
     ) -> Result<Option<(K, V)>, Error>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         let idx = hashed_key.next(conf.bit_width)?;
 

--- a/ipld/kamt/src/iter.rs
+++ b/ipld/kamt/src/iter.rs
@@ -34,7 +34,7 @@ where
         }
     }
 
-    pub(crate) fn new_from<Q: Sized>(
+    pub(crate) fn new_from<Q>(
         store: &'a BS,
         root: &'a Node<K, V, H, N>,
         key: &Q,
@@ -42,7 +42,7 @@ where
     ) -> Result<Self, Error>
     where
         K: Borrow<Q> + PartialOrd,
-        Q: PartialEq,
+        Q: PartialEq + Sized,
         H: AsHashedKey<Q, N>,
     {
         let hashed_key = H::as_hashed_key(key);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.78.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]

--- a/shared/tests/address_test.rs
+++ b/shared/tests/address_test.rs
@@ -581,7 +581,7 @@ fn address_hashmap() {
 
     // insert other value
     let h2 = Address::new_id(2);
-    assert!(hm.get(&h2).is_none());
+    assert!(!hm.contains_key(&h2));
     hm.insert(h2, 2);
     assert_eq!(hm.get(&h2).unwrap(), &2);
 


### PR DESCRIPTION
- upgrade rust toolchain to 1.78.0
- fix new clippy warnings

```
warning: bound is defined in more than one place
   --> ipld/hamt/src/node.rs:229:18
    |
229 |     fn get_value<Q: ?Sized, S: Blockstore>(
    |                  ^
...
239 |         Q: Eq + Hash,
    |         ^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#multiple_bound_locations
```

```
warning: unnecessary use of `get(&h2).is_none()`
   --> shared/tests/address_test.rs:584:16
    |
584 |     assert!(hm.get(&h2).is_none());
    |             ---^^^^^^^^^^^^^^^^^^
    |             |
    |             help: replace it with: `!hm.contains_key(&h2)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check
```