### PR TITLE
chore: release v3.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,8 +1902,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
 ]
 
 [[package]]
@@ -1939,8 +1939,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime 15.0.0-rc1",
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
 ]
 
 [[package]]
@@ -1948,8 +1948,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
  "serde",
  "serde_tuple",
 ]
@@ -1959,8 +1959,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
 ]
 
 [[package]]
@@ -1971,8 +1971,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
  "num-derive 0.4.2",
  "num-traits",
  "serde",
@@ -1983,8 +1983,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
  "log",
  "serde",
  "serde_tuple",
@@ -1994,8 +1994,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
 ]
 
 [[package]]
@@ -2006,8 +2006,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
  "serde",
  "serde_tuple",
 ]
@@ -2017,8 +2017,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
  "minicov",
 ]
 
@@ -2026,16 +2026,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
 ]
 
 [[package]]
@@ -2044,8 +2044,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
 ]
 
 [[package]]
@@ -2054,16 +2054,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
 ]
 
 [[package]]
@@ -2072,8 +2072,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime 15.0.0-rc1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 3.11.0",
- "fvm_shared 3.11.0",
+ "fvm_sdk 3.11.1",
+ "fvm_shared 3.11.1",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2414,7 +2414,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 3.11.0",
+ "fvm_shared 3.11.1",
  "lazy_static",
  "log",
  "minstant",
@@ -2445,7 +2445,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.11.0",
+ "fvm_shared 3.11.1",
  "hex",
 ]
 
@@ -2498,7 +2498,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.11.0",
+ "fvm_shared 3.11.1",
  "itertools 0.13.0",
  "ittapi-rs",
  "lazy_static",
@@ -2520,7 +2520,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 3.11.0",
+ "fvm_shared 3.11.1",
  "num-derive 0.4.2",
  "num-traits",
  "serde",
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -2542,7 +2542,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.11.0",
+ "fvm_shared 3.11.1",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2777,11 +2777,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.11.0",
+ "fvm_shared 3.11.1",
  "lazy_static",
  "log",
  "num-traits",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2831,7 +2831,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 3.11.0",
+ "fvm_shared 3.11.1",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.11.0"
+version = "3.11.1"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -25,10 +25,10 @@ multihash = { version = "0.18.1", default-features = false }
 wasmtime = { version = "25.0.2", default-features = false, features = ["cranelift", "pooling-allocator", "parallel-compilation", "runtime"] }
 wasmtime-environ = "25.0.2"
 
-fvm = { path = "fvm", version = "~3.11.0", default-features = false }
-fvm_shared = { path = "shared", version = "~3.11.0", default-features = false }
-fvm_sdk = { path = "sdk", version = "~3.11.0" }
-fvm_integration_tests = { path = "testing/integration", version = "~3.11.0" }
+fvm = { path = "fvm", version = "~3.11.1", default-features = false }
+fvm_shared = { path = "shared", version = "~3.11.1", default-features = false }
+fvm_sdk = { path = "sdk", version = "~3.11.1" }
+fvm_integration_tests = { path = "testing/integration", version = "~3.11.1" }
 
 [profile.actor]
 inherits = "release"

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 3.11.1 [2024-10-21]
+
+- Update to wasmtime 25.
+
 ## 3.11.0 [2024-09-12]
 
 - Update to wasmtime 24.

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 3.11.1 [2024-10-21]
+
+- Update to wasmtime 25.
+
 ## 3.11.0 [2024-09-12]
 
 - Update to wasmtime 24.

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 3.11.1 [2024-10-21]
+
+- Update to wasmtime 25.
+
 ## 3.11.0 [2024-09-12]
 
 - Update to wasmtime 24.


### PR DESCRIPTION
This release brings in wasmtime 25.0.2. We're doing this as a patch release because 3.11 brought in wasmtime 24 which introduced a significant regression in wasm compile time (and there shouldn't be anything breaking in this release either).