### PR TITLE
Release 4.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli 0.31.0",
+ "gimli 0.31.1",
 ]
 
 [[package]]
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 dependencies = [
  "backtrace",
 ]
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -278,13 +278,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -295,9 +295,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
@@ -580,9 +580,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cast"
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "jobserver",
  "libc",
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -760,14 +760,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -810,7 +810,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.1",
+ "fvm_shared 4.4.2",
  "libfuzzer-sys",
  "multihash 0.18.1",
  "rand",
@@ -1216,7 +1216,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1237,7 +1237,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "unicode-xid",
 ]
 
@@ -1450,7 +1450,7 @@ checksum = "ce8cd46a041ad005ab9c71263f9a0ff5b529eac0fe4cc9b4a20f4f0765d8cf4b"
 dependencies = [
  "execute-command-tokens",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1511,8 +1511,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "fil_actors_runtime",
@@ -1520,7 +1520,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "num-derive 0.3.3",
  "num-traits",
  "serde",
@@ -1547,13 +1547,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "log",
  "num-derive 0.3.3",
  "num-traits",
@@ -1562,8 +1562,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_datacap"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "cid 0.10.1",
  "fil_actors_runtime",
@@ -1573,7 +1573,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "lazy_static",
  "log",
  "num-derive 0.3.3",
@@ -1583,8 +1583,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_eam"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1592,7 +1592,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "hex-literal",
  "log",
  "multihash 0.18.1",
@@ -1604,14 +1604,14 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_ethaccount"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "hex-literal",
  "num-derive 0.3.3",
  "num-traits",
@@ -1620,8 +1620,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_evm"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1631,7 +1631,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_kamt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "hex",
  "hex-literal",
  "log",
@@ -1644,8 +1644,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1654,7 +1654,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "log",
  "num-derive 0.3.3",
  "num-traits",
@@ -1663,8 +1663,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1675,7 +1675,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "integer-encoding 3.0.4",
  "lazy_static",
  "libipld-core 0.13.1",
@@ -1687,8 +1687,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -1701,7 +1701,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -1713,8 +1713,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1724,7 +1724,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "indexmap 1.9.3",
  "integer-encoding 3.0.4",
  "num-derive 0.3.3",
@@ -1734,8 +1734,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1743,7 +1743,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "num-derive 0.3.3",
  "num-traits",
  "serde",
@@ -1751,13 +1751,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_placeholder"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 
 [[package]]
 name = "fil_actor_power"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1766,7 +1766,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "indexmap 1.9.3",
  "integer-encoding 3.0.4",
  "lazy_static",
@@ -1778,13 +1778,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "lazy_static",
  "log",
  "num-derive 0.3.3",
@@ -1794,15 +1794,15 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "num-derive 0.3.3",
  "num-traits",
  "serde",
@@ -1810,8 +1810,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -1822,7 +1822,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "lazy_static",
  "log",
  "num-derive 0.3.3",
@@ -1832,12 +1832,12 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_evm_shared"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "hex",
  "serde",
  "uint",
@@ -1845,8 +1845,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1858,8 +1858,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "integer-encoding 3.0.4",
  "itertools 0.10.5",
  "lazy_static",
@@ -1883,14 +1883,14 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
 ]
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "14.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+version = "15.0.0-rc1"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "cid 0.10.1",
  "clap",
@@ -1920,8 +1920,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
 ]
 
 [[package]]
@@ -1930,8 +1930,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1942,8 +1942,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
  "serde",
  "serde_tuple",
 ]
@@ -1953,8 +1953,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
 ]
 
 [[package]]
@@ -1965,8 +1965,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
  "libipld",
  "num-derive 0.4.2",
  "num-traits",
@@ -1978,8 +1978,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
  "log",
  "serde",
  "serde_tuple",
@@ -1989,8 +1989,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
 ]
 
 [[package]]
@@ -2001,8 +2001,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
  "serde",
  "serde_tuple",
 ]
@@ -2012,8 +2012,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
  "minicov",
 ]
 
@@ -2021,16 +2021,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
 ]
 
 [[package]]
@@ -2039,8 +2039,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
 ]
 
 [[package]]
@@ -2049,16 +2049,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
 ]
 
 [[package]]
@@ -2067,8 +2067,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -2079,8 +2079,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
  "serde",
  "serde_tuple",
 ]
@@ -2091,8 +2091,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
  "serde",
  "serde_tuple",
 ]
@@ -2181,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2203,6 +2203,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "forest_hash_utils"
@@ -2246,8 +2252,8 @@ dependencies = [
  "frc42_hasher",
  "frc42_macros",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "thiserror",
 ]
 
@@ -2257,8 +2263,8 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238a28ff638f138c4b4c75f4d35cd28cedcb45858cfcaa4df36dc25b0b3298db"
 dependencies = [
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "thiserror",
 ]
 
