### PR TITLE
chore: release v4.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.4.0",
  "libfuzzer-sys",
  "multihash 0.18.1",
  "rand",
@@ -1520,7 +1520,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "num-derive 0.3.3",
  "num-traits",
  "serde",
@@ -1553,7 +1553,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "log",
  "num-derive 0.3.3",
  "num-traits",
@@ -1573,7 +1573,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "lazy_static",
  "log",
  "num-derive 0.3.3",
@@ -1592,7 +1592,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "hex-literal",
  "log",
  "multihash 0.18.1",
@@ -1611,7 +1611,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "hex-literal",
  "num-derive 0.3.3",
  "num-traits",
@@ -1631,7 +1631,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_kamt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "hex",
  "hex-literal",
  "log",
@@ -1654,7 +1654,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "log",
  "num-derive 0.3.3",
  "num-traits",
@@ -1675,7 +1675,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "integer-encoding 3.0.4",
  "lazy_static",
  "libipld-core 0.13.1",
@@ -1701,7 +1701,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -1724,7 +1724,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "indexmap 1.9.3",
  "integer-encoding 3.0.4",
  "num-derive 0.3.3",
@@ -1743,7 +1743,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "num-derive 0.3.3",
  "num-traits",
  "serde",
@@ -1766,7 +1766,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "indexmap 1.9.3",
  "integer-encoding 3.0.4",
  "lazy_static",
@@ -1784,7 +1784,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "lazy_static",
  "log",
  "num-derive 0.3.3",
@@ -1802,7 +1802,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "num-derive 0.3.3",
  "num-traits",
  "serde",
@@ -1822,7 +1822,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "lazy_static",
  "log",
  "num-derive 0.3.3",
@@ -1837,7 +1837,7 @@ source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "hex",
  "serde",
  "uint",
@@ -1858,8 +1858,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "integer-encoding 3.0.4",
  "itertools 0.10.5",
  "lazy_static",
@@ -1883,8 +1883,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
 ]
 
 [[package]]
@@ -1920,8 +1920,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
 ]
 
 [[package]]
@@ -1930,8 +1930,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1942,8 +1942,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
  "serde",
  "serde_tuple",
 ]
@@ -1953,8 +1953,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
 ]
 
 [[package]]
@@ -1965,8 +1965,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
  "libipld",
  "num-derive 0.4.2",
  "num-traits",
@@ -1978,8 +1978,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
  "log",
  "serde",
  "serde_tuple",
@@ -1989,8 +1989,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
 ]
 
 [[package]]
@@ -2001,8 +2001,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
  "serde",
  "serde_tuple",
 ]
@@ -2012,8 +2012,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
  "minicov",
 ]
 
@@ -2021,16 +2021,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
 ]
 
 [[package]]
@@ -2039,8 +2039,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
 ]
 
 [[package]]
@@ -2049,16 +2049,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
 ]
 
 [[package]]
@@ -2067,8 +2067,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -2079,8 +2079,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
  "serde",
  "serde_tuple",
 ]
@@ -2091,8 +2091,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
  "serde",
  "serde_tuple",
 ]
@@ -2246,8 +2246,8 @@ dependencies = [
  "frc42_hasher",
  "frc42_macros",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "thiserror",
 ]
 
@@ -2257,8 +2257,8 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238a28ff638f138c4b4c75f4d35cd28cedcb45858cfcaa4df36dc25b0b3298db"
 dependencies = [
- "fvm_sdk 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "thiserror",
 ]
 
@@ -2287,8 +2287,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "integer-encoding 4.0.2",
  "num-traits",
  "serde",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.3.2"
+version = "4.4.0"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2431,7 +2431,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.4.0",
  "lazy_static",
  "log",
  "minstant",
@@ -2461,7 +2461,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.4.0",
  "hex",
 ]
 
@@ -2488,8 +2488,8 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.3.2",
+ "fvm_shared 4.3.2",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -2514,7 +2514,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.4.0",
  "itertools 0.13.0",
  "ittapi-rs",
  "lazy_static",
@@ -2535,7 +2535,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.3.2",
+ "fvm_shared 4.4.0",
  "num-derive 0.4.2",
  "num-traits",
  "serde",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.3.2"
