### PR TITLE
chore: release 4.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.1",
+ "fvm_shared 4.3.2",
  "libfuzzer-sys",
  "multihash 0.18.1",
  "rand",
@@ -1748,8 +1748,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
 ]
 
 [[package]]
@@ -1785,8 +1785,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
 ]
 
 [[package]]
@@ -1795,8 +1795,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1807,8 +1807,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "serde",
  "serde_tuple",
 ]
@@ -1818,8 +1818,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
 ]
 
 [[package]]
@@ -1830,8 +1830,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "libipld",
  "num-derive 0.4.1",
  "num-traits",
@@ -1843,8 +1843,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "log",
  "serde",
  "serde_tuple",
@@ -1854,8 +1854,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
 ]
 
 [[package]]
@@ -1866,8 +1866,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "serde",
  "serde_tuple",
 ]
@@ -1877,8 +1877,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "minicov",
 ]
 
@@ -1886,16 +1886,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
 ]
 
 [[package]]
@@ -1904,8 +1904,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
 ]
 
 [[package]]
@@ -1914,16 +1914,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
 ]
 
 [[package]]
@@ -1932,8 +1932,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -1944,8 +1944,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "serde",
  "serde_tuple",
 ]
@@ -1956,8 +1956,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "serde",
  "serde_tuple",
 ]
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2300,7 +2300,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.3.1",
+ "fvm_shared 4.3.2",
  "lazy_static",
  "log",
  "minstant",
@@ -2331,7 +2331,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.1",
+ "fvm_shared 4.3.2",
  "hex",
 ]
 
@@ -2384,7 +2384,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.1",
+ "fvm_shared 4.3.2",
  "itertools 0.11.0",
  "ittapi-rs",
  "lazy_static",
@@ -2405,7 +2405,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.3.1",
+ "fvm_shared 4.3.2",
  "num-derive 0.4.1",
  "num-traits",
  "serde",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2428,8 +2428,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.1",
- "fvm_shared 4.3.1",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2692,11 +2692,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.1",
+ "fvm_shared 4.3.2",
  "lazy_static",
  "log",
  "num-traits",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2743,7 +2743,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.1",
+ "fvm_shared 4.3.2",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.3.1"
+version = "4.3.2"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -74,9 +74,9 @@ minstant = "0.1.3"
 coverage-helper = "0.2.0"
 
 # workspace
