### PR TITLE
feat: kamt: Add public fn clear to reset and clear all entries in KAMT

### DIFF
--- a/ipld/kamt/src/kamt.rs
+++ b/ipld/kamt/src/kamt.rs
@@ -571,13 +571,13 @@ mod tests {
         assert_eq!(kamt.get(&2).unwrap(), Some(&"b".to_string()));
 
         // Verify the KAMT is not empty
-        assert_eq!(kamt.is_empty(), false);
+        assert!(!kamt.is_empty());
 
         // Clear the KAMT
         kamt.clear();
 
         // Verify the KAMT is empty
-        assert_eq!(kamt.is_empty(), true);
+        assert!(kamt.is_empty());
 
         // Verify previous entries are gone
         assert_eq!(kamt.get(&1).unwrap(), None);

--- a/ipld/kamt/src/kamt.rs
+++ b/ipld/kamt/src/kamt.rs
@@ -130,6 +130,12 @@ where
     pub fn is_empty(&self) -> bool {
         self.root.is_empty()
     }
+
+    /// Clears all entries in the KAMT and resets the root to an empty node.
+    pub fn clear(&mut self) {
+        self.root = Node::default(); // Reset the root to an empty node
+        self.flushed_cid = None; // Invalidate the flushed CID
+    }
 }
 
 impl<BS, K, V, H, const N: usize> Kamt<BS, K, V, H, N>
@@ -548,5 +554,37 @@ mod tests {
         assert_eq!(kvs, results);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_clear() {
+        let store = MemoryBlockstore::default();
+        let mut kamt: Kamt<_, u32, String, Identity> = Kamt::new_with_config(store, Config::default());
+
+
+        // Insert some entries into the KAMT
+        kamt.set(1, "a".to_string()).unwrap();
+        kamt.set(2, "b".to_string()).unwrap();
+
+        // Verify the entries exist
+        assert_eq!(kamt.get(&1).unwrap(), Some(&"a".to_string()));
+        assert_eq!(kamt.get(&2).unwrap(), Some(&"b".to_string()));
+
+        // Verify the KAMT is not empty
+        assert_eq!(kamt.is_empty(), false);
+
+        // Clear the KAMT
+        kamt.clear();
+
+        // Verify the KAMT is empty
+        assert_eq!(kamt.is_empty(), true);
+
+        // Verify previous entries are gone
+        assert_eq!(kamt.get(&1).unwrap(), None);
+        assert_eq!(kamt.get(&2).unwrap(), None);
+
+        // Ensure subsequent operations still work
+        kamt.set(3, "c".to_string()).unwrap();
+        assert_eq!(kamt.get(&3).unwrap(), Some(&"c".to_string()));
     }
 }

--- a/ipld/kamt/src/kamt.rs
+++ b/ipld/kamt/src/kamt.rs
@@ -559,8 +559,8 @@ mod tests {
     #[test]
     fn test_clear() {
         let store = MemoryBlockstore::default();
-        let mut kamt: Kamt<_, u32, String, Identity> = Kamt::new_with_config(store, Config::default());
-
+        let mut kamt: Kamt<_, u32, String, Identity> =
+            Kamt::new_with_config(store, Config::default());
 
         // Insert some entries into the KAMT
         kamt.set(1, "a".to_string()).unwrap();

--- a/ipld/kamt/src/kamt.rs
+++ b/ipld/kamt/src/kamt.rs
@@ -133,6 +133,11 @@ where
 
     /// Clears all entries in the KAMT and resets the root to an empty node.
     pub fn clear(&mut self) {
+        // Check if the KAMT is already empty
+        if self.is_empty() {
+            return; // Avoid unnecessary root reset
+        }
+
         self.root = Node::default(); // Reset the root to an empty node
         self.flushed_cid = None; // Invalidate the flushed CID
     }
@@ -561,6 +566,15 @@ mod tests {
         let store = MemoryBlockstore::default();
         let mut kamt: Kamt<_, u32, String, Identity> =
             Kamt::new_with_config(store, Config::default());
+
+        // Verify the KAMT is initially empty
+        assert!(kamt.is_empty());
+
+        // Call clear on an already empty KAMT
+        kamt.clear();
+
+        // Verify it is still empty
+        assert!(kamt.is_empty());
 
         // Insert some entries into the KAMT
         kamt.set(1, "a".to_string()).unwrap();


### PR DESCRIPTION
This PR introduces a new `clear` method to the `Kamt` data structure, allowing users to reset the root to an empty node and clear all entries. 

#### Changes:
- Added `pub fn clear` to `Kamt` to reset and clear all entries.
- Updated the test suite with `test_clear` to verify:
  - Entries exist before clearing.
  - Entries are removed after calling `clear`.
  - The `Kamt` remains functional post-clear.

This addition enhances usability by providing an efficient way to clear the `Kamt`. 

This functionality is introduced to support the implementation of Transient Storage (EIP-1153) in `builtin-actors`, enabling efficient clearing of the KAMT while adhering to Rust's RAII expectations and best practices. The previous approach attempts of using `take`/`delete` followed by `new` was unsuitable in Rust due to its ownership model and memory safety guarantees. The new `clear` method resolves this limitation, providing a safe and efficient way to reset the KAMT without requiring a full reallocation.