### PR TITLE
test: use the correct wasm profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,20 +87,13 @@ fvm_integration_tests = { path = "testing/integration", version = "~4.4.1" }
 fvm_gas_calibration_shared = { path = "testing/calibration/shared" }
 fvm_test_actors = { path = "testing/test_actors" }
 
-[profile.actor]
-inherits = "release"
-panic = "abort"
-overflow-checks = true
-lto = true
-opt-level = "z"
-#strip = true
-
+# Same as in the built-in actors repo
 [profile.wasm]
 inherits = "release"
-panic = "abort"
-overflow-checks = false
-lto = true
-opt-level = "z"
+panic = "unwind"
+overflow-checks = true
+lto = "thin"
+opt-level = 3
 strip = true
 codegen-units = 1
 incremental = false

--- a/testing/test_actors/actors/fil-integer-overflow-actor/src/actor/mod.rs
+++ b/testing/test_actors/actors/fil-integer-overflow-actor/src/actor/mod.rs
@@ -86,11 +86,11 @@ pub fn invoke(params_pointer: u32) -> u32 {
 
             None
         }
-        // Overflow value
+        // Overflow value, wrapping
         2 => {
             let mut state = State::load();
 
-            state.value = (state.value >> 1i64) * (state.value + 1);
+            state.value = (state.value >> 1i64).wrapping_mul(state.value.wrapping_add(1));
             state.save();
 
             None
@@ -108,6 +108,15 @@ pub fn invoke(params_pointer: u32) -> u32 {
                     );
                 }
             }
+        }
+        // Overflow value, default
+        4 => {
+            let mut state = State::load();
+
+            state.value = (state.value >> 1i64) * (state.value + 1);
+            state.save();
+
+            None
         }
         _ => abort(
             ExitCode::USR_UNHANDLED_MESSAGE.value(),

--- a/testing/test_actors/actors/fil-oom-actor/src/lib.rs
+++ b/testing/test_actors/actors/fil-oom-actor/src/lib.rs
@@ -48,6 +48,7 @@ fn allocate_one() {
         let cap = mem.len();
         mem.resize(2 * cap, 0);
     }
+    std::hint::black_box(mem);
 }
 
 // Allocate many small chunks until OOm
@@ -59,10 +60,11 @@ fn allocate_many() {
         chunk.resize(1024 * 1024, 0);
         chunks.push(chunk);
     }
+    std::hint::black_box(chunks);
 }
 
 #[cfg(target_arch = "wasm32")]
 fn allocate_some() {
     // 64 WASM pages
-    let _ = Vec::<u8>::with_capacity(64 * 65536);
+    std::hint::black_box(Vec::<u8>::with_capacity(64 * 65536));
 }


### PR DESCRIPTION
And update the integer overflow tests to match. It also gives us better test coverage of panics/traps.