@@ -2287,8 +2293,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "integer-encoding 4.0.2",
  "num-traits",
  "serde",
@@ -2314,9 +2320,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2329,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2339,15 +2345,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2356,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -2375,32 +2381,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2416,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.4.1"
+version = "4.4.2"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2431,7 +2437,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.4.1",
+ "fvm_shared 4.4.2",
  "lazy_static",
  "log",
  "minstant",
@@ -2461,7 +2467,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.1",
+ "fvm_shared 4.4.2",
  "hex",
 ]
 
@@ -2488,8 +2494,8 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_sdk 4.3.2",
- "fvm_shared 4.3.2",
+ "fvm_sdk 4.3.3",
+ "fvm_shared 4.3.3",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -2514,7 +2520,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.1",
+ "fvm_shared 4.4.2",
  "itertools 0.13.0",
  "ittapi-rs",
  "lazy_static",
@@ -2535,7 +2541,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.4.1",
+ "fvm_shared 4.4.2",
  "num-derive 0.4.2",
  "num-traits",
  "serde",
@@ -2544,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.4.1"
+version = "4.4.2"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2558,8 +2564,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.1",
- "fvm_shared 4.4.1",
+ "fvm_sdk 4.4.2",
+ "fvm_shared 4.4.2",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2806,13 +2812,13 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.3.2"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ae1b65e7da2deb17ee3bf61597ab3e79dd6b535710134274d003d3307662de"
+checksum = "7e53061f4d51562b90fb3fe9be7a3ab9650a9bd8f08cc6b48d25e6bfe052a21b"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "lazy_static",
  "log",
  "num-traits",
@@ -2821,11 +2827,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.4.1"
+version = "4.4.2"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.1",
+ "fvm_shared 4.4.2",
  "lazy_static",
  "log",
  "num-traits",
@@ -2834,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.3.2"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b70df84e1e8b43e61d2e3700724fb5e560eee4e81fd428b9c8e278a465f694d"
+checksum = "9d3355d3bd2eb159a734a06d67dbb21b067a99540f5aefaf7d0d26503ccc73e3"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -2859,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.4.1"
+version = "4.4.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2872,7 +2878,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.1",
+ "fvm_shared 4.4.2",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",
@@ -2955,15 +2961,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "stable_deref_trait",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -3040,6 +3046,15 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -3146,12 +3161,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -3334,9 +3349,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "0cb94a0ffd3f3ee755c20f7d8752f45cac88605a4dcf808abcff72873296ec7b"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3376,9 +3391,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -3830,7 +3845,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3886,21 +3901,21 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "crc32fast",
- "hashbrown 0.14.5",
- "indexmap 2.5.0",
+ "hashbrown 0.15.0",
+ "indexmap 2.6.0",
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
@@ -4032,9 +4047,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plotters"
@@ -4113,9 +4128,9 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
@@ -4157,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
@@ -4286,9 +4301,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4308,9 +4323,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4320,9 +4335,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4331,9 +4346,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "replace_with"
@@ -4504,7 +4519,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4551,7 +4566,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4865,9 +4880,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4894,9 +4909,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
 dependencies = [
  "filetime",
  "libc",
@@ -4919,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -4941,22 +4956,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5049,9 +5064,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -5061,30 +5076,30 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsigned-varint"
@@ -5144,14 +5159,14 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vm_api"
 version = "1.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#a45fb87910bca74d62215b0d58ed90cf78b6c8ff"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#12d9af8a00d0909598c67e1a18dc1577e0833137"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_hamt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_shared 4.3.2",
+ "fvm_shared 4.3.3",
  "num-derive 0.3.3",
  "num-traits",
  "rand",
@@ -5177,9 +5192,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "ef073ced962d62984fb38a36e5fdc1a2b23c9e0e1fa0689bb97afa4202ef6887"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5188,24 +5203,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "c4bfab14ef75323f4eb75fa52ee0a3fb59611977fd3240da19b2cf36ff85030e"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "65471f79c1022ffa5291d33520cbbb53b7687b01c2f8e83b57d102eed7ed479d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5215,9 +5230,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "a7bec9830f60924d9ceb3ef99d55c155be8afa76954edffbb5936ff4509474e7"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5225,22 +5240,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "a42f6c679374623f295a8623adfe63d9284091245c3504bde47c17a3ce2777d9"
 
 [[package]]
 name = "wasm-encoder"
@@ -5262,11 +5277,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.217.0"
+version = "0.219.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88b0814c9a2b323a9b46c687e726996c255ac8b64aa237dd11c81ed4854760"
+checksum = "e2b1b95711b3ad655656a341e301cc64e33cbee94de9a99a1c5a2ab88efab79d"
 dependencies = [
  "leb128",
+ "wasmparser 0.219.0",
 ]
 
 [[package]]
@@ -5286,7 +5302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
  "bitflags 2.6.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "semver",
 ]
 
