### PR TITLE
chore: release v2.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_conformance_tests"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.9.0"
+version = "2.9.1"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -25,9 +25,9 @@ fvm_ipld_encoding = { version = "0.4.0" }
 wasmtime = { version = "25.0.2", default-features = false, features = ["cranelift", "pooling-allocator", "parallel-compilation", "runtime"] }
 wasmtime-environ = "25.0.2"
 
-fvm = { path = "fvm", version = "~2.9.0", default-features = false }
-fvm_shared = { path = "shared", version = "~2.9.0", default-features = false }
-fvm_sdk = { path = "sdk", version = "~2.9.0" }
+fvm = { path = "fvm", version = "~2.9.1", default-features = false }
+fvm_shared = { path = "shared", version = "~2.9.1", default-features = false }
+fvm_sdk = { path = "sdk", version = "~2.9.1" }
 
 [profile.actor]
 inherits = "release"

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 2.9.1 (2024-10-21)
+
+- Update to wasmtime 25.
+
 ## 2.9.0 (2024-09-12)
 
 - Update to wasmtime 24.

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.9.1 (2024-10-21)
+
+- Update to wasmtime 25.
+
 ## 2.9.0 (2024-09-12)
 
 - Update misc dependencies.

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.9.1 (2024-10-21)
+
+- Update to wasmtime 25.
+
 ## 2.9.0 (2024-09-12)
 
 - Update misc dependencies.


### PR DESCRIPTION
This release brings in wasmtime 25.0.2. We're doing this as a patch release because 2.9 brought in wasmtime 24 which introduced a significant regression in wasm compile time (and there shouldn't be anything breaking in this release either).