### PR TITLE
 ci: automate creation of GitHub releases and tags

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,21 @@
+name: Release Checker
+
+on:
+  pull_request_target:
+    paths: ["Cargo.toml"]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-check:
+    uses: ipdxco/unified-github-workflows/.github/workflows/release-check.yml@v1.0
+    with:
+      sources: '["Cargo.toml"]'

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -3,18 +3,7 @@ name: Release Checker
 on:
   pull_request_target:
     paths:
-      - "Cargo.toml"
-      - "fvm/Cargo.toml"
-      - "testing/integration/Cargo.toml"
-      - "ipld/amt/Cargo.toml"
-      - "ipld/bitfield/Cargo.toml"
-      - "ipld/blockstore/Cargo.toml"
-      - "ipld/car/Cargo.toml"
-      - "ipld/encoding/Cargo.toml"
-      - "ipld/hamt/Cargo.toml"
-      - "ipld/kamt/Cargo.toml"
-      - "sdk/Cargo.toml"
-      - "shared/Cargo.toml"
+      - "**/Cargo.toml"
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
   workflow_dispatch:
 

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -45,9 +45,9 @@ jobs:
           "shared/Cargo.toml"
         ]
       separator: "@"
-  cargo-publish-dry-run:
+  cargo-publish:
     needs: [release-check]
-    if: toJSON(fromJSON(needs.release-check.outputs.json)) != '[]'
+    if: needs.release-check.outputs.json != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -2,7 +2,18 @@ name: Release Checker
 
 on:
   pull_request_target:
-    paths: ["Cargo.toml"]
+    paths:
+      - "fvm/Cargo.toml"
+      - "testing/integration/Cargo.toml"
+      - "ipld/amt/Cargo.toml"
+      - "ipld/bitfield/Cargo.toml"
+      - "ipld/blockstore/Cargo.toml"
+      - "ipld/car/Cargo.toml"
+      - "ipld/encoding/Cargo.toml"
+      - "ipld/hamt/Cargo.toml"
+      - "ipld/kamt/Cargo.toml"
+      - "sdk/Cargo.toml"
+      - "shared/Cargo.toml"
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
   workflow_dispatch:
 
@@ -18,4 +29,34 @@ jobs:
   release-check:
     uses: ipdxco/unified-github-workflows/.github/workflows/release-check.yml@v1.0
     with:
-      sources: '["Cargo.toml"]'
+      sources: |
+        [
+          "fvm/Cargo.toml",
+          "testing/integration/Cargo.toml",
+          "ipld/amt/Cargo.toml",
+          "ipld/bitfield/Cargo.toml",
+          "ipld/blockstore/Cargo.toml",
+          "ipld/car/Cargo.toml",
+          "ipld/encoding/Cargo.toml",
+          "ipld/hamt/Cargo.toml",
+          "ipld/kamt/Cargo.toml",
+          "sdk/Cargo.toml",
+          "shared/Cargo.toml"
+        ]
+      separator: "@"
+  cargo-publish-dry-run:
+    needs: [release-check]
+    if: toJSON(fromJSON(needs.release-check.outputs.json)) != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        source: ${{ fromJSON(needs.release-check.outputs.json).*.source }}
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          source: ${{ matrix.source }}
+        run: |
+          pushd "$(dirname $source)"
+          cargo publish --dry-run
+          popd

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -3,6 +3,7 @@ name: Release Checker
 on:
   pull_request_target:
     paths:
