### PR TITLE
chore: release v3.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,8 +1902,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
 ]
 
 [[package]]
@@ -1939,8 +1939,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime 14.0.0",
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
 ]
 
 [[package]]
@@ -1948,8 +1948,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
  "serde",
  "serde_tuple",
 ]
@@ -1959,8 +1959,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
 ]
 
 [[package]]
@@ -1971,8 +1971,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
  "num-derive 0.4.2",
  "num-traits",
  "serde",
@@ -1983,8 +1983,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
  "log",
  "serde",
  "serde_tuple",
@@ -1994,8 +1994,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
 ]
 
 [[package]]
@@ -2006,8 +2006,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
  "serde",
  "serde_tuple",
 ]
@@ -2017,8 +2017,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
  "minicov",
 ]
 
@@ -2026,16 +2026,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
 ]
 
 [[package]]
@@ -2044,8 +2044,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
 ]
 
 [[package]]
@@ -2054,16 +2054,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
 ]
 
 [[package]]
@@ -2072,8 +2072,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime 14.0.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.3.0",
- "fvm_shared 3.10.0",
+ "fvm_sdk 3.11.0",
+ "fvm_shared 3.11.0",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2408,7 +2408,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 3.10.0",
+ "fvm_shared 3.11.0",
  "lazy_static",
  "log",
  "minstant",
@@ -2439,7 +2439,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.10.0",
+ "fvm_shared 3.11.0",
  "hex",
 ]
 
@@ -2492,7 +2492,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.10.0",
+ "fvm_shared 3.11.0",
  "itertools 0.13.0",
  "ittapi-rs",
  "lazy_static",
@@ -2514,7 +2514,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 3.10.0",
+ "fvm_shared 3.11.0",
  "num-derive 0.4.2",
  "num-traits",
  "serde",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "3.3.0"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -2536,7 +2536,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.10.0",
+ "fvm_shared 3.11.0",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2771,11 +2771,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.3.0"
+version = "3.11.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.10.0",
+ "fvm_shared 3.11.0",
  "lazy_static",
  "log",
  "num-traits",
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2825,7 +2825,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.10.0",
+ "fvm_shared 3.11.0",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,23 @@ members = [
     "tools/fvm-bench",
 ]
 
+[workspace.package]
+version = "3.11.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+repository = "https://github.com/filecoin-project/ref-fvm"
+authors = ["Protocol Labs", "Filecoin Core Devs"]
+
 [workspace.dependencies]
 cid = { version = "0.10.1", default-features = false }
 multihash = { version = "0.18.1", default-features = false }
 wasmtime = { version = "24.0.0", default-features = false, features = ["cranelift", "pooling-allocator", "parallel-compilation", "runtime"] }
 wasmtime-environ = "24.0.0"
+
+fvm = { path = "fvm", version = "~3.11.0", default-features = false }
+fvm_shared = { path = "shared", version = "~3.11.0", default-features = false }
+fvm_sdk = { path = "sdk", version = "~3.11.0" }
+fvm_integration_tests = { path = "testing/integration", version = "~3.11.0" }
 
 [profile.actor]
 inherits = "release"

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,12 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 3.11.0 [2024-09-12]
+
+- Update to wasmtime 24.
+- Switch from mach ports to unix signal handlers on macos.
+- Update misc dependencies.
+
 ## 3.10.0 [2024-06-12]
 
 - Update `filecoin-proofs-api` to v18

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fvm"
 description = "Filecoin Virtual Machine reference implementation"
-version = "3.10.0"
-license = "MIT OR Apache-2.0"
-authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/ref-fvm"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+authors.workspace = true
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]
@@ -17,7 +17,7 @@ thiserror = "1.0.40"
 num-traits = "0.2"
 cid = { workspace = true, features = ["serde-codec"] }
 multihash = { workspace = true, features = ["sha2", "sha3", "ripemd"] }
-fvm_shared = { version = "3.10.0", path = "../shared", features = ["crypto"] }
+fvm_shared = { workspace = true, features = ["crypto"] }
 fvm_ipld_hamt = { version = "0.9.0" }
 fvm_ipld_amt = { version = "0.6.1" }
 fvm_ipld_blockstore = { version = "0.2.0" }

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## 3.11.0 [2024-09-12]
+
+- Update to wasmtime 24.
+- Switch from mach ports to unix signal handlers on macos.
+- Update misc dependencies.
+
 ## 3.3.0 [2023-06-28]
 
 Breaking Changes:

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "fvm_sdk"
 description = "Filecoin Virtual Machine actor development SDK"
-version = "3.3.0"
-license = "MIT OR Apache-2.0"
-authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/ref-fvm"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+authors.workspace = true
 
 [lib]
 crate-type = ["lib"]
 
 [dependencies]
 cid = { workspace = true }
-fvm_shared = { version = "3.6.0", path = "../shared" }
+fvm_shared = { workspace = true }
 ## num-traits; disabling default features makes it play nice with no_std.
 num-traits = { version = "0.2.15", default-features = false }
 lazy_static = { version = "1.4.0" }

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## 3.11.0 [2024-09-12]
+
+- Update to wasmtime 24.
+- Switch from mach ports to unix signal handlers on macos.
+- Update misc dependencies.
+
 ## 3.10.0 [2024-06-12]
 
 - Update `filecoin-proofs-api` to v18

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fvm_shared"
 description = "Filecoin Virtual Machine shared types and functions"
