### PR TITLE
fix: remove default multihash-codetable features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,19 +463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake3"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.6",
- "cc",
- "cfg-if",
- "constant_time_eq 0.3.1",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,16 +3653,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67996849749d25f1da9f238e8ace2ece8f9d6bdf3f9750aaf2ae7de3a5cad8ea"
 dependencies = [
  "blake2b_simd",
- "blake2s_simd 1.0.2",
- "blake3",
  "core2",
  "digest 0.10.7",
  "multihash-derive 0.9.1",
  "ripemd",
- "sha1",
  "sha2 0.10.8",
  "sha3",
- "strobe-rs",
 ]
 
 [[package]]
@@ -4549,17 +4532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4804,19 +4776,6 @@ dependencies = [
  "serde",
  "storage-proofs-core",
  "storage-proofs-porep",
-]
-
-[[package]]
-name = "strobe-rs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fe17535ea31344936cc58d29fec9b500b0452ddc4cc24c429c8a921a0e84e5"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "keccak",
- "subtle",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ futures = "0.3.28"
 # IPLD/Encoding
 cid = { version = "0.11.1", default-features = false }
 ipld-core = { version = "0.4.1", features = ["serde"] }
-multihash-codetable = { version = "0.1.4" }
-multihash-derive = { version = "0.9.1" }
+multihash-codetable = { version = "0.1.4", default-features = false }
+multihash-derive = { version = "0.9.1", default-features = false }
 
 # crypto
 blake2b_simd = "1.0.1"


### PR DESCRIPTION
We explicitly specify the features we need and don't want to depend on blake3, sha1, or strobe-rs unnecessarily.