+version = "4.4.0"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2558,8 +2558,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.4.0",
+ "fvm_shared 4.4.0",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2807,9 +2807,11 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ae1b65e7da2deb17ee3bf61597ab3e79dd6b535710134274d003d3307662de"
 dependencies = [
  "cid 0.10.1",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 4.3.2",
  "lazy_static",
  "log",
@@ -2819,52 +2821,15 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ae1b65e7da2deb17ee3bf61597ab3e79dd6b535710134274d003d3307662de"
+version = "4.4.0"
 dependencies = [
  "cid 0.10.1",
- "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.4.0",
+ "fvm_shared 4.4.0",
  "lazy_static",
  "log",
  "num-traits",
  "thiserror",
-]
-
-[[package]]
-name = "fvm_shared"
-version = "4.3.2"
-dependencies = [
- "anyhow",
- "arbitrary",
- "bitflags 2.6.0",
- "blake2b_simd",
- "bls-signatures",
- "cid 0.10.1",
- "coverage-helper",
- "data-encoding",
- "data-encoding-macro",
- "filecoin-proofs-api",
- "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.2",
- "lazy_static",
- "libsecp256k1",
- "multihash 0.18.1",
- "num-bigint",
- "num-derive 0.4.2",
- "num-integer",
- "num-traits",
- "quickcheck",
- "quickcheck_macros",
- "rand",
- "rand_chacha",
- "rusty-fork",
- "serde",
- "serde_json",
- "serde_tuple",
- "thiserror",
- "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -2890,6 +2855,41 @@ dependencies = [
  "serde_tuple",
  "thiserror",
  "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "fvm_shared"
+version = "4.4.0"
+dependencies = [
+ "anyhow",
+ "arbitrary",
+ "bitflags 2.6.0",
+ "blake2b_simd",
+ "bls-signatures",
+ "cid 0.10.1",
+ "coverage-helper",
+ "data-encoding",
+ "data-encoding-macro",
+ "filecoin-proofs-api",
+ "fvm_ipld_encoding 0.4.0",
+ "fvm_shared 4.4.0",
+ "lazy_static",
+ "libsecp256k1",
+ "multihash 0.18.1",
+ "num-bigint",
+ "num-derive 0.4.2",
+ "num-integer",
+ "num-traits",
+ "quickcheck",
+ "quickcheck_macros",
+ "rand",
+ "rand_chacha",
+ "rusty-fork",
+ "serde",
+ "serde_json",
+ "serde_tuple",
+ "thiserror",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -5151,7 +5151,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.3.2",
  "num-derive 0.3.3",
  "num-traits",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.3.2"
+version = "4.4.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -73,9 +73,9 @@ minstant = "0.1.3"
 coverage-helper = "0.2.0"
 
 # workspace
-fvm = { path = "fvm", version = "~4.3.2", default-features = false }
-fvm_shared = { path = "shared", version = "~4.3.2", default-features = false }
-fvm_sdk = { path = "sdk", version = "~4.3.2" }
+fvm = { path = "fvm", version = "~4.4.0", default-features = false }
+fvm_shared = { path = "shared", version = "~4.4.0", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.4.0" }
 fvm_ipld_amt = { path = "ipld/amt", version = "0.6.2" }
 fvm_ipld_hamt = { path = "ipld/hamt", version = "0.9.0" }
 fvm_ipld_kamt = { path = "ipld/kamt", version = "0.3.0" }
@@ -83,7 +83,7 @@ fvm_ipld_car = { path = "ipld/car", version = "0.7.1" }
 fvm_ipld_blockstore = { path = "ipld/blockstore", version = "0.2.1" }
 fvm_ipld_bitfield = { path = "ipld/bitfield", version = "0.6.0" }
 fvm_ipld_encoding = { path = "ipld/encoding", version = "0.4.0" }
-fvm_integration_tests = { path = "testing/integration", version = "~4.3.2" }
+fvm_integration_tests = { path = "testing/integration", version = "~4.4.0" }
 fvm_gas_calibration_shared = { path = "testing/calibration/shared" }
 fvm_test_actors = { path = "testing/test_actors" }
 

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,12 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.4.0 [2024-09-12]
+
+- Update to wasmtime 24.
+- Switch from mach ports to unix signal handlers on macos.
+- Update misc dependencies.
+
 ## 4.3.2 [2024-08-16]
 
 - feat: add `nv24-dev` feature flag [#2029](https://github.com/filecoin-project/ref-fvm/pull/2029)

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## 4.4.0 [2024-09-12]
+
+- Update to wasmtime 24.
+- Switch from mach ports to unix signal handlers on macos.
+- Update misc dependencies.
+
 ## 4.3.2 [2024-08-16]
 
 - feat: add `nv24-dev` feature flag [#2029](https://github.com/filecoin-project/ref-fvm/pull/2029)

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## 4.4.0 [2024-09-12]
+
+- Update to wasmtime 24.
+- Switch from mach ports to unix signal handlers on macos.
+- Update misc dependencies.
+
 ## 4.3.2 [2024-08-16]
 
 - feat: add `nv24-dev` feature flag [#2029](https://github.com/filecoin-project/ref-fvm/pull/2029)


### PR DESCRIPTION
* update wasmtime from v19 to v24
* macos: use unix signal handling instead of mach ports
* update misc dependencies