### PR TITLE
chore: update ipld crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,12 +692,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
 dependencies = [
- "arbitrary",
  "core2",
  "multibase",
  "multihash 0.18.1",
- "quickcheck",
- "rand",
  "serde",
  "serde_bytes",
  "unsigned-varint 0.7.2",
@@ -709,9 +706,12 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
 dependencies = [
+ "arbitrary",
  "core2",
  "multibase",
- "multihash 0.19.1",
+ "multihash 0.19.2",
+ "quickcheck",
+ "rand",
  "serde",
  "serde_bytes",
  "unsigned-varint 0.8.0",
@@ -807,12 +807,11 @@ name = "common_fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
- "cid 0.10.1",
+ "cid 0.11.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
  "fvm_shared 4.4.3",
  "libfuzzer-sys",
- "multihash 0.18.1",
  "rand",
  "serde",
 ]
@@ -1928,7 +1927,7 @@ dependencies = [
 name = "fil_custom_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "cid 0.10.1",
+ "cid 0.11.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 4.4.3",
  "fvm_shared 4.4.3",
@@ -1962,12 +1961,12 @@ name = "fil_gas_calibration_actor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid 0.10.1",
+ "cid 0.11.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 4.4.3",
  "fvm_shared 4.4.3",
- "libipld",
+ "ipld-core",
  "num-derive 0.4.2",
  "num-traits",
  "serde",
@@ -1998,11 +1997,12 @@ name = "fil_integer_overflow_actor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid 0.10.1",
+ "cid 0.11.1",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 4.4.3",
  "fvm_shared 4.4.3",
+ "multihash-codetable",
  "serde",
  "serde_tuple",
 ]
@@ -2037,7 +2037,7 @@ dependencies = [
 name = "fil_readonly_actor"
 version = "0.1.0"
 dependencies = [
- "cid 0.10.1",
+ "cid 0.11.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 4.4.3",
  "fvm_shared 4.4.3",
@@ -2047,7 +2047,7 @@ dependencies = [
 name = "fil_sself_actor"
 version = "0.1.0"
 dependencies = [
- "cid 0.10.1",
+ "cid 0.11.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 4.4.3",
  "fvm_shared 4.4.3",
@@ -2070,14 +2070,15 @@ dependencies = [
  "fvm_sdk 4.4.3",
  "fvm_shared 4.4.3",
  "minicov",
- "multihash 0.18.1",
+ "multihash-codetable",
+ "multihash-derive 0.9.1",
 ]
 
 [[package]]
 name = "fil_upgrade_actor"
 version = "0.1.0"
 dependencies = [
- "cid 0.10.1",
+ "cid 0.11.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 4.4.3",
  "fvm_shared 4.4.3",
@@ -2089,7 +2090,7 @@ dependencies = [
 name = "fil_upgrade_receive_actor"
 version = "0.1.0"
 dependencies = [
- "cid 0.10.1",
+ "cid 0.11.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_sdk 4.4.3",
  "fvm_shared 4.4.3",
@@ -2427,7 +2428,7 @@ dependencies = [
  "ambassador",
  "anyhow",
  "arbitrary",
- "cid 0.10.1",
+ "cid 0.11.1",
  "coverage-helper",
  "derive_more",
  "filecoin-proofs-api",
@@ -2441,7 +2442,8 @@ dependencies = [
  "lazy_static",
  "log",
  "minstant",
- "multihash 0.18.1",
+ "multihash-codetable",
+ "multihash-derive 0.9.1",
  "num-traits",
  "pretty_assertions",
  "quickcheck",
@@ -2509,7 +2511,7 @@ dependencies = [
  "anyhow",
  "async-std",
  "base64 0.22.1",
- "cid 0.10.1",
+ "cid 0.11.1",
  "colored",
  "criterion",
  "either",
@@ -2521,12 +2523,11 @@ dependencies = [
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_shared 4.4.3",
+ "ipld-core",
  "itertools 0.13.0",
  "ittapi-rs",
  "lazy_static",
- "libipld-core 0.16.0",
  "log",
- "multihash 0.18.1",
  "num-traits",
  "regex",
  "serde",
@@ -2556,7 +2557,7 @@ dependencies = [
  "anyhow",
  "blake2b_simd",
  "bls-signatures",
- "cid 0.10.1",
+ "cid 0.11.1",
  "criterion",
  "fil_builtin_actors_bundle",
  "futures",
@@ -2572,7 +2573,7 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "minstant",
- "multihash 0.18.1",
+ "multihash-codetable",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -2589,11 +2590,12 @@ name = "fvm_ipld_amt"
 version = "0.6.2"
 dependencies = [
  "anyhow",
- "cid 0.10.1",
+ "cid 0.11.1",
  "criterion",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "itertools 0.13.0",
+ "multihash-codetable",
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
@@ -2650,8 +2652,8 @@ name = "fvm_ipld_blockstore"
 version = "0.2.1"
 dependencies = [
  "anyhow",
- "cid 0.10.1",
- "multihash 0.18.1",
+ "cid 0.11.1",
+ "multihash-codetable",
 ]
 
 [[package]]
@@ -2670,10 +2672,12 @@ name = "fvm_ipld_car"
 version = "0.7.1"
 dependencies = [
  "async-std",
- "cid 0.10.1",
+ "cid 0.11.1",
  "futures",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
+ "multihash-codetable",
+ "multihash-derive 0.9.1",
  "serde",
  "thiserror",
  "unsigned-varint 0.8.0",
@@ -2699,9 +2703,9 @@ name = "fvm_ipld_encoding"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "cid 0.10.1",
+ "cid 0.11.1",
  "fvm_ipld_blockstore 0.2.1",
- "multihash 0.18.1",
+ "multihash-codetable",
  "serde",
  "serde_ipld_dagcbor 0.6.1",
  "serde_json",
@@ -2733,14 +2737,14 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "byteorder",
- "cid 0.10.1",
+ "cid 0.11.1",
  "criterion",
  "forest_hash_utils",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "hex",
- "libipld-core 0.16.0",
- "multihash 0.18.1",
+ "ipld-core",
+ "multihash-codetable",
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
@@ -2777,13 +2781,13 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "byteorder",
- "cid 0.10.1",
+ "cid 0.11.1",
  "criterion",
  "forest_hash_utils",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "hex",
- "multihash 0.18.1",
+ "multihash-codetable",
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
@@ -2830,7 +2834,7 @@ dependencies = [
 name = "fvm_sdk"
 version = "4.4.3"
 dependencies = [
- "cid 0.10.1",
+ "cid 0.11.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_shared 4.4.3",
  "lazy_static",
@@ -2873,7 +2877,7 @@ dependencies = [
  "bitflags 2.6.0",
  "blake2b_simd",
  "bls-signatures",
- "cid 0.10.1",
+ "cid 0.11.1",
  "coverage-helper",
  "data-encoding",
  "data-encoding-macro",
@@ -2882,7 +2886,7 @@ dependencies = [
  "fvm_shared 4.4.3",
  "lazy_static",
  "libsecp256k1",
- "multihash 0.18.1",
+ "multihash-codetable",
  "num-bigint",
  "num-derive 0.4.2",
  "num-integer",
@@ -3209,7 +3213,7 @@ name = "ipld_amt_fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
- "cid 0.10.1",
+ "cid 0.11.1",
  "fvm_ipld_amt 0.6.2",
  "fvm_ipld_blockstore 0.2.1",
  "itertools 0.13.0",
@@ -3399,48 +3403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libipld"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ccd6b8ffb3afee7081fcaec00e1b099fd1c7ccf35ba5729d88538fcc3b4599"
-dependencies = [
- "fnv",
- "libipld-cbor",
- "libipld-cbor-derive",
- "libipld-core 0.16.0",
- "libipld-json",
- "libipld-macro",
- "libipld-pb",
- "log",
- "multihash 0.18.1",
- "thiserror",
-]
-
-[[package]]
-name = "libipld-cbor"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d98c9d1747aa5eef1cf099cd648c3fd2d235249f5fed07522aaebc348e423b"
-dependencies = [
- "byteorder",
- "libipld-core 0.16.0",
- "thiserror",
-]
-
-[[package]]
-name = "libipld-cbor-derive"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5ba3a729b72973e456a1812b0afe2e176a376c1836cc1528e9fc98ae8cb838"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
-]
-
-[[package]]
 name = "libipld-core"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,39 +3429,6 @@ dependencies = [
  "multibase",
  "multihash 0.18.1",
  "serde",
- "thiserror",
-]
-
-[[package]]
-name = "libipld-json"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25856def940047b07b25c33d4e66d248597049ab0202085215dc4dca0487731c"
-dependencies = [
- "libipld-core 0.16.0",
- "multihash 0.18.1",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "libipld-macro"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71171c54214f866ae6722f3027f81dff0931e600e5a61e6b1b6a49ca0b5ed4ae"
-dependencies = [
- "libipld-core 0.16.0",
-]
-
-[[package]]
-name = "libipld-pb"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f2d0f866c4cd5dc9aa8068c429ba478d2882a3a4b70ab56f7e9a0eddf5d16f"
-dependencies = [
- "bytes",
- "libipld-core 0.16.0",
- "quick-protobuf",
  "thiserror",
 ]
 
@@ -3696,7 +3625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
  "core2",
- "multihash-derive",
+ "multihash-derive 0.8.1",
  "serde",
  "serde-big-array",
  "unsigned-varint 0.7.2",
@@ -3708,32 +3637,45 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
 dependencies = [
- "arbitrary",
  "blake2b_simd",
- "blake2s_simd 1.0.2",
- "blake3",
  "core2",
- "digest 0.10.7",
- "multihash-derive",
- "quickcheck",
- "rand",
- "ripemd",
+ "multihash-derive 0.8.1",
  "serde",
  "serde-big-array",
- "sha2 0.10.8",
- "sha3",
  "unsigned-varint 0.7.2",
 ]
 
 [[package]]
 name = "multihash"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
+checksum = "cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2"
 dependencies = [
+ "arbitrary",
  "core2",
+ "quickcheck",
+ "rand",
  "serde",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
+]
+
+[[package]]
+name = "multihash-codetable"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67996849749d25f1da9f238e8ace2ece8f9d6bdf3f9750aaf2ae7de3a5cad8ea"
+dependencies = [
+ "blake2b_simd",
+ "blake2s_simd 1.0.2",
+ "blake3",
+ "core2",
+ "digest 0.10.7",
+ "multihash-derive 0.9.1",
+ "ripemd",
+ "sha1",
+ "sha2 0.10.8",
+ "sha3",
+ "strobe-rs",
 ]
 
 [[package]]
@@ -3742,12 +3684,36 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.1.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f1b7edab35d920890b88643a765fc9bd295cf0201f4154dda231bef9b8404eb"
+dependencies = [
+ "core2",
+ "multihash 0.19.2",
+ "multihash-derive-impl",
+]
+
+[[package]]
+name = "multihash-derive-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3dc7141bd06405929948754f0628d247f5ca1865be745099205e5086da957cb"
+dependencies = [
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -4139,6 +4105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4185,15 +4160,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-protobuf"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "quickcheck"
@@ -4583,6 +4549,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4830,6 +4807,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "strobe-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98fe17535ea31344936cc58d29fec9b500b0452ddc4cc24c429c8a921a0e84e5"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "keccak",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "substrate-bn"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4891,6 +4881,17 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5007,6 +5008,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap 2.6.0",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -5765,6 +5783,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,10 @@ log = "0.4.19"
 futures = "0.3.28"
 
 # IPLD/Encoding
-cid = { version = "0.10.1", default-features = false }
-multihash = { version = "0.18.1", default-features = false }
-libipld = { version = "0.16.0",  features = ["serde-codec"] }
-libipld-core = { version = "0.16.0", features = ["serde-codec"] }
+cid = { version = "0.11.1", default-features = false }
+ipld-core = { version = "0.4.1", features = ["serde"] }
+multihash-codetable = { version = "0.1.4" }
+multihash-derive = { version = "0.9.1" }
 
 # crypto
 blake2b_simd = "1.0.1"

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -16,7 +16,8 @@ anyhow = { workspace = true, features = ["backtrace"] }
 thiserror = { workspace = true }
 num-traits = { workspace = true }
 cid = { workspace = true, features = ["serde-codec"] }
-multihash = { workspace = true, features = ["sha2", "sha3", "ripemd"] }
+multihash-codetable = { workspace = true, features = ["sha2", "sha3", "ripemd"] }
+multihash-derive = { workspace = true }
 fvm_shared = { workspace = true, features = ["crypto"] }
 fvm_ipld_hamt = { workspace = true }
 fvm_ipld_amt = { workspace = true }

--- a/fvm/src/blockstore/buffered.rs
+++ b/fvm/src/blockstore/buffered.rs
@@ -238,10 +238,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use cid::multihash::{Code, Multihash};
     use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
     use fvm_ipld_encoding::CborStore;
     use fvm_shared::{commcid, IDENTITY_HASH};
+    use multihash_codetable::{Code, Multihash};
     use serde::{Deserialize, Serialize};
 
     use super::*;

--- a/fvm/src/init_actor.rs
+++ b/fvm/src/init_actor.rs
@@ -45,7 +45,7 @@ impl State {
     #[allow(unused)]
     pub fn new_test<B: Blockstore>(store: &B) -> Self {
         #[cfg(feature = "m2-native")]
-        use cid::multihash::Code::Blake2b256;
+        use multihash_codetable::Code::Blake2b256;
 
         // Empty hamt Cid used for testing
         let e_cid = Hamt::<_, String>::new_with_bit_width(&store, 5)

--- a/fvm/src/ipld/mod.rs
+++ b/fvm/src/ipld/mod.rs
@@ -144,7 +144,7 @@ mod test {
     use fvm_ipld_encoding::{CBOR, DAG_CBOR, IPLD_RAW};
     use fvm_shared::commcid::FIL_COMMITMENT_UNSEALED;
     use fvm_shared::version::NetworkVersion;
-    use multihash::{Multihash, MultihashDigest};
+    use multihash_codetable::{Multihash, MultihashDigest};
     use num_traits::Zero;
     use serde::{Deserialize, Serialize};
 
@@ -183,7 +183,10 @@ mod test {
 
     #[test]
     fn basic_cbor() {
-        let test_cid = Cid::new_v1(IPLD_RAW, multihash::Code::Blake2b256.digest(b"foobar"));
+        let test_cid = Cid::new_v1(
+            IPLD_RAW,
+            multihash_codetable::Code::Blake2b256.digest(b"foobar"),
+        );
 
         let data = fvm_ipld_encoding::to_vec(&Test(0, test_cid, 1)).unwrap();
 
@@ -208,7 +211,10 @@ mod test {
 
     #[test]
     fn recursive_cbor() {
-        let test_cid = Cid::new_v1(IPLD_RAW, multihash::Code::Blake2b256.digest(b"foobar"));
+        let test_cid = Cid::new_v1(
+            IPLD_RAW,
+            multihash_codetable::Code::Blake2b256.digest(b"foobar"),
+        );
         let inlined_data = fvm_ipld_encoding::to_vec(&Test(0, test_cid, 1)).unwrap();
         let inline_cid = Cid::new_v1(DAG_CBOR, Multihash::wrap(0, &inlined_data).unwrap());
         let data = fvm_ipld_encoding::to_vec(&Test(0, inline_cid, 1)).unwrap();
@@ -223,7 +229,7 @@ mod test {
     fn ignores_pieces() {
         let test_cid = Cid::new_v1(
             FIL_COMMITMENT_UNSEALED,
-            multihash::Code::Blake2b256.digest(b"foobar"),
+            multihash_codetable::Code::Blake2b256.digest(b"foobar"),
         );
         let data = fvm_ipld_encoding::to_vec(&Test(0, test_cid, 1)).unwrap();
         assert!(scan_for_links(DAG_CBOR, &data, 4, 1).unwrap().is_empty());

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -12,7 +12,7 @@ use fvm_shared::error::ErrorNumber;
 use fvm_shared::event::{ActorEvent, Entry, Flags};
 use fvm_shared::sys::out::vm::ContextFlags;
 use fvm_shared::upgrade::UpgradeInfo;
-use multihash::MultihashDigest;
+use multihash_codetable::MultihashDigest;
 
 use super::blocks::{Block, BlockRegistry};
 use super::error::Result;
@@ -692,13 +692,8 @@ where
     }
 
     fn hash(&self, code: u64, data: &[u8]) -> Result<Multihash> {
-        let hasher = SupportedHashes::try_from(code).map_err(|e| {
-            if let multihash::Error::UnsupportedCode(code) = e {
-                syscall_error!(IllegalArgument; "unsupported hash code {}", code)
-            } else {
-                syscall_error!(AssertionFailed; "hash expected unsupported code, got {}", e)
-            }
-        })?;
+        let hasher = SupportedHashes::try_from(code)
+            .map_err(|err| syscall_error!(IllegalArgument; "unsupported hash code {}", err.0))?;
 
         let t = self.call_manager.charge_gas(
             self.call_manager

--- a/fvm/src/kernel/hash.rs
+++ b/fvm/src/kernel/hash.rs
@@ -1,9 +1,10 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use multihash::derive::Multihash;
-use multihash::{Blake2b256, Blake2b512, Keccak256, Ripemd160, Sha2_256};
+use multihash_codetable::{
+    Blake2b256, Blake2b512, Keccak256, MultihashDigest, Ripemd160, Sha2_256,
+};
 
-#[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, MultihashDigest, PartialEq, Hash)]
 #[mh(alloc_size = 64)]
 /// Codes and hashers supported by FVM.
 /// You _can_ use this hash directly inside of your actor,

--- a/fvm/src/kernel/mod.rs
+++ b/fvm/src/kernel/mod.rs
@@ -323,7 +323,6 @@ pub mod prelude {
     pub use super::{Block, BlockId, BlockRegistry, BlockStat, CallResult, Kernel, SyscallHandler};
     pub use crate::gas::{Gas, GasTimer, PriceList};
     pub use ambassador::Delegate;
-    pub use cid::Cid;
     pub use fvm_shared::address::Address;
     pub use fvm_shared::clock::ChainEpoch;
     pub use fvm_shared::crypto::signature::{
@@ -337,7 +336,9 @@ pub mod prelude {
     pub use fvm_shared::sys::SendFlags;
     pub use fvm_shared::version::NetworkVersion;
     pub use fvm_shared::{ActorID, MethodNum};
-    pub use multihash::Multihash;
+
+    pub use cid::Cid;
+    pub type Multihash = cid::multihash::Multihash<64>;
 }
 
 use prelude::*;

--- a/fvm/src/lib.rs
+++ b/fvm/src/lib.rs
@@ -51,7 +51,7 @@ mod test {
     use fvm_ipld_encoding::{CborStore, DAG_CBOR};
     use fvm_shared::state::StateTreeVersion;
     use fvm_shared::IDENTITY_HASH;
-    use multihash::{Code, Multihash};
+    use multihash_codetable::{Code, Multihash};
 
     use crate::call_manager::DefaultCallManager;
     use crate::engine::EnginePool;

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -8,7 +8,7 @@ use fvm_ipld_blockstore::{Block, Blockstore, Buffered};
 use fvm_ipld_encoding::{CborStore, DAG_CBOR};
 use fvm_shared::version::NetworkVersion;
 use log::debug;
-use multihash::Code::Blake2b256;
+use multihash_codetable::Code::Blake2b256;
 
 use super::{Machine, MachineContext};
 use crate::blockstore::BufferedBlockstore;

--- a/fvm/src/machine/manifest.rs
+++ b/fvm/src/machine/manifest.rs
@@ -32,8 +32,8 @@ pub struct Manifest {
 const fn id_cid(name: &[u8]) -> Cid {
     use std::mem;
 
+    use cid::multihash::Multihash;
     use fvm_shared::{IDENTITY_HASH, IPLD_RAW};
-    use multihash::Multihash;
 
     // This code is ugly because const fns are a bit ugly right now:
     //

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -5,7 +5,7 @@
 use std::cell::RefCell;
 
 use anyhow::{anyhow, Context as _};
-use cid::{multihash, Cid};
+use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
 use fvm_ipld_hamt::Hamt;
@@ -71,7 +71,10 @@ where
             }
             StateTreeVersion::V5 => {
                 let cid = store
-                    .put_cbor(&StateInfo0::default(), multihash::Code::Blake2b256)
+                    .put_cbor(
+                        &StateInfo0::default(),
+                        multihash_codetable::Code::Blake2b256,
+                    )
                     .context("failed to put state info")
                     .or_fatal()?;
                 Some(cid)
@@ -264,7 +267,7 @@ where
         // Set state for init actor in store and update root Cid
         actor.state = self
             .store()
-            .put_cbor(&state, multihash::Code::Blake2b256)
+            .put_cbor(&state, multihash_codetable::Code::Blake2b256)
             .or_fatal()?;
 
         self.set_actor(crate::init_actor::INIT_ACTOR_ID, actor);
@@ -349,7 +352,7 @@ where
                 };
                 let root = self
                     .store()
-                    .put_cbor(obj, multihash::Code::Blake2b256)
+                    .put_cbor(obj, multihash_codetable::Code::Blake2b256)
                     .or_fatal()?;
                 Ok(root)
             }

--- a/fvm/tests/default_kernel/mod.rs
+++ b/fvm/tests/default_kernel/mod.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use fvm::kernel::default::DefaultKernel;
 use fvm::kernel::{Block, BlockRegistry};
 use fvm::Kernel;
-use multihash::Code;
+use multihash_codetable::Code;
 use num_traits::Zero;
 
 use super::*;

--- a/fvm/tests/default_kernel/ops.rs
+++ b/fvm/tests/default_kernel/ops.rs
@@ -9,7 +9,7 @@ mod ipld {
     use fvm::machine::Machine;
     use fvm_ipld_blockstore::Blockstore;
     use fvm_ipld_encoding::{DAG_CBOR, IPLD_RAW};
-    use multihash::MultihashDigest;
+    use multihash_codetable::MultihashDigest;
     use pretty_assertions::{assert_eq, assert_ne};
 
     use super::*;

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -23,7 +23,7 @@ use fvm_shared::event::StampedEvent;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, IDENTITY_HASH};
-use multihash::{Code, Multihash};
+use multihash_codetable::{Code, Multihash};
 
 pub const STUB_NETWORK_VER: NetworkVersion = NetworkVersion::V21;
 

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
-cid = { workspace = true, features = ["serde-codec"] }
+cid = { workspace = true, features = ["serde"] }
+multihash-codetable = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 once_cell = { workspace = true }

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -96,7 +96,6 @@
 //! in the cache.
 
 use anyhow::anyhow;
-use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::de::DeserializeOwned;
@@ -104,6 +103,7 @@ use fvm_ipld_encoding::ser::Serialize;
 use fvm_ipld_encoding::serde::Deserialize;
 use fvm_ipld_encoding::CborStore;
 use itertools::sorted;
+use multihash_codetable::Code;
 
 use super::ValueMut;
 use crate::node::{CollapsedNode, Link};

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -5,10 +5,10 @@
 use std::convert::{TryFrom, TryInto};
 
 use anyhow::anyhow;
-use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{strict_bytes, BytesSer, CborStore};
+use multihash_codetable::Code;
 use once_cell::unsync::OnceCell;
 use serde::de::{self, DeserializeOwned};
 use serde::{ser, Deserialize, Serialize};

--- a/ipld/blockstore/Cargo.toml
+++ b/ipld/blockstore/Cargo.toml
@@ -10,9 +10,7 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 [dependencies]
 cid = { workspace = true, features = ["serde-codec", "std"] }
 anyhow = { workspace = true }
-# multihash is also re-exported by `cid`. Having `multihash` here as a
-# depdendency is needed to enable the features of the re-export.
-multihash = { workspace = true, features = ["multihash-impl"] }
+multihash-codetable = { workspace = true }
 
 [features]
 default = []

--- a/ipld/blockstore/src/block.rs
+++ b/ipld/blockstore/src/block.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use cid::multihash::{self, MultihashDigest};
 use cid::Cid;
+use multihash_codetable::MultihashDigest;
 
 /// Block represents a typed (i.e., with codec) IPLD block.
 #[derive(Copy, Clone)]
@@ -27,7 +27,7 @@ where
         Self { codec, data }
     }
 
-    pub fn cid(&self, mh_code: multihash::Code) -> Cid {
+    pub fn cid(&self, mh_code: multihash_codetable::Code) -> Cid {
         Cid::new_v1(self.codec, mh_code.digest(self.data.as_ref()))
     }
 

--- a/ipld/blockstore/src/lib.rs
+++ b/ipld/blockstore/src/lib.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use anyhow::Result;
-use cid::{multihash, Cid};
+use cid::Cid;
 
 pub mod tracking;
 
@@ -37,7 +37,7 @@ pub trait Blockstore {
     /// Puts the block into the blockstore, computing the hash with the specified multicodec.
     ///
     /// By default, this defers to put.
-    fn put<D>(&self, mh_code: multihash::Code, block: &Block<D>) -> Result<Cid>
+    fn put<D>(&self, mh_code: multihash_codetable::Code, block: &Block<D>) -> Result<Cid>
     where
         Self: Sized,
         D: AsRef<[u8]>,
@@ -51,7 +51,7 @@ pub trait Blockstore {
     ///
     ///
     /// ```rust
-    /// use multihash::Code::Blake2b256;
+    /// use multihash_codetable::Code::Blake2b256;
     /// use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore, Block};
     ///
     /// let bs = MemoryBlockstore::default();
@@ -62,7 +62,7 @@ pub trait Blockstore {
     where
         Self: Sized,
         D: AsRef<[u8]>,
-        I: IntoIterator<Item = (multihash::Code, Block<D>)>,
+        I: IntoIterator<Item = (multihash_codetable::Code, Block<D>)>,
     {
         self.put_many_keyed(blocks.into_iter().map(|(mc, b)| (b.cid(mc), b)))?;
         Ok(())
@@ -105,7 +105,7 @@ macro_rules! impl_blockstore {
                     (**self).has(k)
                 }
 
-                fn put<D>(&self, mh_code: multihash::Code, block: &Block<D>) -> Result<Cid>
+                fn put<D>(&self, mh_code: multihash_codetable::Code, block: &Block<D>) -> Result<Cid>
                 where
                     Self: Sized,
                     D: AsRef<[u8]>,
@@ -117,7 +117,7 @@ macro_rules! impl_blockstore {
                 where
                     Self: Sized,
                     D: AsRef<[u8]>,
-                    I: IntoIterator<Item = (multihash::Code, Block<D>)>,
+                    I: IntoIterator<Item = (multihash_codetable::Code, Block<D>)>,
                 {
                     (**self).put_many(blocks)
                 }

--- a/ipld/blockstore/src/tracking.rs
+++ b/ipld/blockstore/src/tracking.rs
@@ -5,8 +5,8 @@
 use std::cell::RefCell;
 
 use anyhow::Result;
-use cid::multihash::{self, Code};
 use cid::Cid;
+use multihash_codetable::Code;
 
 use super::{Block, Blockstore};
 
@@ -83,7 +83,7 @@ where
     where
         Self: Sized,
         D: AsRef<[u8]>,
-        I: IntoIterator<Item = (multihash::Code, Block<D>)>,
+        I: IntoIterator<Item = (multihash_codetable::Code, Block<D>)>,
     {
         let mut stats = self.stats.borrow_mut();
         self.base.put_many(blocks.into_iter().inspect(|(_, b)| {

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -9,6 +9,8 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
 cid = { workspace = true }
+multihash-codetable = { workspace = true }
+multihash-derive = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 unsigned-varint = { workspace = true, features = ["futures"] }

--- a/ipld/car/src/error.rs
+++ b/ipld/car/src/error.rs
@@ -25,8 +25,8 @@ impl From<cid::Error> for Error {
     }
 }
 
-impl From<cid::multihash::Error> for Error {
-    fn from(err: cid::multihash::Error) -> Error {
+impl From<multihash_derive::UnsupportedCode> for Error {
+    fn from(err: multihash_derive::UnsupportedCode) -> Error {
         Error::ParsingError(err.to_string())
     }
 }

--- a/ipld/car/src/lib.rs
+++ b/ipld/car/src/lib.rs
@@ -5,8 +5,6 @@
 mod error;
 mod util;
 
-use std::convert::TryFrom;
-
 use cid::Cid;
 pub use error::*;
 use futures::{AsyncRead, AsyncWrite, Stream, StreamExt};
@@ -96,7 +94,7 @@ where
 
     /// Returns the next IPLD Block in the buffer
     pub async fn next_block(&mut self) -> Result<Option<Block>, Error> {
-        use cid::multihash::{self, MultihashDigest};
+        use multihash_codetable::{Code, MultihashDigest};
         // Read node -> cid, bytes
         if let Some((cid, data)) = read_node(&mut self.reader).await? {
             if self.validate {
@@ -110,7 +108,7 @@ where
                         }
                     }
                     code => {
-                        let code = multihash::Code::try_from(code)?;
+                        let code = Code::try_from(code)?;
                         let actual = Cid::new_v1(cid.codec(), code.digest(&data));
                         if actual != cid {
                             return Err(Error::InvalidFile(format!(
@@ -180,10 +178,9 @@ mod tests {
     use async_std::channel::bounded;
     use async_std::io::Cursor;
     use async_std::sync::RwLock;
-    use cid::multihash::Code::Blake2b256;
-    use cid::multihash::MultihashDigest;
     use fvm_ipld_blockstore::MemoryBlockstore;
     use fvm_ipld_encoding::DAG_CBOR;
+    use multihash_codetable::{Code::Blake2b256, MultihashDigest};
 
     use super::*;
 

--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -10,13 +10,11 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 [dependencies]
 serde = { workspace = true }
 serde_tuple = { workspace = true }
-cid = { workspace = true, features = ["serde-codec", "std"] }
+cid = { workspace = true, features = ["serde", "std"] }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
-# multihash is also re-exported by `cid`. Having `multihash` here as a
-# depdendency is needed to enable the features of the re-export.
-multihash = { workspace = true, features = ["blake2b", "multihash-impl"] }
+multihash-codetable = { workspace = true, features = ["blake2b"] }
 serde_ipld_dagcbor = "0.6.1"
 serde_repr = "0.1"
 

--- a/ipld/encoding/src/cbor_store.rs
+++ b/ipld/encoding/src/cbor_store.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::anyhow;
-use cid::{multihash, Cid};
+use cid::Cid;
 use fvm_ipld_blockstore::{Block, Blockstore};
 use serde::{de, ser};
 
@@ -27,7 +27,7 @@ pub trait CborStore: Blockstore + Sized {
     }
 
     /// Put an object in the block store and return the Cid identifier.
-    fn put_cbor<S>(&self, obj: &S, code: multihash::Code) -> anyhow::Result<Cid>
+    fn put_cbor<S>(&self, obj: &S, code: multihash_codetable::Code) -> anyhow::Result<Cid>
     where
         S: ser::Serialize,
     {

--- a/ipld/encoding/src/lib.rs
+++ b/ipld/encoding/src/lib.rs
@@ -28,6 +28,8 @@ pub const DAG_CBOR: u64 = 0x71;
 /// RAW should be used for raw data.
 pub const IPLD_RAW: u64 = 0x55;
 
+pub type Multihash = cid::multihash::Multihash<64>;
+
 // TODO: these really don't work all that well in a shared context like this as anyone importing
 // them also need to _explicitly_ import the serde_tuple & serde_repr crates. These are _macros_,
 // not normal items.

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 [dependencies]
 serde = { workspace = true }
 byteorder = { workspace = true }
-cid = { workspace = true, features = ["serde-codec"] }
-multihash = { workspace = true }
+cid = { workspace = true, features = ["serde"] }
+multihash-codetable = { workspace = true }
 thiserror = { workspace = true }
 once_cell = { workspace = true }
 anyhow = { workspace = true }
@@ -19,7 +19,7 @@ fvm_ipld_encoding = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 sha2 = "0.10"
 forest_hash_utils = "0.1"
-libipld-core = { workspace = true }
+ipld-core = { workspace = true }
 
 
 [features]

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -9,7 +9,7 @@ use cid::Cid;
 use forest_hash_utils::BytesKey;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
-use multihash::Code;
+use multihash_codetable::Code;
 use serde::de::DeserializeOwned;
 use serde::{Serialize, Serializer};
 

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{CborStore, DAG_CBOR};
-use multihash::Code;
+use multihash_codetable::Code;
 use once_cell::unsync::OnceCell;
 use serde::de::DeserializeOwned;
 use serde::{Serialize, Serializer};

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -6,7 +6,7 @@ use std::cmp::Ordering;
 use std::convert::{TryFrom, TryInto};
 
 use cid::Cid;
-use libipld_core::ipld::Ipld;
+use ipld_core::ipld::Ipld;
 use once_cell::unsync::OnceCell;
 use serde::de::{self, DeserializeOwned};
 use serde::{ser, Deserialize, Deserializer, Serialize, Serializer};

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -14,7 +14,7 @@ use fvm_ipld_encoding::CborStore;
 #[cfg(feature = "identity")]
 use fvm_ipld_hamt::Identity;
 use fvm_ipld_hamt::{BytesKey, Config, Error, Hamt, Hash};
-use multihash::Code;
+use multihash_codetable::Code;
 use quickcheck::Arbitrary;
 use rand::seq::SliceRandom;
 use rand::SeedableRng;

--- a/ipld/kamt/Cargo.toml
+++ b/ipld/kamt/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 [dependencies]
 serde = { workspace = true }
 byteorder = { workspace = true }
-cid = { workspace = true, features = ["serde-codec"] }
-multihash = { workspace = true }
+cid = { workspace = true, features = ["serde"] }
+multihash-codetable = { workspace = true }
 thiserror = { workspace = true }
 once_cell = { workspace = true }
 anyhow = { workspace = true }

--- a/ipld/kamt/src/kamt.rs
+++ b/ipld/kamt/src/kamt.rs
@@ -7,7 +7,7 @@ use std::borrow::Borrow;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
-use multihash::Code;
+use multihash_codetable::Code;
 use serde::de::DeserializeOwned;
 use serde::{Serialize, Serializer};
 

--- a/ipld/kamt/src/node.rs
+++ b/ipld/kamt/src/node.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{CborStore, DAG_CBOR};
-use multihash::Code;
+use multihash_codetable::Code;
 use once_cell::unsync::OnceCell;
 use serde::de::DeserializeOwned;
 use serde::{Serialize, Serializer};

--- a/ipld/kamt/tests/kamt_tests.rs
+++ b/ipld/kamt/tests/kamt_tests.rs
@@ -12,7 +12,7 @@ use fvm_ipld_encoding::de::DeserializeOwned;
 use fvm_ipld_encoding::CborStore;
 use fvm_ipld_kamt::id::Identity;
 use fvm_ipld_kamt::{Config, Error, HashedKey, Kamt};
-use multihash::Code;
+use multihash_codetable::Code;
 use quickcheck::Arbitrary;
 use rand::seq::SliceRandom;
 use rand::SeedableRng;

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -14,7 +14,6 @@ num-traits = { workspace = true }
 num-derive = { workspace = true }
 lazy_static = { workspace = true }
 cid = { workspace = true, features = ["serde-codec", "std"] }
-multihash = { workspace = true }
 unsigned-varint = { workspace = true }
 anyhow = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
@@ -39,7 +38,7 @@ bls-signatures = { workspace = true, default-features = false, optional = true }
 [dev-dependencies]
 rand = { workspace = true }
 serde_json = { workspace = true }
-multihash = { workspace = true, features = ["multihash-impl", "sha2", "sha3", "ripemd"] }
+multihash-codetable = { workspace = true, features = ["sha2", "sha3", "ripemd"] }
 quickcheck_macros = { workspace = true }
 coverage-helper = { workspace = true }
 fvm_shared = { path = ".", features = ["arb"] }

--- a/shared/src/crypto/hash.rs
+++ b/shared/src/crypto/hash.rs
@@ -9,3 +9,9 @@ pub enum SupportedHashes {
     Keccak256 = 0x1b,
     Ripemd160 = 0x1053,
 }
+
+impl From<SupportedHashes> for u64 {
+    fn from(value: SupportedHashes) -> Self {
+        value as Self
+    }
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -35,11 +35,11 @@ pub mod sys;
 pub mod upgrade;
 pub mod version;
 
+use cid::multihash::Multihash;
 use crypto::hash::SupportedHashes;
 use econ::TokenAmount;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::DAG_CBOR;
-use multihash::Multihash;
 
 use crate::error::ExitCode;
 
@@ -153,8 +153,8 @@ pub const EMPTY_ARR_CID: Cid = Cid::new_v1(
 
 #[test]
 fn test_empty_arr_cid() {
-    use cid::multihash::{Code, MultihashDigest};
     use fvm_ipld_encoding::to_vec;
+    use multihash_codetable::{Code, MultihashDigest};
 
     let empty = to_vec::<[(); 0]>(&[]).unwrap();
     let expected = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));

--- a/shared/tests/commcid_tests.rs
+++ b/shared/tests/commcid_tests.rs
@@ -2,9 +2,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use cid::multihash::{Code, Multihash, MultihashDigest};
 use cid::Cid;
 use fvm_shared::commcid::*;
+use multihash_codetable::{Code, Multihash, MultihashDigest};
 use rand::{thread_rng, Rng};
 
 fn rand_comm() -> Commitment {

--- a/testing/common_fuzz/fuzz/Cargo.toml
+++ b/testing/common_fuzz/fuzz/Cargo.toml
@@ -13,7 +13,6 @@ libfuzzer-sys = { workspace = true }
 arbitrary ={ workspace = true, features = ["derive"] }
 rand = { workspace = true }
 cid = { workspace = true, features = ["serde-codec", "arb", "std"] }
-multihash = { workspace = true }
 
 fvm_ipld_bitfield = { workspace = true, features = ["enable-arbitrary"] }
 fvm_ipld_encoding = { workspace = true }

--- a/testing/conformance/Cargo.toml
+++ b/testing/conformance/Cargo.toml
@@ -18,14 +18,13 @@ fvm_ipld_encoding = { workspace = true }
 anyhow = { workspace = true }
 num-traits = { workspace = true }
 cid = { workspace = true }
-multihash = { workspace = true }
 serde = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
-libipld-core = { workspace = true }
+ipld-core = { workspace = true }
 async-std = { version = "1.12", features = ["attributes"] }
 wasmtime = { workspace = true }
 base64 = "0.22.1"

--- a/testing/conformance/src/driver.rs
+++ b/testing/conformance/src/driver.rs
@@ -18,8 +18,8 @@ use fvm_shared::crypto::signature::SECP_SIG_LEN;
 use fvm_shared::message::Message;
 use fvm_shared::receipt::Receipt;
 use fvm_shared::version::NetworkVersion;
+use ipld_core::ipld::Ipld;
 use lazy_static::lazy_static;
-use libipld_core::ipld::Ipld;
 use regex::Regex;
 use walkdir::DirEntry;
 

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -18,7 +18,7 @@ fvm_sdk = { workspace = true }
 anyhow = { workspace = true }
 cid = { workspace = true }
 futures = { workspace = true }
-multihash = { workspace = true }
+multihash-codetable = { workspace = true, features = ["blake2b"] }
 num-traits = { workspace = true }
 lazy_static = { workspace = true }
 libsecp256k1 = { workspace = true }

--- a/testing/integration/src/builtin.rs
+++ b/testing/integration/src/builtin.rs
@@ -9,7 +9,7 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
 use fvm_shared::address::Address;
 use fvm_shared::ActorID;
-use multihash::Code;
+use multihash_codetable::Code;
 
 use crate::error::Error::{FailedToLoadManifest, FailedToSetState};
 

--- a/testing/integration/src/dummy.rs
+++ b/testing/integration/src/dummy.rs
@@ -1,10 +1,10 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
+use cid::multihash::Multihash;
 use cid::Cid;
 use fvm::externs::{Chain, Consensus, Externs, Rand};
 use fvm_ipld_encoding::DAG_CBOR;
 use fvm_shared::IDENTITY_HASH;
-use multihash::Multihash;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 pub struct DummyExterns;

--- a/testing/integration/src/tester.rs
+++ b/testing/integration/src/tester.rs
@@ -18,7 +18,7 @@ use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, IPLD_RAW};
 use lazy_static::lazy_static;
 use libsecp256k1::{PublicKey, SecretKey};
-use multihash::Code;
+use multihash_codetable::Code;
 
 use crate::builtin::{
     fetch_builtin_code_cid, set_burnt_funds_account, set_eam_actor, set_init_actor, set_sys_actor,

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -1179,7 +1179,7 @@ fn upgrade_actor_test() {
             codec: fvm_shared::IPLD_RAW,
             data: bytes,
         }
-        .cid(multihash::Code::Blake2b256)
+        .cid(multihash_codetable::Code::Blake2b256)
     };
 
     let receiver = Address::new_id(10000);

--- a/testing/test_actors/actors/fil-gas-calibration-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-gas-calibration-actor/Cargo.toml
@@ -15,7 +15,7 @@ num-derive = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
 anyhow = { workspace = true }
-libipld = { workspace = true }
+ipld-core = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = { workspace = true }
 cid = { workspace = true }
 serde = { workspace = true }
 serde_tuple = { workspace = true }
+multihash-codetable = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-integer-overflow-actor/src/actor/blockstore.rs
+++ b/testing/test_actors/actors/fil-integer-overflow-actor/src/actor/blockstore.rs
@@ -3,10 +3,10 @@
 use std::convert::TryFrom;
 
 use anyhow::{anyhow, Result};
-use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_blockstore::Block;
 use fvm_sdk as sdk;
+use multihash_codetable::Code;
 
 /// A blockstore that delegates to IPLD syscalls.
 pub struct Blockstore;

--- a/testing/test_actors/actors/fil-integer-overflow-actor/src/actor/mod.rs
+++ b/testing/test_actors/actors/fil-integer-overflow-actor/src/actor/mod.rs
@@ -1,13 +1,12 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{to_vec, CborStore, RawBytes, CBOR, DAG_CBOR};
 use fvm_sdk::message::params_raw;
 use fvm_sdk::vm::abort;
 use fvm_sdk::NO_DATA_BLOCK_ID;
-use fvm_shared::error::ExitCode;
+use fvm_shared::{crypto::hash::SupportedHashes, error::ExitCode};
 mod blockstore;
 use blockstore::Blockstore;
 
@@ -50,7 +49,7 @@ impl State {
             ),
         };
         let cid = match fvm_sdk::ipld::put(
-            Code::Blake2b256.into(),
+            SupportedHashes::Blake2b256.into(),
             32,
             DAG_CBOR,
             serialized.as_slice(),

--- a/testing/test_actors/actors/fil-readonly-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-readonly-actor/src/actor.rs
@@ -1,11 +1,12 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use cid::multihash::{Code, MultihashDigest};
+use cid::multihash::Multihash;
 use cid::Cid;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::{to_vec, CBOR, DAG_CBOR, IPLD_RAW};
 use fvm_sdk as sdk;
 use fvm_shared::address::{Address, SECP_PUB_LEN};
+use fvm_shared::crypto::hash::SupportedHashes;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::event::{Entry, Flags};
 use fvm_shared::sys::SendFlags;
@@ -100,7 +101,12 @@ fn invoke_method(blk: u32, method: u64) -> u32 {
 
             // Root should not be updated.
             let empty = to_vec::<[(); 0]>(&[]).unwrap();
-            let expected_root = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));
+            let mh = Multihash::wrap(
+                SupportedHashes::Blake2b256.into(),
+                &sdk::crypto::hash_blake2b(&empty),
+            )
+            .unwrap();
+            let expected_root = Cid::new_v1(DAG_CBOR, mh);
             let root = sdk::sself::root().unwrap();
             assert_eq!(root, expected_root);
 

--- a/testing/test_actors/actors/fil-sself-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-sself-actor/src/actor.rs
@@ -1,10 +1,10 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use cid::multihash::{Code, MultihashDigest};
+use cid::multihash::Multihash;
 use cid::Cid;
 use fvm_ipld_encoding::{to_vec, DAG_CBOR};
 use fvm_sdk as sdk;
-use fvm_shared::econ::TokenAmount;
+use fvm_shared::{crypto::hash::SupportedHashes, econ::TokenAmount};
 use sdk::error::{ActorDeleteError, StateReadError, StateUpdateError};
 
 #[no_mangle]
@@ -16,7 +16,12 @@ pub fn invoke(_: u32) -> u32 {
     // test that root() returns the correct root
     //
     let empty = to_vec::<[(); 0]>(&[]).unwrap();
-    let expected_root = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));
+    let mh = Multihash::wrap(
+        SupportedHashes::Blake2b256.into(),
+        &sdk::crypto::hash_blake2b(&empty),
+    )
+    .unwrap();
+    let expected_root = Cid::new_v1(DAG_CBOR, mh);
     let root = sdk::sself::root().unwrap();
     assert_eq!(root, expected_root);
 

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -8,7 +8,8 @@ publish = false
 fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
-multihash = { workspace = true, features = ["sha3", "sha2", "ripemd"] }
+multihash-derive = { workspace = true }
+multihash-codetable = { workspace = true, features = ["sha3", "sha2", "ripemd"] }
 minicov = {version = "0.3", optional = true}
 actors_v12_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }
 

--- a/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
@@ -8,11 +8,11 @@ use fvm_shared::crypto::hash::SupportedHashes as SharedSupportedHashes;
 use fvm_shared::crypto::signature::{Signature, SECP_SIG_LEN};
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::sector::RegisteredSealProof;
-use multihash::derive::Multihash;
-use multihash::{Blake2b256, Blake2b512, Keccak256, Ripemd160, Sha2_256};
+use multihash_codetable::{Blake2b256, Blake2b512, Keccak256, Ripemd160, Sha2_256};
+use multihash_derive::MultihashDigest;
 use std::ptr;
 
-#[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, MultihashDigest, PartialEq)]
 #[mh(alloc_size = 64)]
 // import hash functions into actor to test against output from syscall
 pub enum SupportedHashes {
@@ -263,7 +263,6 @@ fn test_bls_aggregate() {
 
 // use SDK methods to hash and compares against locally (inside the actor) hashed digest
 fn test_expected_hash() {
-    use multihash::MultihashDigest;
     let test_bytes = b"foo bar baz boxy";
 
     let blake_local = SupportedHashes::Blake2b256.digest(test_bytes);


### PR DESCRIPTION
This is a major breaking change and requires a bit of a refactor. It updates:

- cid
- multihash
- ipld-core

Importantly, the code-table has been factored out of the core multihash crate.