### PR TITLE
fix: use unix signal handlers instead of Mach ports

### DIFF
--- a/fvm/src/engine/mod.rs
+++ b/fvm/src/engine/mod.rs
@@ -247,6 +247,15 @@ fn wasmtime_config(ec: &EngineConfig) -> anyhow::Result<wasmtime::Config> {
     // todo(M2): make sure this is guaranteed to run in linear time.
     c.cranelift_opt_level(Speed);
 
+    // Use traditional unix signal handlers instead of Mach ports on MacOS. The Mach ports signal
+    // handlers don't appear to be capturing all SIGILL signals (when run under lotus) and we're not
+    // entirely sure why. Upstream documentation indicates that this could be due to the use of
+    // `fork`, but we're only using threads, not subprocesses.
+    //
+    // The downside to using traditional signal handlers is that this may interfere with some
+    // debugging tools. But we'll just have to live with that.
+    c.macos_use_mach_ports(false);
+
     Ok(c)
 }
 


### PR DESCRIPTION
This will apparently interfere with some debugging tools, but we ran into an issue where Mach ports weren't always catching illegal instruction signals form wasmtime (affecting macos only).