### PR TITLE
chore: remove `nv23-dev` flag

### DIFF
--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to the reference FVM implementation.
 ## [Unreleased]
 
 - **BREAKING**: Simplify the verify-signtures feature and update ambassador. This is a minor-breaking change because the ambassador macros are now only exported from the prelude/kernel module, not the crate root as they previously were.
+- chore: remove the `nv23-dev` feature flag [#2022](https://github.com/filecoin-project/ref-fvm/pull/2022)
 
 ## 4.3.0 [2023-06-12]
 

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -57,7 +57,6 @@ arb = ["arbitrary", "quickcheck", "fvm_shared/arb"]
 m2-native = []
 upgrade-actor = []
 gas_calibration = []
-nv23-dev = []
 # Use this feature to keep `verify_signature` syscall that is supposed to be removed by FIP-0079,
 # The current implementation keeps it by default for backward compatibility reason.
 # See <https://github.com/filecoin-project/ref-fvm/issues/2001>

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -1001,9 +1001,7 @@ impl PriceList {
 /// Returns gas price list by NetworkVersion for gas consumption.
 pub fn price_list_by_network_version(network_version: NetworkVersion) -> &'static PriceList {
     match network_version {
-        NetworkVersion::V21 | NetworkVersion::V22 => &WATERMELON_PRICES,
-        #[cfg(feature = "nv23-dev")]
-        NetworkVersion::V23 => &WATERMELON_PRICES,
+        NetworkVersion::V21 | NetworkVersion::V22 | NetworkVersion::V23 => &WATERMELON_PRICES,
         _ => panic!("network version {nv} not supported", nv = network_version),
     }
 }

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -51,11 +51,6 @@ where
     /// * `blockstore`: The underlying [blockstore][`Blockstore`] for reading/writing state.
     /// * `externs`: Client-provided ["external"][`Externs`] methods for accessing chain state.
     pub fn new(context: &MachineContext, blockstore: B, externs: E) -> anyhow::Result<Self> {
-        #[cfg(not(feature = "nv23-dev"))]
-        const SUPPORTED_VERSIONS: RangeInclusive<NetworkVersion> =
-            NetworkVersion::V21..=NetworkVersion::V22;
-
-        #[cfg(feature = "nv23-dev")]
         const SUPPORTED_VERSIONS: RangeInclusive<NetworkVersion> =
             NetworkVersion::V21..=NetworkVersion::V23;
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- chore: remove the `nv23-dev` feature flag [#2022](https://github.com/filecoin-project/ref-fvm/pull/2022)
+
 ## 4.3.0 [2023-06-12]
 
 - feat: FIP-0079: syscall for aggregated bls verification [#2003](https://github.com/filecoin-project/ref-fvm/pull/2003)

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- chore: remove the `nv23-dev` feature flag [#2022](https://github.com/filecoin-project/ref-fvm/pull/2022)
+
 ## 4.3.0 [2023-06-12]
 
 - feat: FIP-0079: syscall for aggregated bls verification [#2003](https://github.com/filecoin-project/ref-fvm/pull/2003)


### PR DESCRIPTION
- removed the `nv23-dev` feature flag and enabled NV23 support by default.