### PR TITLE
chore: update the lockfile to the correct version of the blockstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 4.0.0",
  "num-derive 0.3.3",
@@ -1404,7 +1404,7 @@ dependencies = [
  "cid 0.10.1",
  "clap",
  "futures",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_car 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
@@ -1418,7 +1418,7 @@ version = "12.0.0"
 source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#73376dfcf268b23e7d4281a62cc959668050a342"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 4.0.0",
  "log",
@@ -1437,7 +1437,7 @@ dependencies = [
  "frc42_dispatch",
  "frc46_token",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
  "fvm_shared 4.0.0",
@@ -1457,7 +1457,7 @@ dependencies = [
  "cid 0.10.1",
  "fil_actors_evm_shared",
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 4.0.0",
  "hex-literal",
@@ -1495,7 +1495,7 @@ dependencies = [
  "fil_actors_evm_shared",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_kamt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 4.0.0",
@@ -1518,7 +1518,7 @@ dependencies = [
  "cid 0.10.1",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
  "fvm_shared 4.0.0",
@@ -1539,7 +1539,7 @@ dependencies = [
  "frc42_dispatch",
  "frc46_token",
  "fvm_ipld_bitfield 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
  "fvm_shared 4.0.0",
@@ -1564,7 +1564,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_amt 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_bitfield 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
  "fvm_shared 4.0.0",
@@ -1587,7 +1587,7 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
  "fvm_shared 4.0.0",
@@ -1607,7 +1607,7 @@ dependencies = [
  "cid 0.10.1",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 4.0.0",
  "num-derive 0.3.3",
@@ -1629,7 +1629,7 @@ dependencies = [
  "cid 0.10.1",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
  "fvm_shared 4.0.0",
@@ -1648,7 +1648,7 @@ version = "12.0.0"
 source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#73376dfcf268b23e7d4281a62cc959668050a342"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 4.0.0",
  "lazy_static",
@@ -1666,7 +1666,7 @@ dependencies = [
  "anyhow",
  "cid 0.10.1",
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 4.0.0",
  "num-derive 0.3.3",
@@ -1685,7 +1685,7 @@ dependencies = [
  "frc42_dispatch",
  "frc46_token",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
  "fvm_shared 4.0.0",
@@ -1721,7 +1721,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_amt 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_bitfield 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
  "fvm_sdk 4.0.0",
@@ -2151,7 +2151,7 @@ dependencies = [
  "cid 0.10.1",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
  "fvm_sdk 4.0.0",
@@ -2356,7 +2356,7 @@ dependencies = [
  "anyhow",
  "cid 0.10.1",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_sdk 4.0.0",
  "fvm_shared 4.0.0",
@@ -2472,7 +2472,7 @@ checksum = "5fea333475130094f27ce67809aae3f69eb5247541d835950b7c5da733dbbb34"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.11.0",
  "once_cell",
@@ -2510,9 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_blockstore"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417f52f6915b9f9a68de8462e1cf46f14a2c16420f484b8d2066873de2ffe420"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -2522,6 +2520,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d064b957420f5ecc137a153baaa6c32e2eb19b674135317200b6f2537eabdbfd"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -2550,7 +2550,7 @@ checksum = "6190f03442b67b21a3d4e115c4d4dd3468aed24e27ebb074218822c1b3df41ba"
 dependencies = [
  "cid 0.10.1",
  "futures",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "thiserror",
@@ -2581,7 +2581,7 @@ checksum = "90608092e31d9a06236268c58f7c36668ab4b2a48afafe3a97e08f094ad7ae50"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash 0.18.1",
  "serde",
  "serde_ipld_dagcbor",
@@ -2600,7 +2600,7 @@ dependencies = [
  "byteorder",
  "cid 0.10.1",
  "forest_hash_utils",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libipld-core 0.16.0",
  "multihash 0.18.1",
@@ -2666,7 +2666,7 @@ dependencies = [
  "byteorder",
  "cid 0.10.1",
  "forest_hash_utils",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash 0.18.1",
  "once_cell",
@@ -4956,7 +4956,7 @@ source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#7
 dependencies = [
  "anyhow",
  "cid 0.10.1",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.8.0",
  "fvm_shared 4.0.0",


### PR DESCRIPTION
I have no idea how this could have gotten out of date. But apparently...