### PR TITLE
chore: update ipld-core and serde_ipld_dagcbor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2718,7 +2718,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.3.1",
  "multihash-codetable",
  "serde",
- "serde_ipld_dagcbor 0.6.1",
+ "serde_ipld_dagcbor 0.6.2",
  "serde_json",
  "serde_repr",
  "serde_tuple",
@@ -2736,7 +2736,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash-codetable",
  "serde",
- "serde_ipld_dagcbor 0.6.1",
+ "serde_ipld_dagcbor 0.6.2",
  "serde_repr",
  "serde_tuple",
  "thiserror",
@@ -3337,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "ipld-core"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ede82a79e134f179f4b29b5fdb1eb92bd1b38c4dfea394c539051150a21b9b"
+checksum = "104718b1cc124d92a6d01ca9c9258a7df311405debb3408c445a36452f9bf8db"
 dependencies = [
  "cid 0.11.1",
  "serde",
@@ -4581,9 +4581,9 @@ dependencies = [
 
 [[package]]
 name = "serde_ipld_dagcbor"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded35fbe4ab8fdec1f1d14b4daff2206b1eada4d6e708cb451d464d2d965f493"
+checksum = "6851dcd54a7271dd9013195fdccbdaba70c8e71014364e396d4b938d0e67f324"
 dependencies = [
  "cbor4ii",
  "ipld-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ futures = "0.3.28"
 
 # IPLD/Encoding
 cid = { version = "0.11.1", default-features = false }
-ipld-core = { version = "0.4.1", features = ["serde"] }
+ipld-core = { version = "0.4.2", features = ["serde"] }
 multihash-codetable = { version = "0.1.4", default-features = false }
 multihash-derive = { version = "0.9.1", default-features = false }
 

--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 multihash-codetable = { workspace = true, features = ["blake2b"] }
-serde_ipld_dagcbor = "0.6.1"
+serde_ipld_dagcbor = "0.6.2"
 serde_repr = "0.1"
 
 [features]


### PR DESCRIPTION
Adds support for default fields by being less strict up-front when decoding maps and lists and allowing the visitors to determine what/how to consume the tokens.

I had a bit of trouble using `cargo` commands to make this happen, particularly to get ipld/encoding/Cargo.toml updated, so I ended up just bumping the numbers manually and doing `cargo build` to get Cargo.lock to update. So I'd like to know what the proper way would be to do this.