-fvm = { path = "fvm", version = "~4.3.1", default-features = false }
-fvm_shared = { path = "shared", version = "~4.3.1", default-features = false }
-fvm_sdk = { path = "sdk", version = "~4.3.1" }
+fvm = { path = "fvm", version = "~4.3.2", default-features = false }
+fvm_shared = { path = "shared", version = "~4.3.2", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.3.2" }
 fvm_ipld_amt = { path = "ipld/amt", version = "0.6.2" }
 fvm_ipld_hamt = { path = "ipld/hamt", version = "0.9.0" }
 fvm_ipld_kamt = { path = "ipld/kamt", version = "0.3.0" }
@@ -84,7 +84,7 @@ fvm_ipld_car = { path = "ipld/car", version = "0.7.1" }
 fvm_ipld_blockstore = { path = "ipld/blockstore", version = "0.2.1" }
 fvm_ipld_bitfield = { path = "ipld/bitfield", version = "0.6.0" }
 fvm_ipld_encoding = { path = "ipld/encoding", version = "0.4.0" }
-fvm_integration_tests = { path = "testing/integration", version = "~4.3.1" }
+fvm_integration_tests = { path = "testing/integration", version = "~4.3.2" }
 fvm_gas_calibration_shared = { path = "testing/calibration/shared" }
 fvm_test_actors = { path = "testing/test_actors" }
 

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
-## 4.3.2 [2024-07-01]
+## 4.3.2 [2024-08-16]
 
 - feat: add `nv24-dev` feature flag [#2029](https://github.com/filecoin-project/ref-fvm/pull/2029)
 

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,13 +4,17 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
-## 4.3.1 [2023-06-26]
+## 4.3.2 [2024-07-01]
+
+- feat: add `nv24-dev` feature flag [#2029](https://github.com/filecoin-project/ref-fvm/pull/2029)
+
+## 4.3.1 [2024-06-26]
 
 - **BREAKING**: Simplify the verify-signtures feature and update ambassador. This is a minor-breaking change because the ambassador macros are now only exported from the prelude/kernel module, not the crate root as they previously were.
 - chore: remove the `nv23-dev` feature flag [#2022](https://github.com/filecoin-project/ref-fvm/pull/2022)
 - chore: update wasmtime to 19.0.2
 
-## 4.3.0 [2023-06-12]
+## 4.3.0 [2024-06-12]
 
 - feat: FIP-0079: syscall for aggregated bls verification [#2003](https://github.com/filecoin-project/ref-fvm/pull/2003)
 - fix: install rust nightly toolchain for clusterfuzzlite [#2007](https://github.com/filecoin-project/ref-fvm/pull/2007)
@@ -19,22 +23,22 @@ Changes to the reference FVM implementation.
 - Small tidy-ups in CONTRIBUTING.md [#2012](https://github.com/filecoin-project/ref-fvm/pull/2012)
 - NI-PoRep support [#2010](https://github.com/filecoin-project/ref-fvm/pull/2010)
 
-## 4.2.0 [2023-04-29]
+## 4.2.0 [2024-04-29]
 
 - chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/ref-fvm/pull/1993)
 - Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/ref-fvm/pull/2000)
 - feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/ref-fvm/pull/1989)
 - feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/ref-fvm/pull/1984)
 
-## 4.1.2 [2023-01-31]
+## 4.1.2 [2024-01-31]
 
 feat: allow CBOR events
 
-## 4.1.1 [2023-01-25]
+## 4.1.1 [2024-01-25]
 
 Enable nv22 support by default.
 
-## 4.1.0 [2023-01-24]
+## 4.1.0 [2024-01-24]
 
 - Default the concurrency of the `ThreadedExecutor` to the available parallelism instead of 8.
 - Support custom syscalls (only needed for non-Filecoin users).

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## [Unreleased]
 
-## 4.3.1 [2023-06-26]
+## 4.3.2 [2024-07-01]
+
+- feat: add `nv24-dev` feature flag [#2029](https://github.com/filecoin-project/ref-fvm/pull/2029)
+
+## 4.3.1 [2024-06-26]
 
 - chore: remove the `nv23-dev` feature flag [#2022](https://github.com/filecoin-project/ref-fvm/pull/2022)
 
-## 4.3.0 [2023-06-12]
+## 4.3.0 [2024-06-12]
 
 - feat: FIP-0079: syscall for aggregated bls verification [#2003](https://github.com/filecoin-project/ref-fvm/pull/2003)
 - fix: install rust nightly toolchain for clusterfuzzlite [#2007](https://github.com/filecoin-project/ref-fvm/pull/2007)
@@ -15,22 +19,22 @@
 - Small tidy-ups in CONTRIBUTING.md [#2012](https://github.com/filecoin-project/ref-fvm/pull/2012)
 - NI-PoRep support [#2010](https://github.com/filecoin-project/ref-fvm/pull/2010)
 
-## 4.2.0 [2023-04-29]
+## 4.2.0 [2024-04-29]
 
 - chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/ref-fvm/pull/1993)
 - Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/ref-fvm/pull/2000)
 - feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/ref-fvm/pull/1989)
 - feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/ref-fvm/pull/1984)
 
-## 4.1.2 [2023-01-31]
+## 4.1.2 [2024-01-31]
 
 feat: allow CBOR events
 
-## 4.1.1 [2023-01-25]
+## 4.1.1 [2024-01-25]
 
 Enable nv22 support by default.
 
-## 4.1.0 [2023-01-24]
+## 4.1.0 [2024-01-24]
 
 - Add a syscall to upgrade the running actor's code-CID (behind the "actor-upgrade" feature flag).
 - Export the `fvm_syscalls` macro for defining syscall bindings (needed for custom syscall implementers).

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## 4.3.2 [2024-07-01]
+## 4.3.2 [2024-08-16]
 
 - feat: add `nv24-dev` feature flag [#2029](https://github.com/filecoin-project/ref-fvm/pull/2029)
 

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## [Unreleased]
 
-## 4.3.1 [2023-06-26]
+## 4.3.2 [2024-07-01]
+
+- feat: add `nv24-dev` feature flag [#2029](https://github.com/filecoin-project/ref-fvm/pull/2029)
+
+## 4.3.1 [2024-06-26]
 
 - chore: remove the `nv23-dev` feature flag [#2022](https://github.com/filecoin-project/ref-fvm/pull/2022)
 
-## 4.3.0 [2023-06-12]
+## 4.3.0 [2024-06-12]
 
 - feat: FIP-0079: syscall for aggregated bls verification [#2003](https://github.com/filecoin-project/ref-fvm/pull/2003)
 - fix: install rust nightly toolchain for clusterfuzzlite [#2007](https://github.com/filecoin-project/ref-fvm/pull/2007)
@@ -15,22 +19,22 @@
 - Small tidy-ups in CONTRIBUTING.md [#2012](https://github.com/filecoin-project/ref-fvm/pull/2012)
 - NI-PoRep support [#2010](https://github.com/filecoin-project/ref-fvm/pull/2010)
 
-## 4.2.0 [2023-04-29]
+## 4.2.0 [2024-04-29]
 
 - chore: update to wasmtime 19.0.1 [#1993](https://github.com/filecoin-project/ref-fvm/pull/1993)
 - Enable nv23 support behind the `nv23-dev` feature flag [#2000](https://github.com/filecoin-project/ref-fvm/pull/2000)
 - feat: fvm: remove once_cell [#1989](https://github.com/filecoin-project/ref-fvm/pull/1989)
 - feat: shared: check bls zero address without lazy_static [#1984](https://github.com/filecoin-project/ref-fvm/pull/1984)
 
-## 4.1.2 [2023-01-31]
+## 4.1.2 [2024-01-31]
 
 feat: allow CBOR events
 
-## 4.1.1 [2023-01-25]
+## 4.1.1 [2024-01-25]
 
 Enable nv22 support by default.
 
-## 4.1.0 [2023-01-24]
+## 4.1.0 [2024-01-24]
 
 - Pretty-print addresses when debug-formatting, instead of printing the raw bytes as a vector.
 - Move the `ActorState` struct to this crate (from the `fvm` crate).

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## 4.3.2 [2024-07-01]
+## 4.3.2 [2024-08-16]
 
 - feat: add `nv24-dev` feature flag [#2029](https://github.com/filecoin-project/ref-fvm/pull/2029)
 


### PR DESCRIPTION
Closes #2028 

Updated `Cargo.toml` for a new release.
Dates were wrong in the `CHANGELOG.md` files for 2024 releases (lmk if I am wrong).

If you guys want to merge more PRs before the release and make it a breaking change, happy to wait for it.

cc @rjan90 