### PR TITLE
feat(ipld): undeprecate `for_each` methods for hamt/kamt

### DIFF
--- a/ipld/amt/benches/amt_benchmark.rs
+++ b/ipld/amt/benches/amt_benchmark.rs
@@ -123,7 +123,6 @@ fn for_each(c: &mut Criterion) {
     c.bench_function("AMT for_each function", |b| {
         b.iter(|| {
             let a = Amt::load(&cid, &db).unwrap();
-            #[allow(deprecated)]
             black_box(a).for_each(|_, _v: &u64| Ok(())).unwrap();
         })
     });

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -448,7 +448,6 @@ where
     /// assert_eq!(&values, &[(1, "One".to_owned()), (4, "Four".to_owned())]);
     /// ```
     #[inline]
-    #[deprecated = "use `.iter()` instead"]
     pub fn for_each<F>(&self, mut f: F) -> Result<(), Error>
     where
         F: FnMut(u64, &V) -> anyhow::Result<()>,
@@ -462,7 +461,6 @@ where
 
     /// Iterates over each value in the Amt and runs a function on the values, for as long as that
     /// function keeps returning `true`.
-    #[deprecated = "use `.iter()` instead"]
     pub fn for_each_while<F>(&self, mut f: F) -> Result<(), Error>
     where
         F: FnMut(u64, &V) -> anyhow::Result<bool>,
@@ -508,7 +506,6 @@ where
     /// assert_eq!(num_traversed, 3);
     /// assert_eq!(next_idx, Some(10));
     /// ```
-    #[deprecated = "use `.iter_from()` and `.take(limit)` instead"]
     pub fn for_each_ranged<F>(
         &self,
         start_at: Option<u64>,
@@ -539,7 +536,6 @@ where
     /// `limit` elements have been traversed. Returns a tuple describing the number of elements
     /// iterated over and optionally the index of the next element in the AMT if more elements
     /// remain.
-    #[deprecated = "use `.iter_from()` and `.take(limit)` instead"]
     pub fn for_each_while_ranged<F>(
         &self,
         start_at: Option<u64>,

--- a/ipld/amt/src/iter.rs
+++ b/ipld/amt/src/iter.rs
@@ -343,7 +343,6 @@ mod tests {
         let k = Amt::<&str, _>::new_from_iter(&mem, data.iter().map(|s| &**s)).unwrap();
         let a: Amt<String, _> = Amt::load(&k, &mem).unwrap();
         let mut restored = Vec::new();
-        #[allow(deprecated)]
         a.for_each(|k, v| {
             restored.push((k as usize, v.clone()));
             Ok(())
@@ -381,7 +380,6 @@ mod tests {
         let new_amt = Amt::load(&c, &db).unwrap();
 
         let mut x = 0;
-        #[allow(deprecated)]
         new_amt
             .for_each(|k, _: &BytesDe| {
                 if k != indexes[x] {

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -352,7 +352,6 @@ fn for_each() {
 
     // Iterate over amt with dirty cache
     let mut x = 0;
-    #[allow(deprecated)]
     a.for_each(|_, _: &BytesDe| {
         x += 1;
         Ok(())
@@ -367,7 +366,6 @@ fn for_each() {
     assert_eq!(new_amt.count(), indexes.len() as u64);
 
     let mut x = 0;
-    #[allow(deprecated)]
     new_amt
         .for_each(|i, _: &BytesDe| {
             if i != indexes[x] {
@@ -382,7 +380,6 @@ fn for_each() {
         .unwrap();
     assert_eq!(x, indexes.len());
 
-    #[allow(deprecated)]
     new_amt.for_each(|_, _: &BytesDe| Ok(())).unwrap();
     assert_eq!(
         c.to_string().as_str(),
@@ -420,7 +417,6 @@ fn for_each_ranged() {
     // Iterate over amt with dirty cache from different starting values
     for start_val in 0..RANGE {
         let mut retrieved_values = Vec::new();
-        #[allow(deprecated)]
         let (count, next_key) = a
             .for_each_while_ranged(Some(start_val), None, |index, _: &BytesDe| {
                 retrieved_values.push(index);
@@ -436,7 +432,6 @@ fn for_each_ranged() {
 
     // Iterate out of bounds
     for i in [RANGE, RANGE + 1, 2 * RANGE, 8 * RANGE] {
-        #[allow(deprecated)]
         let (count, next_key) = a
             .for_each_while_ranged(Some(i), None, |_, _: &BytesDe| {
                 panic!("didn't expect to iterate")
@@ -449,7 +444,6 @@ fn for_each_ranged() {
     // Iterate over amt with dirty cache with different page sizes
     for page_size in 1..=RANGE {
         let mut retrieved_values = Vec::new();
-        #[allow(deprecated)]
         let (count, next_key) = a
             .for_each_while_ranged(None, Some(page_size), |index, _: &BytesDe| {
                 retrieved_values.push(index);
@@ -471,7 +465,6 @@ fn for_each_ranged() {
     let mut retrieved_values = Vec::new();
     let mut start_cursor = None;
     loop {
-        #[allow(deprecated)]
         let (num_traversed, next_cursor) = a
             .for_each_while_ranged(start_cursor, Some(page_size), |idx, _val| {
                 retrieved_values.push(idx);
@@ -497,7 +490,6 @@ fn for_each_ranged() {
     let mut retrieved_values = Vec::new();
     let mut start_cursor = None;
     loop {
-        #[allow(deprecated)]
         let (num_traversed, next_cursor) = a
             .for_each_ranged(start_cursor, Some(page_size), |idx, _val: &BytesDe| {
                 retrieved_values.push(idx);
@@ -523,7 +515,6 @@ fn for_each_ranged() {
 
     // Iterate over the amt with dirty cache ignoring gaps in the address space including at the
     // beginning of the amt, we should only see the values that were not deleted
-    #[allow(deprecated)]
     let (num_traversed, next_cursor) = a
         .for_each_while_ranged(Some(0), Some(501), |i, _v| {
             assert_eq!((i / 10) % 2, 1); // only "odd" batches of ten 10 - 19, 30 - 39, etc. should be present
@@ -536,7 +527,6 @@ fn for_each_ranged() {
     // flush the amt to the blockstore, reload and repeat the test with a clean cache
     let cid = a.flush().unwrap();
     let a = Amt::load(&cid, &db).unwrap();
-    #[allow(deprecated)]
     let (num_traversed, next_cursor) = a
         .for_each_while_ranged(Some(0), Some(501), |i, _v: &BytesDe| {
             assert_eq!((i / 10) % 2, 1); // only "odd" batches of ten 10 - 19, 30 - 39, etc. should be present
@@ -632,7 +622,6 @@ fn new_from_iter() {
 
     let a: Amt<String, _> = Amt::load(&k, &mem).unwrap();
     let mut restored = Vec::new();
-    #[allow(deprecated)]
     a.for_each(|k, v| {
         restored.push((k as usize, v.clone()));
         Ok(())

--- a/ipld/kamt/src/kamt.rs
+++ b/ipld/kamt/src/kamt.rs
@@ -339,7 +339,6 @@ where
     /// assert_eq!(total, 3);
     /// ```
     #[inline]
-    #[deprecated = "use `.iter()` instead"]
     pub fn for_each<F>(&self, mut f: F) -> Result<(), Error>
     where
         V: DeserializeOwned,


### PR DESCRIPTION
These are useful because they handle some error cases and the ranged version is especially useful as using iter + skip etc. is actually kind of annoying. It would still be better to replace these with iterators in many cases, but replacing them _everywhere_ is annoying and not worth the effort.