-version = "3.10.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
 blake2b_simd = "1.0.1"

--- a/testing/calibration/shared/Cargo.toml
+++ b/testing/calibration/shared/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Protocol Labs", "Filecoin Core Devs"]
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "3.6.0", path = "../../../shared", features = ["testing"] }
+fvm_shared = { workspace = true, features = ["testing"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 num-traits = "0.2"

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -9,7 +9,8 @@ publish = false
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-fvm_shared = { version = "3.6.0", path = "../../shared" }
+fvm = { workspace = true, features = ["testing"] }
+fvm_shared = { workspace = true }
 fvm_ipld_car = { version = "0.7.1" }
 fvm_ipld_blockstore = { version = "0.2.0" }
 fvm_ipld_encoding = { version = "0.4.0" }
@@ -37,12 +38,6 @@ ittapi-rs = { version = "0.3.0", optional = true }
 libipld-core = { version = "0.16.0", features = ["serde-codec"] }
 tar = { version = "0.4.38", default-features = false }
 zstd = { version = "0.13.2", default-features = false }
-
-[dependencies.fvm]
-version = "3.10.0"
-path = "../../fvm"
-default-features = false
-features = ["testing"]
 
 [features]
 vtune = ["wasmtime/profiling", "ittapi-rs"]

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "fvm_integration_tests"
 description = "Filecoin Virtual Machine integration tests framework"
-version = "3.3.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs", "Polyphene"]
-repository = "https://github.com/filecoin-project/ref-fvm"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-fvm = { version = "3.10.0", path = "../../fvm", default-features = false, features = ["testing"] }
-fvm_shared = { version = "3.10.0", path = "../../shared", features = ["testing"] }
+fvm = { workspace = true, features = ["testing"] }
+fvm_shared = { workspace = true, features = ["testing"] }
 fvm_ipld_car = { version = "0.7.1" }
 fvm_ipld_blockstore = { version = "0.2.0" }
 fvm_ipld_encoding = { version = "0.4.0" }

--- a/testing/test_actors/actors/fil-address-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-address-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0" }
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-create-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-create-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }
 
 [lib]

--- a/testing/test_actors/actors/fil-events-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-events-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0" }
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 serde = {version = "1.0.164", features = ["derive"] }
 serde_tuple = "0.5.0"
 

--- a/testing/test_actors/actors/fil-exit-data-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-exit-data-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 fvm_ipld_encoding = { version = "0.4.0" }
 
 [lib]

--- a/testing/test_actors/actors/fil-gas-calibration-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-gas-calibration-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 fvm_ipld_encoding = { version = "0.4.0" }
 fvm_gas_calibration_shared = { path = "../../../calibration/shared" }
 

--- a/testing/test_actors/actors/fil-gaslimit-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-gaslimit-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0" }
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 serde = {version = "1.0.164", features = ["derive"] }
 serde_tuple = "0.5.0"
 log = "0.4.19"

--- a/testing/test_actors/actors/fil-hello-world-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-hello-world-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 fvm_ipld_encoding = { version = "0.4.0" }
 fvm_ipld_blockstore = { version = "0.2.0" }
 

--- a/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0" }
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 
 [target.'cfg(coverage)'.dependencies]
 minicov = "0.3"

--- a/testing/test_actors/actors/fil-malformed-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-malformed-syscall-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
+fvm_shared = { workspace = true }
+fvm_sdk = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-oom-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-oom-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-readonly-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-readonly-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 fvm_ipld_encoding = { version = "0.4.0" }
 cid = { workspace = true }
 

--- a/testing/test_actors/actors/fil-sself-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-sself-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 fvm_ipld_encoding = { version = "0.4.0" }
 cid = { workspace = true }
 

--- a/testing/test_actors/actors/fil-stack-overflow-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-stack-overflow-actor/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fvm_ipld_encoding = { version = "0.4.0" }
-fvm_sdk = { version = "3.3.0", path = "../../../../sdk" }
-fvm_shared = { version = "3.6.0", path = "../../../../shared" }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
 minicov = {version = "0.3", optional = true}
 actors_v10_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }
 multihash = { workspace = true, features = ["sha3", "sha2", "ripemd"]  }

--- a/tools/fvm-bench/Cargo.toml
+++ b/tools/fvm-bench/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "fvm-bench"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+publish = false
 
 [dependencies]
-fvm_integration_tests = { path = "../../testing/integration" }
+fvm = { workspace = true }
+fvm_integration_tests = { workspace = true }
 fvm_ipld_encoding = { version = "0.4" }
-fvm_shared = { path = "../../shared" }
+fvm_shared = { workspace = true }
 anyhow = "1.0.71"
 clap = { version = "4.3.9", features = ["derive", "std", "help", "usage", "error-context"], default-features = false }
 hex = "0.4.3"
 env_logger = "0.11.5"
-fvm = { path = "../../fvm", default-features = false }


### PR DESCRIPTION
And switch to workspace dependencies/versions to simplify the release process.