### PR TITLE
fix(ci): don't use nightly for fuzz build

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -32,7 +32,7 @@ FUZZ_TARGET_OUTPUT_DIR="$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release"
 for project in "${PROJECTS[@]}"; do
 	pushd "${PROJECT_PATHS[$project]}"
 
-	cargo +nightly fuzz build -O --debug-assertions
+	cargo fuzz build -O --debug-assertions
 
 	for f in fuzz_targets/*.rs; do
 		FUZZ_TARGET_NAME=$(basename "${f%.*}")


### PR DESCRIPTION
testing a theory that it's `+nightly` that makes this frustratingly unstable in CI, e.g. currently broken because of `-lc++` linking https://github.com/filecoin-project/ref-fvm/actions/runs/9394298344/job/25872490528?pr=2010