@@ -5299,9 +5315,19 @@ dependencies = [
  "ahash",
  "bitflags 2.6.0",
  "hashbrown 0.14.5",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.219.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "324b4e56d24439495b88cd81439dad5e97f3c7b1eedc3c7e10455ed1e045e9a2"
+dependencies = [
+ "bitflags 2.6.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -5338,7 +5364,7 @@ dependencies = [
  "cfg-if",
  "fxprof-processed-profile",
  "hashbrown 0.14.5",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "ittapi",
  "libc",
  "libm",
@@ -5388,7 +5414,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -5434,7 +5460,7 @@ dependencies = [
  "cranelift-bitset",
  "cranelift-entity",
  "gimli 0.29.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "log",
  "object",
  "postcard",
@@ -5499,7 +5525,7 @@ checksum = "ac3621bfccd4e4336ae141d62b96e96316c0f23c47d64e9700594ebe3c4d9a10"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5510,37 +5536,37 @@ checksum = "ee0f4524da226d2cb503d794c8928de6bc24878758cebd4e383c946e9fdb8b3a"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "wit-parser",
 ]
 
 [[package]]
 name = "wast"
-version = "217.0.0"
+version = "219.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79004ecebded92d3c710d4841383368c7f04b63d0992ddd6b0c7d5029b7629b7"
+checksum = "06880ecb25662bc21db6a83f4fcc27c41f71fbcba4f1980b650c88ada92728e1"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.217.0",
+ "wasm-encoder 0.219.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.217.0"
+version = "1.219.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c126271c3d92ca0f7c63e4e462e40c69cca52fd4245fcda730d1cf558fb55088"
+checksum = "11e56dbf9fc89111b0d97c91e683d7895b1a6e5633a729f2ccad2303724005b6"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "44188d185b5bdcae1052d08bcbcf9091a5524038d4572cc4f4f2bb9d5554ddd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5590,7 +5616,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5755,7 +5781,7 @@ checksum = "935a97eaffd57c3b413aa510f8f0b550a4a9fe7d59e79cd8b89a83dcb860321f"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "log",
  "semver",
  "serde",
@@ -5776,9 +5802,9 @@ dependencies = [
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yastl"
@@ -5808,7 +5834,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5828,7 +5854,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.4.1"
+version = "4.4.2"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -55,7 +55,7 @@ bls-signatures = { version = "0.15", default-features = false }
 
 # wasmtime
 wasmtime = {version = "24.0.1", default-features = false, features = ["cranelift", "pooling-allocator", "parallel-compilation", "runtime"] }
-wasmtime-environ = "24.0.0"
+wasmtime-environ = "24.0.1"
 
 # misc
 libfuzzer-sys = "0.4"
@@ -73,9 +73,9 @@ minstant = "0.1.3"
 coverage-helper = "0.2.0"
 
 # workspace
-fvm = { path = "fvm", version = "~4.4.1", default-features = false }
-fvm_shared = { path = "shared", version = "~4.4.1", default-features = false }
-fvm_sdk = { path = "sdk", version = "~4.4.1" }
+fvm = { path = "fvm", version = "~4.4.2", default-features = false }
+fvm_shared = { path = "shared", version = "~4.4.2", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.4.2" }
 fvm_ipld_amt = { path = "ipld/amt", version = "0.6.2" }
 fvm_ipld_hamt = { path = "ipld/hamt", version = "0.9.0" }
 fvm_ipld_kamt = { path = "ipld/kamt", version = "0.3.0" }

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.4.2 [2024-10-09]
+
+- Update wasmtime to 24.0.1.
+
 ## 4.4.1 [2024-10-04]
 
 - chore: remove the `nv24-dev` feature flag [#2051](https://github.com/filecoin-project/ref-fvm/pull/2051)

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 4.4.2 [2024-10-09]
+
+- Update wasmtime to 24.0.1.
+
 ## 4.4.1 [2024-10-04]
 
 - chore: remove the `nv24-dev` feature flag [#2051](https://github.com/filecoin-project/ref-fvm/pull/2051)

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 4.4.2 [2024-10-09]
+
+- Update wasmtime to 24.0.1.
+
 ## 4.4.1 [2024-10-04]
 
 - chore: remove the `nv24-dev` feature flag [#2051](https://github.com/filecoin-project/ref-fvm/pull/2051)


### PR DESCRIPTION
- Update wasmtime
- Update other deps

I've gone ahead and updated the rest of the deps as well (no major releases, just semver compatible versions) because there was a slew of other wasmtime and related crates that didn't appear to be automatically pulled in otherwise.