### PR TITLE
chore: release v4.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.0",
+ "fvm_shared 4.4.1",
  "libfuzzer-sys",
  "multihash 0.18.1",
  "rand",
@@ -1883,8 +1883,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
 ]
 
 [[package]]
@@ -1920,8 +1920,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
 ]
 
 [[package]]
@@ -1930,8 +1930,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1942,8 +1942,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
  "serde",
  "serde_tuple",
 ]
@@ -1953,8 +1953,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
 ]
 
 [[package]]
@@ -1965,8 +1965,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
  "libipld",
  "num-derive 0.4.2",
  "num-traits",
@@ -1978,8 +1978,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
  "log",
  "serde",
  "serde_tuple",
@@ -1989,8 +1989,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
 ]
 
 [[package]]
@@ -2001,8 +2001,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
  "serde",
  "serde_tuple",
 ]
@@ -2012,8 +2012,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
  "minicov",
 ]
 
@@ -2021,16 +2021,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
 ]
 
 [[package]]
@@ -2039,8 +2039,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
 ]
 
 [[package]]
@@ -2049,16 +2049,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
 ]
 
 [[package]]
@@ -2067,8 +2067,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -2079,8 +2079,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
  "serde",
  "serde_tuple",
 ]
@@ -2091,8 +2091,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
  "serde",
  "serde_tuple",
 ]
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2431,7 +2431,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.4.0",
+ "fvm_shared 4.4.1",
  "lazy_static",
  "log",
  "minstant",
@@ -2461,7 +2461,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.0",
+ "fvm_shared 4.4.1",
  "hex",
 ]
 
@@ -2514,7 +2514,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.0",
+ "fvm_shared 4.4.1",
  "itertools 0.13.0",
  "ittapi-rs",
  "lazy_static",
@@ -2535,7 +2535,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.4.0",
+ "fvm_shared 4.4.1",
  "num-derive 0.4.2",
  "num-traits",
  "serde",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2558,8 +2558,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.0",
- "fvm_shared 4.4.0",
+ "fvm_sdk 4.4.1",
+ "fvm_shared 4.4.1",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2821,11 +2821,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.0",
+ "fvm_shared 4.4.1",
  "lazy_static",
  "log",
  "num-traits",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2872,7 +2872,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.0",
+ "fvm_shared 4.4.1",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.4.0"
+version = "4.4.1"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -73,9 +73,9 @@ minstant = "0.1.3"
 coverage-helper = "0.2.0"
 
 # workspace
-fvm = { path = "fvm", version = "~4.4.0", default-features = false }
-fvm_shared = { path = "shared", version = "~4.4.0", default-features = false }
-fvm_sdk = { path = "sdk", version = "~4.4.0" }
+fvm = { path = "fvm", version = "~4.4.1", default-features = false }
+fvm_shared = { path = "shared", version = "~4.4.1", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.4.1" }
 fvm_ipld_amt = { path = "ipld/amt", version = "0.6.2" }
 fvm_ipld_hamt = { path = "ipld/hamt", version = "0.9.0" }
 fvm_ipld_kamt = { path = "ipld/kamt", version = "0.3.0" }
@@ -83,7 +83,7 @@ fvm_ipld_car = { path = "ipld/car", version = "0.7.1" }
 fvm_ipld_blockstore = { path = "ipld/blockstore", version = "0.2.1" }
 fvm_ipld_bitfield = { path = "ipld/bitfield", version = "0.6.0" }
 fvm_ipld_encoding = { path = "ipld/encoding", version = "0.4.0" }
-fvm_integration_tests = { path = "testing/integration", version = "~4.4.0" }
+fvm_integration_tests = { path = "testing/integration", version = "~4.4.1" }
 fvm_gas_calibration_shared = { path = "testing/calibration/shared" }
 fvm_test_actors = { path = "testing/test_actors" }
 

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.4.1 [2024-10-04]
+
 - chore: remove the `nv24-dev` feature flag [#2051](https://github.com/filecoin-project/ref-fvm/pull/2051)
 
 ## 4.4.0 [2024-09-12]

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 4.4.1 [2024-10-04]
+
 - chore: remove the `nv24-dev` feature flag [#2051](https://github.com/filecoin-project/ref-fvm/pull/2051)
 
 ## 4.4.0 [2024-09-12]

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 4.4.1 [2024-10-04]
+
 - chore: remove the `nv24-dev` feature flag [#2051](https://github.com/filecoin-project/ref-fvm/pull/2051)
 
 ## 4.4.0 [2024-09-12]


### PR DESCRIPTION
Release v4.4.1 which drops the feature flag for network version 24.