### PR TITLE
chore: release v4.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "libfuzzer-sys",
  "multihash 0.18.1",
  "rand",
@@ -1883,8 +1883,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -1920,8 +1920,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -1930,8 +1930,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1942,8 +1942,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "serde",
  "serde_tuple",
 ]
@@ -1953,8 +1953,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -1965,8 +1965,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "libipld",
  "num-derive 0.4.2",
  "num-traits",
@@ -1978,8 +1978,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "log",
  "serde",
  "serde_tuple",
@@ -1989,8 +1989,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -2001,8 +2001,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "serde",
  "serde_tuple",
 ]
@@ -2012,8 +2012,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "minicov",
 ]
 
@@ -2021,16 +2021,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -2039,8 +2039,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -2049,16 +2049,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -2067,8 +2067,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -2079,8 +2079,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "serde",
  "serde_tuple",
 ]
@@ -2091,8 +2091,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "serde",
  "serde_tuple",
 ]
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.4.3"
+version = "4.4.4"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2437,7 +2437,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "lazy_static",
  "log",
  "minstant",
@@ -2467,7 +2467,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "hex",
 ]
 
@@ -2520,7 +2520,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "itertools 0.13.0",
  "ittapi-rs",
  "lazy_static",
@@ -2541,7 +2541,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "num-derive 0.4.2",
  "num-traits",
  "serde",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.4.3"
+version = "4.4.4"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2565,8 +2565,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2828,11 +2828,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.4.3"
+version = "4.4.4"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "lazy_static",
  "log",
  "num-traits",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.4.3"
+version = "4.4.4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2879,7 +2879,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.4.3"
+version = "4.4.4"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -73,10 +73,10 @@ minstant = "0.1.3"
 coverage-helper = "0.2.0"
 
 # workspace (FVM)
-fvm = { path = "fvm", version = "~4.4.3", default-features = false }
-fvm_shared = { path = "shared", version = "~4.4.3", default-features = false }
-fvm_sdk = { path = "sdk", version = "~4.4.3" }
-fvm_integration_tests = { path = "testing/integration", version = "~4.4.3" }
+fvm = { path = "fvm", version = "~4.4.4", default-features = false }
+fvm_shared = { path = "shared", version = "~4.4.4", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.4.4" }
+fvm_integration_tests = { path = "testing/integration", version = "~4.4.4" }
 
 # workspace (other)
 fvm_ipld_amt = { path = "ipld/amt", version = "0.6.2" }

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.4.4 [2024-11-18]
+
+- feat: add `nv25-dev` feature flag [#2076](https://github.com/filecoin-project/ref-fvm/pull/2076)
+
 ## 4.4.3 [2024-10-21]
 
 - Update wasmtime to 25.0.2.

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -60,3 +60,4 @@ gas_calibration = []
 # The current implementation keeps it by default for backward compatibility reason.
 # See <https://github.com/filecoin-project/ref-fvm/issues/2001>
 verify-signature = []
+nv25-dev = []

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -1004,6 +1004,8 @@ pub fn price_list_by_network_version(network_version: NetworkVersion) -> &'stati
         NetworkVersion::V21 | NetworkVersion::V22 | NetworkVersion::V23 | NetworkVersion::V24 => {
             &WATERMELON_PRICES
         }
+        #[cfg(feature = "nv25-dev")]
+        NetworkVersion::V25 => &WATERMELON_PRICES,
         _ => panic!("network version {nv} not supported", nv = network_version),
     }
 }

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -51,8 +51,13 @@ where
     /// * `blockstore`: The underlying [blockstore][`Blockstore`] for reading/writing state.
     /// * `externs`: Client-provided ["external"][`Externs`] methods for accessing chain state.
     pub fn new(context: &MachineContext, blockstore: B, externs: E) -> anyhow::Result<Self> {
+        #[cfg(not(feature = "nv25-dev"))]
         const SUPPORTED_VERSIONS: RangeInclusive<NetworkVersion> =
             NetworkVersion::V21..=NetworkVersion::V24;
+
+        #[cfg(feature = "nv25-dev")]
+        const SUPPORTED_VERSIONS: RangeInclusive<NetworkVersion> =
+            NetworkVersion::V21..=NetworkVersion::V25;
 
         debug!(
             "initializing a new machine, epoch={}, base_fee={}, nv={:?}, root={}",

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 4.4.4 [2024-11-18]
+
+- feat: add `nv25-dev` feature flag [#2076](https://github.com/filecoin-project/ref-fvm/pull/2076)
+
 ## 4.4.3 [2024-10-21]
 
 - Update wasmtime to 25.0.2.

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 4.4.4 [2024-11-18]
+
+- feat: add `nv25-dev` feature flag [#2076](https://github.com/filecoin-project/ref-fvm/pull/2076)
+
 ## 4.4.3 [2024-10-21]
 
 - Update wasmtime to 25.0.2.

--- a/shared/src/version/mod.rs
+++ b/shared/src/version/mod.rs
@@ -61,8 +61,10 @@ impl NetworkVersion {
     pub const V22: Self = Self(22);
     /// Waffle (builtin-actors v14)
     pub const V23: Self = Self(23);
-    /// TBD (builtin-actors v15)
+    /// TukTuk (builtin-actors v15)
     pub const V24: Self = Self(24);
+    /// TBD (builtin-actors v16)
+    pub const V25: Self = Self(25);
 
     pub const MAX: Self = Self(u32::MAX);
 


### PR DESCRIPTION
Closes: https://github.com/filecoin-project/ref-fvm/issues/2075

As per comment in: https://github.com/filecoin-project/ref-fvm/pull/2077#issuecomment-2467259607, we need to cut the skeleton work on release/4.4 until porting of a newer version of cid/multihash has happened elsewhere before we can bubble up releases on v4.5.x 