### PR TITLE
chore: release v4.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.2",
+ "fvm_shared 4.4.3",
  "libfuzzer-sys",
  "multihash 0.18.1",
  "rand",
@@ -1883,8 +1883,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
 ]
 
 [[package]]
@@ -1920,8 +1920,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
 ]
 
 [[package]]
@@ -1930,8 +1930,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1942,8 +1942,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
  "serde",
  "serde_tuple",
 ]
@@ -1953,8 +1953,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
 ]
 
 [[package]]
@@ -1965,8 +1965,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
  "libipld",
  "num-derive 0.4.2",
  "num-traits",
@@ -1978,8 +1978,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
  "log",
  "serde",
  "serde_tuple",
@@ -1989,8 +1989,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
 ]
 
 [[package]]
@@ -2001,8 +2001,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
  "serde",
  "serde_tuple",
 ]
@@ -2012,8 +2012,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
  "minicov",
 ]
 
@@ -2021,16 +2021,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
 ]
 
 [[package]]
@@ -2039,8 +2039,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
 ]
 
 [[package]]
@@ -2049,16 +2049,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
 ]
 
 [[package]]
@@ -2067,8 +2067,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -2079,8 +2079,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
  "serde",
  "serde_tuple",
 ]
@@ -2091,8 +2091,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
  "serde",
  "serde_tuple",
 ]
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.4.2"
+version = "4.4.3"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2437,7 +2437,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.4.2",
+ "fvm_shared 4.4.3",
  "lazy_static",
  "log",
  "minstant",
@@ -2467,7 +2467,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.2",
+ "fvm_shared 4.4.3",
  "hex",
 ]
 
@@ -2520,7 +2520,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.2",
+ "fvm_shared 4.4.3",
  "itertools 0.13.0",
  "ittapi-rs",
  "lazy_static",
@@ -2541,7 +2541,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.4.2",
+ "fvm_shared 4.4.3",
  "num-derive 0.4.2",
  "num-traits",
  "serde",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.4.2"
+version = "4.4.3"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2565,8 +2565,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.2",
- "fvm_shared 4.4.2",
+ "fvm_sdk 4.4.3",
+ "fvm_shared 4.4.3",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2828,11 +2828,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.4.2"
+version = "4.4.3"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.2",
+ "fvm_shared 4.4.3",
  "lazy_static",
  "log",
  "num-traits",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.4.2"
+version = "4.4.3"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2879,7 +2879,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.2",
+ "fvm_shared 4.4.3",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.4.2"
+version = "4.4.3"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -72,10 +72,13 @@ quickcheck_macros = "1.0.0"
 minstant = "0.1.3"
 coverage-helper = "0.2.0"
 
-# workspace
-fvm = { path = "fvm", version = "~4.4.2", default-features = false }
-fvm_shared = { path = "shared", version = "~4.4.2", default-features = false }
-fvm_sdk = { path = "sdk", version = "~4.4.2" }
+# workspace (FVM)
+fvm = { path = "fvm", version = "~4.4.3", default-features = false }
+fvm_shared = { path = "shared", version = "~4.4.3", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.4.3" }
+fvm_integration_tests = { path = "testing/integration", version = "~4.4.3" }
+
+# workspace (other)
 fvm_ipld_amt = { path = "ipld/amt", version = "0.6.2" }
 fvm_ipld_hamt = { path = "ipld/hamt", version = "0.9.0" }
 fvm_ipld_kamt = { path = "ipld/kamt", version = "0.3.0" }
@@ -83,7 +86,6 @@ fvm_ipld_car = { path = "ipld/car", version = "0.7.1" }
 fvm_ipld_blockstore = { path = "ipld/blockstore", version = "0.2.1" }
 fvm_ipld_bitfield = { path = "ipld/bitfield", version = "0.6.0" }
 fvm_ipld_encoding = { path = "ipld/encoding", version = "0.4.0" }
-fvm_integration_tests = { path = "testing/integration", version = "~4.4.1" }
 fvm_gas_calibration_shared = { path = "testing/calibration/shared" }
 fvm_test_actors = { path = "testing/test_actors" }
 

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,11 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.4.3 [2024-10-21]
+
+- Update wasmtime to 25.0.2.
+- Fixes long wasm compile times with wasmtime 24.
+
 ## 4.4.2 [2024-10-09]
 
 - Update wasmtime to 24.0.1.

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## 4.4.3 [2024-10-21]
+
+- Update wasmtime to 25.0.2.
+- Fixes long wasm compile times with wasmtime 24.
+
 ## 4.4.2 [2024-10-09]
 
 - Update wasmtime to 24.0.1.

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## 4.4.3 [2024-10-21]
+
+- Update wasmtime to 25.0.2.
+- Fixes long wasm compile times with wasmtime 24.
+
 ## 4.4.2 [2024-10-09]
 
 - Update wasmtime to 24.0.1.


### PR DESCRIPTION
This release brings in wasmtime 25.0.2. We're doing this as a _patch_ release because 4.4 brought in wasmtime 24 which introduced a significant regression in wasm compile time (and there shouldn't be anything breaking in this release either).