### PR TITLE
chore: remove the hash-utils dependency from the KAMT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,7 +2812,6 @@ dependencies = [
  "byteorder",
  "cid 0.11.1",
  "criterion",
- "forest_hash_utils",
  "fvm_ipld_blockstore 0.3.1",
  "fvm_ipld_encoding 0.5.1",
  "hex",

--- a/ipld/kamt/Cargo.toml
+++ b/ipld/kamt/Cargo.toml
@@ -17,7 +17,6 @@ once_cell = { workspace = true }
 anyhow = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
-forest_hash_utils = "0.1"
 
 [dev-dependencies]
 hex = { workspace = true }

--- a/ipld/kamt/tests/kamt_tests.rs
+++ b/ipld/kamt/tests/kamt_tests.rs
@@ -6,9 +6,9 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 
 use cid::Cid;
-use forest_hash_utils::BytesKey;
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::de::DeserializeOwned;
+use fvm_ipld_encoding::BytesDe;
 use fvm_ipld_encoding::CborStore;
 use fvm_ipld_kamt::id::Identity;
 use fvm_ipld_kamt::{Config, Error, HashedKey, Kamt};
@@ -104,7 +104,7 @@ fn test_load(factory: KamtFactory) {
 
     // loading from an empty store does not work
     let empty_store = MemoryBlockstore::default();
-    assert!(factory.load::<_, u32, BytesKey>(&c2, &empty_store).is_err());
+    assert!(factory.load::<_, u32, BytesDe>(&c2, &empty_store).is_err());
 
     // storing the kamt should produce the same cid as storing the root
     let c3 = kamt.flush().unwrap();
@@ -319,8 +319,8 @@ fn prop_cid_ops_reduced<const N: u32>(factory: KamtFactory, ops: LimitedKeyOps<N
     cid1 == cid2
 }
 
-fn tstring(v: impl Display) -> BytesKey {
-    BytesKey(v.to_string().into_bytes())
+fn tstring(v: impl Display) -> BytesDe {
+    BytesDe(v.to_string().into_bytes())
 }
 
 fn kstring(v: impl Display) -> HashedKey<32> {


### PR DESCRIPTION
We still need to do this for the HAMT, but this is progress.