+      - "Cargo.toml"
       - "fvm/Cargo.toml"
       - "testing/integration/Cargo.toml"
       - "ipld/amt/Cargo.toml"

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,0 +1,21 @@
+name: Releaser
+
+on:
+  push:
+    paths: ["Cargo.toml"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  releaser:
+    uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1.0
+    with:
+      sources: '["Cargo.toml"]'
+    secrets:
+      UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -3,18 +3,7 @@ name: Releaser
 on:
   push:
     paths:
-      - "Cargo.toml"
-      - "fvm/Cargo.toml"
-      - "testing/integration/Cargo.toml"
-      - "ipld/amt/Cargo.toml"
-      - "ipld/bitfield/Cargo.toml"
-      - "ipld/blockstore/Cargo.toml"
-      - "ipld/car/Cargo.toml"
-      - "ipld/encoding/Cargo.toml"
-      - "ipld/hamt/Cargo.toml"
-      - "ipld/kamt/Cargo.toml"
-      - "sdk/Cargo.toml"
-      - "shared/Cargo.toml"
+      - "**/Cargo.toml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -3,6 +3,7 @@ name: Releaser
 on:
   push:
     paths:
+      - "Cargo.toml"
       - "fvm/Cargo.toml"
       - "testing/integration/Cargo.toml"
       - "ipld/amt/Cargo.toml"

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -2,7 +2,18 @@ name: Releaser
 
 on:
   push:
-    paths: ["Cargo.toml"]
+    paths:
+      - "fvm/Cargo.toml"
+      - "testing/integration/Cargo.toml"
+      - "ipld/amt/Cargo.toml"
+      - "ipld/bitfield/Cargo.toml"
+      - "ipld/blockstore/Cargo.toml"
+      - "ipld/car/Cargo.toml"
+      - "ipld/encoding/Cargo.toml"
+      - "ipld/hamt/Cargo.toml"
+      - "ipld/kamt/Cargo.toml"
+      - "sdk/Cargo.toml"
+      - "shared/Cargo.toml"
   workflow_dispatch:
 
 permissions:
@@ -16,6 +27,20 @@ jobs:
   releaser:
     uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1.0
     with:
-      sources: '["Cargo.toml"]'
+      sources: |
+        [
+          "fvm/Cargo.toml",
+          "testing/integration/Cargo.toml",
+          "ipld/amt/Cargo.toml",
+          "ipld/bitfield/Cargo.toml",
+          "ipld/blockstore/Cargo.toml",
+          "ipld/car/Cargo.toml",
+          "ipld/encoding/Cargo.toml",
+          "ipld/hamt/Cargo.toml",
+          "ipld/kamt/Cargo.toml",
+          "sdk/Cargo.toml",
+          "shared/Cargo.toml"
+        ]
+      separator: "@"
     secrets:
       UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Once the release is prepared, it'll go through a review:
 
 Finally, an [FVM "owner"](https://github.com/orgs/filecoin-project/teams/fvm-crate-owners/members) will:
 
-1. Merge the release PR to master.
+1. Merge the release PR to master (this will trigger GitHub release/tag creation if the workspace version in the root `Cargo.toml` was modified).
 2. For each released crate, create a git tag: `crate_name@crate_version`.
 3. Run `cargo publish` for each released crate (in dependency order).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,18 +115,21 @@ This section describes the automated parts of the release process and the manual
 
 #### Current State
 
-1. On a release pull request creation, a [Release Checker](.github/workflows/release-check.yml) workflow will run. It will perform the following actions:
-    1. Extract the version from the modified `Cargo.toml` files. Process each crate in the workspace **independently**.
+1. Create a pull request which updates the [`version` in one or more `Cargo.toml` files](https://github.com/search?q=repo%3Afilecoin-project%2Fref-fvm+path%3ACargo.toml+%2F%5Eversion+%3D%2F&type=code).
+   - Title the PR `chore: release vX.Y.Z`
+2. On such a release PR's creation, a [Release Checker](.github/workflows/release-check.yml) workflow will run. It will perform the following actions:
+    1. Extract the version from the modified `Cargo.toml` files, and process each crate in the workspace **independently**.
     2. Check if a git tag for the version, using the `crate_name@version` as the pattern, already exists. Continue only if it does not.
     3. Create a draft GitHub release with the version as the tag.
     4. Comment on the pull request with a link to the draft release.
     5. Run `cargo publish --dry-run` for the crate for which the release is proposed.
 2. On pull request merge, a [Releaser](.github/workflows/release.yml) workflow will run. It will perform the following actions:
-    1. Extract the version from the modified `Cargo.toml` files. Process each crate in the workspace **independently**.
+    1. Extract the version from the modified `Cargo.toml` files, and process each crate in the workspace **independently**.
     2. Check if a git tag for the version, using the `crate_name@version` as the pattern, already exists. Continue only if it does not.
     3. Check if a draft GitHub release with the version as the tag exists.
     4. If the draft release exists, publish it. Otherwise, create a new release with the version as the tag.
 3. **[MANUAL]** Run `cargo publish` for each crate that has been released in the [reverse dependency order](#crate-dependency-graph).
+   - You will need to be part of [fvm-create-owners](https://github.com/orgs/filecoin-project/teams/fvm-crate-owners) to do this per https://crates.io/crates/fvm.
 
 #### Known Limitations
 


### PR DESCRIPTION
This automates the creation of GitHub releases and associated GitHub tags based on the changes to the version in the selected Cargo.toml files.

The automation uses the same principles as the one you might know from Go projects where we control the current version via version.json file (https://github.com/ipdxco/unified-github-workflows?tab=readme-ov-file#versioning). This is the exact same workflow just updated to work with Cargo.toml.

~~Note, that the automation doesn't take care of cargo publishing currently. It doesn't create `crate_name@crate_version` tags either. To handle these, I'd suggest creating another workflow triggered on tag creation or github release publishing, which creates additional tags and performs cargo publishing.~~

The automation takes care of publishing `crate_name@crate_version` packages. It also creates GitHub releases for each tag.

