### PR TITLE
feat: simplify the verify-signatures feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "ambassador"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b8741165d4c4a8e6e8dcf8a2d09a1b0f94d85722fb57caed8babdd421a9837"
+checksum = "06baa18a48752d8177eca1bafa9970b2dc649a81b98d6dde9ae83bea1867030b"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ arbitrary = "1.3.0"
 itertools = "0.11.0"
 once_cell = "1.18.0"
 unsigned-varint = "0.7.2"
-ambassador = "0.3.5"
+ambassador = "0.4.0"
 
 # dev/tools/tests
 criterion = "0.5.1"

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+- **BREAKING**: Simplify the verify-signtures feature and update ambassador. This is a minor-breaking change because the ambassador macros are now only exported from the prelude/kernel module, not the crate root as they previously were.
+
 ## 4.3.0 [2023-06-12]
 
 - feat: FIP-0079: syscall for aggregated bls verification [#2003](https://github.com/filecoin-project/ref-fvm/pull/2003)

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { workspace = true }
-fvm_sdk = { workspace = true, default-features = false }
+fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 multihash = { workspace = true, features = ["sha3", "sha2", "ripemd"] }
 minicov = {version = "0.3", optional = true}


### PR DESCRIPTION
A new ambassador crate was released so we can now use attributes inside
delegable traits (and some macros that were previously unexported are
now exported by default). Basically, I'm just deleting code.