### PR TITLE
chore: release v4.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "libfuzzer-sys",
  "multihash 0.18.1",
  "rand",
@@ -1748,8 +1748,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
 ]
 
 [[package]]
@@ -1785,8 +1785,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
 ]
 
 [[package]]
@@ -1795,8 +1795,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1807,8 +1807,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "serde",
  "serde_tuple",
 ]
@@ -1818,8 +1818,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
 ]
 
 [[package]]
@@ -1830,8 +1830,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "libipld",
  "num-derive 0.4.1",
  "num-traits",
@@ -1843,8 +1843,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "log",
  "serde",
  "serde_tuple",
@@ -1854,8 +1854,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
 ]
 
 [[package]]
@@ -1866,8 +1866,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "serde",
  "serde_tuple",
 ]
@@ -1877,8 +1877,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "minicov",
 ]
 
@@ -1886,16 +1886,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
 ]
 
 [[package]]
@@ -1904,8 +1904,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
 ]
 
 [[package]]
@@ -1914,16 +1914,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
 ]
 
 [[package]]
@@ -1932,8 +1932,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -1944,8 +1944,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "serde",
  "serde_tuple",
 ]
@@ -1956,8 +1956,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "serde",
  "serde_tuple",
 ]
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2300,7 +2300,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "lazy_static",
  "log",
  "minstant",
@@ -2331,7 +2331,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "hex",
 ]
 
@@ -2384,7 +2384,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "itertools 0.11.0",
  "ittapi-rs",
  "lazy_static",
@@ -2405,7 +2405,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "num-derive 0.4.1",
  "num-traits",
  "serde",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2428,8 +2428,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2692,11 +2692,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "lazy_static",
  "log",
  "num-traits",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2743,7 +2743,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.3.2"
+version = "4.3.3"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -74,9 +74,9 @@ minstant = "0.1.3"
 coverage-helper = "0.2.0"
 
 # workspace
-fvm = { path = "fvm", version = "~4.3.2", default-features = false }
-fvm_shared = { path = "shared", version = "~4.3.2", default-features = false }
-fvm_sdk = { path = "sdk", version = "~4.3.2" }
+fvm = { path = "fvm", version = "~4.3.3", default-features = false }
+fvm_shared = { path = "shared", version = "~4.3.3", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.3.3" }
 fvm_ipld_amt = { path = "ipld/amt", version = "0.6.2" }
 fvm_ipld_hamt = { path = "ipld/hamt", version = "0.9.0" }
 fvm_ipld_kamt = { path = "ipld/kamt", version = "0.3.0" }
@@ -84,7 +84,7 @@ fvm_ipld_car = { path = "ipld/car", version = "0.7.1" }
 fvm_ipld_blockstore = { path = "ipld/blockstore", version = "0.2.1" }
 fvm_ipld_bitfield = { path = "ipld/bitfield", version = "0.6.0" }
 fvm_ipld_encoding = { path = "ipld/encoding", version = "0.4.0" }
-fvm_integration_tests = { path = "testing/integration", version = "~4.3.2" }
+fvm_integration_tests = { path = "testing/integration", version = "~4.3.3" }
 fvm_gas_calibration_shared = { path = "testing/calibration/shared" }
 fvm_test_actors = { path = "testing/test_actors" }
 

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+- chore: remove the `nv24-dev` feature flag [#2051](https://github.com/filecoin-project/ref-fvm/pull/2051)
+
 ## 4.3.2 [2024-08-16]
 
 - feat: add `nv24-dev` feature flag [#2029](https://github.com/filecoin-project/ref-fvm/pull/2029)

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.3.3 [2024-10-04]
+
 - chore: remove the `nv24-dev` feature flag [#2051](https://github.com/filecoin-project/ref-fvm/pull/2051)
 
 ## 4.3.2 [2024-08-16]

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -61,4 +61,3 @@ gas_calibration = []
 # The current implementation keeps it by default for backward compatibility reason.
 # See <https://github.com/filecoin-project/ref-fvm/issues/2001>
 verify-signature = []
-nv24-dev = []

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -1001,9 +1001,9 @@ impl PriceList {
 /// Returns gas price list by NetworkVersion for gas consumption.
 pub fn price_list_by_network_version(network_version: NetworkVersion) -> &'static PriceList {
     match network_version {
-        NetworkVersion::V21 | NetworkVersion::V22 | NetworkVersion::V23 => &WATERMELON_PRICES,
-        #[cfg(feature = "nv24-dev")]
-        NetworkVersion::V24 => &WATERMELON_PRICES,
+        NetworkVersion::V21 | NetworkVersion::V22 | NetworkVersion::V23 | NetworkVersion::V24 => {
+            &WATERMELON_PRICES
+        }
         _ => panic!("network version {nv} not supported", nv = network_version),
     }
 }

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -51,11 +51,6 @@ where
     /// * `blockstore`: The underlying [blockstore][`Blockstore`] for reading/writing state.
     /// * `externs`: Client-provided ["external"][`Externs`] methods for accessing chain state.
     pub fn new(context: &MachineContext, blockstore: B, externs: E) -> anyhow::Result<Self> {
-        #[cfg(not(feature = "nv24-dev"))]
-        const SUPPORTED_VERSIONS: RangeInclusive<NetworkVersion> =
-            NetworkVersion::V21..=NetworkVersion::V23;
-
-        #[cfg(feature = "nv24-dev")]
         const SUPPORTED_VERSIONS: RangeInclusive<NetworkVersion> =
             NetworkVersion::V21..=NetworkVersion::V24;
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 4.3.3 [2024-10-04]
+
 - chore: remove the `nv24-dev` feature flag [#2051](https://github.com/filecoin-project/ref-fvm/pull/2051)
 
 ## 4.3.2 [2024-08-16]

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- chore: remove the `nv24-dev` feature flag [#2051](https://github.com/filecoin-project/ref-fvm/pull/2051)
+
 ## 4.3.2 [2024-08-16]
 
 - feat: add `nv24-dev` feature flag [#2029](https://github.com/filecoin-project/ref-fvm/pull/2029)

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 4.3.3 [2024-10-04]
+
 - chore: remove the `nv24-dev` feature flag [#2051](https://github.com/filecoin-project/ref-fvm/pull/2051)
 
 ## 4.3.2 [2024-08-16]

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- chore: remove the `nv24-dev` feature flag [#2051](https://github.com/filecoin-project/ref-fvm/pull/2051)
+
 ## 4.3.2 [2024-08-16]
 
 - feat: add `nv24-dev` feature flag [#2029](https://github.com/filecoin-project/ref-fvm/pull/2029)


### PR DESCRIPTION
### Context: 

We do not want to pull in the new wasmtime versions for the Lotus v1.30.0 release, just to be conservative because Lotus v1.30.0 will be a mandatory network version.

I have therefore:
- Created a `release/4.3` branch which was branched off the [fvm@v4.3.2](https://github.com/filecoin-project/ref-fvm/tree/fvm%40v4.3.2) tag.
- **In this PR:** Cherry-picked https://github.com/filecoin-project/ref-fvm/pull/2051, and bumped the version to v4.3.3, added changelog entries and updated the cargo.lock.

I looked through other things that have landed in master since v4.3.2 was tagged, but I could not see anything else that was directly needed for the nv24 upgrade. But it would be good if someone else also double confirmed