### PR TITLE
chore: release kamt/hamt to add a clear method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.2",
  "fvm_shared 4.5.1",
  "lazy_static",
  "log",
@@ -1607,7 +1607,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_kamt 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_kamt 0.4.2",
  "fvm_shared 4.5.1",
  "hex",
  "hex-literal",
@@ -1630,7 +1630,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.2",
  "fvm_shared 4.5.1",
  "log",
  "num-derive 0.3.3",
@@ -1651,7 +1651,7 @@ dependencies = [
  "fvm_ipld_bitfield 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.2",
  "fvm_shared 4.5.1",
  "integer-encoding 3.0.4",
  "ipld-core",
@@ -1678,7 +1678,7 @@ dependencies = [
  "fvm_ipld_bitfield 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.2",
  "fvm_shared 4.5.1",
  "itertools 0.10.5",
  "lazy_static",
@@ -1702,7 +1702,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.2",
  "fvm_shared 4.5.1",
  "indexmap 1.9.3",
  "integer-encoding 3.0.4",
@@ -1744,7 +1744,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.2",
  "fvm_shared 4.5.1",
  "indexmap 1.9.3",
  "integer-encoding 3.0.4",
@@ -1801,7 +1801,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.2",
  "fvm_shared 4.5.1",
  "lazy_static",
  "log",
@@ -1836,7 +1836,7 @@ dependencies = [
  "fvm_ipld_bitfield 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.2",
  "fvm_sdk 4.5.1",
  "fvm_shared 4.5.1",
  "integer-encoding 3.0.4",
@@ -2273,7 +2273,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.2",
  "fvm_sdk 4.5.1",
  "fvm_shared 4.5.1",
  "integer-encoding 4.0.2",
@@ -2418,7 +2418,7 @@ dependencies = [
  "fvm_ipld_amt 0.7.3",
  "fvm_ipld_blockstore 0.3.1",
  "fvm_ipld_encoding 0.5.1",
- "fvm_ipld_hamt 0.10.2",
+ "fvm_ipld_hamt 0.10.3",
  "fvm_shared 4.5.3",
  "lazy_static",
  "log",
@@ -2745,30 +2745,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.10.2"
-dependencies = [
- "anyhow",
- "byteorder",
- "cid 0.11.1",
- "criterion",
- "forest_hash_utils",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.1",
- "hex",
- "ipld-core",
- "multihash-codetable",
- "once_cell",
- "quickcheck",
- "quickcheck_macros",
- "rand",
- "serde",
- "sha2 0.10.8",
- "thiserror",
- "unsigned-varint 0.8.0",
-]
-
-[[package]]
-name = "fvm_ipld_hamt"
-version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8512ddaa098c324e0c6b0d8cccacdcbc08834509db11f52d5f5cd7f1f10a39f8"
 dependencies = [
@@ -2787,8 +2763,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "fvm_ipld_kamt"
-version = "0.4.2"
+name = "fvm_ipld_hamt"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2798,12 +2774,14 @@ dependencies = [
  "fvm_ipld_blockstore 0.3.1",
  "fvm_ipld_encoding 0.5.1",
  "hex",
+ "ipld-core",
  "multihash-codetable",
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
  "rand",
  "serde",
+ "sha2 0.10.8",
  "thiserror",
  "unsigned-varint 0.8.0",
 ]
@@ -2824,6 +2802,28 @@ dependencies = [
  "once_cell",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "fvm_ipld_kamt"
+version = "0.4.3"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "cid 0.11.1",
+ "criterion",
+ "forest_hash_utils",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.1",
+ "hex",
+ "multihash-codetable",
+ "once_cell",
+ "quickcheck",
+ "quickcheck_macros",
+ "rand",
+ "serde",
+ "thiserror",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -3365,7 +3365,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_hamt 0.10.2",
+ "fvm_ipld_hamt 0.10.3",
  "libfuzzer-sys",
 ]
 
@@ -3375,7 +3375,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_kamt 0.4.2",
+ "fvm_ipld_kamt 0.4.3",
  "libfuzzer-sys",
 ]
 
@@ -5231,7 +5231,7 @@ dependencies = [
  "cid 0.11.1",
  "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_hamt 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.2",
  "fvm_shared 4.5.1",
  "multihash-codetable",
  "num-derive 0.3.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,8 @@ fvm_integration_tests = { path = "testing/integration", version = "~4.5.3" }
 
 # workspace (other)
 fvm_ipld_amt = { path = "ipld/amt", version = "0.7.3" }
-fvm_ipld_hamt = { path = "ipld/hamt", version = "0.10.2" }
-fvm_ipld_kamt = { path = "ipld/kamt", version = "0.4.2" }
+fvm_ipld_hamt = { path = "ipld/hamt", version = "0.10.3" }
+fvm_ipld_kamt = { path = "ipld/kamt", version = "0.4.3" }
 fvm_ipld_car = { path = "ipld/car", version = "0.8.1" }
 fvm_ipld_blockstore = { path = "ipld/blockstore", version = "0.3.1" }
 fvm_ipld_bitfield = { path = "ipld/bitfield", version = "0.7.1" }

--- a/ipld/hamt/CHANGELOG.md
+++ b/ipld/hamt/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM's HAMT implementation.
 
 ## [Unreleased]
 
+## 0.10.3 [2024-12-04]
+
+- Add a `.clear()` method for resetting the HAMT to empty.
+
 ## 0.10.2 [2024-11-20]
 
 Empty-release intended to un-deprecate `.for_each` but it was never actually deprecated in this crate.

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_hamt"
 description = "Sharded IPLD HashMap implementation."
-version = "0.10.2"
+version = "0.10.3"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/ipld/kamt/CHANGELOG.md
+++ b/ipld/kamt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.3 [2024-12-04]
+
+- Add a `.clear()` method for resetting the KAMT to empty.
+
 ## 0.4.2 [2024-11-20]
 
 - Un-deprecate `.for_each(...)`. The `.iter()` method is still preferred but `.for_each(...)` is still useful.

--- a/ipld/kamt/Cargo.toml
+++ b/ipld/kamt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_kamt"
 description = "Sharded IPLD Map implementation with level skipping."
-version = "0.4.2"
+version = "0.4.3"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"


### PR DESCRIPTION
- fvm_ipld_hamt@v0.10.3
- fvm_ipld_kamt@v0.4.3