### PR TITLE
feat: publicly export GasOutputs

### DIFF
--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -10,7 +10,7 @@ use anyhow::Context;
 use num_traits::Zero;
 
 pub use self::charge::GasCharge;
-pub(crate) use self::outputs::GasOutputs;
+pub use self::outputs::GasOutputs;
 pub use self::price_list::{price_list_by_network_version, PriceList, WasmGasPrices};
 pub use self::timer::{GasDuration, GasInstant, GasTimer};
 use crate::kernel::{ClassifyResult, ExecutionError, Result};

--- a/fvm/src/gas/outputs.rs
+++ b/fvm/src/gas/outputs.rs
@@ -4,7 +4,7 @@
 use fvm_shared::econ::TokenAmount;
 
 #[derive(Clone, Default)]
-pub(crate) struct GasOutputs {
+pub struct GasOutputs {
     pub base_fee_burn: TokenAmount,
     pub over_estimation_burn: TokenAmount,
     pub miner_penalty: TokenAmount,


### PR DESCRIPTION
It would be beneficial for Forest to use the `GasOutputs` type, as it is necessary for computing gas outputs when creating Ethereum transaction receipts.

At present, we are duplicating this code.

This PR tries to fix that by publicly exporting it. Let me know your thoughts, thanks!