### PR TITLE
chore: release v2.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_conformance_tests"
-version = "0.1.0"
+version = "2.9.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "2.4.0"
+version = "2.9.0"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "2.7.0"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,13 @@ members = [
     "testing/conformance",
 ]
 
+[workspace.package]
+version = "2.9.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+repository = "https://github.com/filecoin-project/ref-fvm"
+authors = ["Protocol Labs", "Filecoin Core Devs"]
+
 [workspace.dependencies]
 cid = { version = "0.10.1", default-features = false }
 multihash = { version = "0.18.1", default-features = false }
@@ -17,6 +24,10 @@ fvm_ipld_blockstore = { version = "0.2.0" }
 fvm_ipld_encoding = { version = "0.4.0" }
 wasmtime = { version = "24.0.0", default-features = false, features = ["cranelift", "pooling-allocator", "parallel-compilation", "runtime"] }
 wasmtime-environ = "24.0.0"
+
+fvm = { path = "fvm", version = "~2.9.0", default-features = false }
+fvm_shared = { path = "shared", version = "~2.9.0", default-features = false }
+fvm_sdk = { path = "sdk", version = "~2.9.0" }
 
 [profile.actor]
 inherits = "release"

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,12 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 2.9.0 (2024-09-12)
+
+- Update to wasmtime 24.
+- Switch from mach ports to unix signal handlers on macos.
+- Update misc dependencies.
+
 ## 2.8.0 (2024-06-12)
 
 - Update `filecoin-proofs-api` to v18 

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "2.8.0"
-license = "MIT OR Apache-2.0"
-authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/ref-fvm"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+authors.workspace = true
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]
@@ -19,7 +19,7 @@ derive_builder = "0.20.1"
 num-derive = "0.4.0"
 cid = { workspace = true, features = ["serde-codec"] }
 multihash = { workspace = true }
-fvm_shared = { version = "2.7.0", path = "../shared", features = ["crypto"] }
+fvm_shared = { workspace = true, features = ["crypto"] }
 fvm_ipld_hamt = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.9.0 (2024-09-12)
+
+- Update misc dependencies.
+
 ## 2.4.0 (2023-06-28)
 
 Breaking Changes:

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "2.4.0"
-license = "MIT OR Apache-2.0"
-authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
-repository = "https://github.com/filecoin-project/ref-fvm"
+authors.workspace = true
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["lib"]
 
 [dependencies]
 cid = { workspace = true }
-fvm_shared = { version = "2.6.0", path = "../shared" }
+fvm_shared = { workspace = true }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.14", default-features = false }
 lazy_static = { version = "1.4.0" }

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.9.0 (2024-09-12)
+
+- Update misc dependencies.
+
 ## 2.7.0 (2024-06-12)
 
 - Update `filecoin-proofs-api` to v18 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "2.7.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
 blake2b_simd = "1.0.0"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "fvm_conformance_tests"
 description = "Filecoin Virtual Machine conformance tests"
-version = "0.1.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
 exclude = ["/test-vectors"]
 publish = false
-repository = "https://github.com/filecoin-project/ref-fvm"
+edition.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
-fvm_shared = { version = "2.7.0", path = "../../shared" }
+fvm = { workspace = true, features = ["testing"] }
+fvm_shared = { workspace = true }
 fvm_ipld_hamt = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 fvm_ipld_car = { workspace = true }
@@ -49,12 +50,6 @@ ittapi-rs = { version = "0.3.0", optional = true }
 libipld-core = { version = "0.16.0", features = ["serde-codec"] }
 tar = { version = "0.4.38", default-features = false }
 zstd = { version = "0.13.2", default-features = false }
-
-[dependencies.fvm]
-version = "2.8.0"
-path = "../../fvm"
-default-features = false
-features = ["testing"]
 
 [features]
 vtune = ["wasmtime/profiling", "ittapi-rs"]


### PR DESCRIPTION
Also switch to workspace-based versioning so we can more easily release everything all at once.