### PR TITLE
feat: customizable gas distribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_bitfield 0.6.0",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "libfuzzer-sys",
  "multihash 0.18.1",
  "rand",
@@ -1883,8 +1883,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -1920,8 +1920,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -1930,8 +1930,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1942,8 +1942,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "serde",
  "serde_tuple",
 ]
@@ -1953,8 +1953,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -1965,8 +1965,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "libipld",
  "num-derive 0.4.2",
  "num-traits",
@@ -1978,8 +1978,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "log",
  "serde",
  "serde_tuple",
@@ -1989,8 +1989,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -2001,8 +2001,8 @@ dependencies = [
  "cid 0.10.1",
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "serde",
  "serde_tuple",
 ]
@@ -2012,8 +2012,8 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "minicov",
 ]
 
@@ -2021,16 +2021,16 @@ dependencies = [
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -2039,8 +2039,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -2049,16 +2049,16 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
 ]
 
 [[package]]
@@ -2067,8 +2067,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "minicov",
  "multihash 0.18.1",
 ]
@@ -2079,8 +2079,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "serde",
  "serde_tuple",
 ]
@@ -2091,8 +2091,8 @@ version = "0.1.0"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "serde",
  "serde_tuple",
 ]
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.4.3"
+version = "4.4.4"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2437,7 +2437,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "lazy_static",
  "log",
  "minstant",
@@ -2467,7 +2467,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "hex",
 ]
 
@@ -2520,7 +2520,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "itertools 0.13.0",
  "ittapi-rs",
  "lazy_static",
@@ -2541,7 +2541,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "num-derive 0.4.2",
  "num-traits",
  "serde",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.4.3"
+version = "4.4.4"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2565,8 +2565,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.1",
  "fvm_ipld_car 0.7.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_sdk 4.4.3",
- "fvm_shared 4.4.3",
+ "fvm_sdk 4.4.4",
+ "fvm_shared 4.4.4",
  "fvm_test_actors",
  "hex",
  "lazy_static",
@@ -2828,11 +2828,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.4.3"
+version = "4.4.4"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "lazy_static",
  "log",
  "num-traits",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.4.3"
+version = "4.4.4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2879,7 +2879,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.4.0",
- "fvm_shared 4.4.3",
+ "fvm_shared 4.4.4",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.4.3"
+version = "4.4.4"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -73,10 +73,10 @@ minstant = "0.1.3"
 coverage-helper = "0.2.0"
 
 # workspace (FVM)
-fvm = { path = "fvm", version = "~4.4.3", default-features = false }
-fvm_shared = { path = "shared", version = "~4.4.3", default-features = false }
-fvm_sdk = { path = "sdk", version = "~4.4.3" }
-fvm_integration_tests = { path = "testing/integration", version = "~4.4.3" }
+fvm = { path = "fvm", version = "~4.4.4", default-features = false }
+fvm_shared = { path = "shared", version = "~4.4.4", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.4.4" }
+fvm_integration_tests = { path = "testing/integration", version = "~4.4.4" }
 
 # workspace (other)
 fvm_ipld_amt = { path = "ipld/amt", version = "0.6.2" }

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.4.4 [2024-11-18]
+
+- feat: add `nv25-dev` feature flag [#2076](https://github.com/filecoin-project/ref-fvm/pull/2076)
+
 ## 4.4.3 [2024-10-21]
 
 - Update wasmtime to 25.0.2.

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -60,3 +60,4 @@ gas_calibration = []
 # The current implementation keeps it by default for backward compatibility reason.
 # See <https://github.com/filecoin-project/ref-fvm/issues/2001>
 verify-signature = []
+nv25-dev = []

--- a/fvm/src/call_manager/default.rs
+++ b/fvm/src/call_manager/default.rs
@@ -245,6 +245,7 @@ where
     fn with_transaction(
         &mut self,
         f: impl FnOnce(&mut Self) -> Result<InvocationResult>,
+        always_revert: bool,
     ) -> Result<InvocationResult> {
         self.state_tree_mut().begin_transaction();
         self.events.begin_transaction();
@@ -254,6 +255,7 @@ where
             Ok(v) => (!v.exit_code.is_success(), Ok(v)),
             Err(e) => (true, Err(e)),
         };
+        let revert = always_revert || revert;
 
         self.state_tree_mut().end_transaction(revert)?;
         self.events.end_transaction(revert)?;

--- a/fvm/src/call_manager/mod.rs
+++ b/fvm/src/call_manager/mod.rs
@@ -77,9 +77,12 @@ pub trait CallManager: 'static {
     ) -> Result<InvocationResult>;
 
     /// Execute some operation (usually a call_actor) within a transaction.
+    /// The always_revert parameter indicates if the transaction is going to revert at the end of its
+    /// execution. This is useful for read-only transactions.
     fn with_transaction(
         &mut self,
         f: impl FnOnce(&mut Self) -> Result<InvocationResult>,
+        always_revert: bool,
     ) -> Result<InvocationResult>;
 
     /// Finishes execution, returning the gas used, machine, and exec trace if requested.

--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -20,6 +20,8 @@ use crate::call_manager::Backtrace;
 use crate::trace::ExecutionTrace;
 use crate::Kernel;
 
+pub use default::{ExecutionOptions, TxnGasHook};
+
 /// An executor executes messages on the underlying machine/kernel. It's responsible for:
 ///
 /// 1. Validating messages (nonce, sender, etc).

--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -10,7 +10,7 @@ use anyhow::Context;
 use num_traits::Zero;
 
 pub use self::charge::GasCharge;
-pub(crate) use self::outputs::GasOutputs;
+pub use self::outputs::GasOutputs;
 pub use self::price_list::{price_list_by_network_version, PriceList, WasmGasPrices};
 pub use self::timer::{GasDuration, GasInstant, GasTimer};
 use crate::kernel::{ClassifyResult, ExecutionError, Result};

--- a/fvm/src/gas/outputs.rs
+++ b/fvm/src/gas/outputs.rs
@@ -4,7 +4,7 @@
 use fvm_shared::econ::TokenAmount;
 
 #[derive(Clone, Default)]
-pub(crate) struct GasOutputs {
+pub struct GasOutputs {
     pub base_fee_burn: TokenAmount,
     pub over_estimation_burn: TokenAmount,
     pub miner_penalty: TokenAmount,

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -1004,6 +1004,8 @@ pub fn price_list_by_network_version(network_version: NetworkVersion) -> &'stati
         NetworkVersion::V21 | NetworkVersion::V22 | NetworkVersion::V23 | NetworkVersion::V24 => {
             &WATERMELON_PRICES
         }
+        #[cfg(feature = "nv25-dev")]
+        NetworkVersion::V25 => &WATERMELON_PRICES,
         _ => panic!("network version {nv} not supported", nv = network_version),
     }
 }

--- a/fvm/src/kernel/default.rs
+++ b/fvm/src/kernel/default.rs
@@ -152,17 +152,20 @@ where
         }
 
         // Send.
-        let result = self.call_manager.with_transaction(|cm| {
-            cm.call_actor::<K>(
-                from,
-                *recipient,
-                Entrypoint::Invoke(method),
-                params,
-                value,
-                gas_limit,
-                read_only,
-            )
-        })?;
+        let result = self.call_manager.with_transaction(
+            |cm| {
+                cm.call_actor::<K>(
+                    from,
+                    *recipient,
+                    Entrypoint::Invoke(method),
+                    params,
+                    value,
+                    gas_limit,
+                    read_only,
+                )
+            },
+            false,
+        )?;
 
         // Store result and return.
         Ok(match result {
@@ -240,41 +243,44 @@ where
             return Err(syscall_error!(LimitExceeded; "cannot store return block").into());
         }
 
-        let result = self.call_manager.with_transaction(|cm| {
-            let state = cm
-                .get_actor(self.actor_id)?
-                .ok_or_else(|| syscall_error!(IllegalOperation; "actor deleted"))?;
+        let result = self.call_manager.with_transaction(
+            |cm| {
+                let state = cm
+                    .get_actor(self.actor_id)?
+                    .ok_or_else(|| syscall_error!(IllegalOperation; "actor deleted"))?;
 
-            // store the code cid of the calling actor before running the upgrade entrypoint
-            // in case it was changed (which could happen if the target upgrade entrypoint
-            // sent a message to this actor which in turn called upgrade)
-            let code = state.code;
+                // store the code cid of the calling actor before running the upgrade entrypoint
+                // in case it was changed (which could happen if the target upgrade entrypoint
+                // sent a message to this actor which in turn called upgrade)
+                let code = state.code;
 
-            // update the code cid of the actor to new_code_cid
-            cm.set_actor(
-                self.actor_id,
-                ActorState::new(
-                    new_code_cid,
-                    state.state,
-                    state.balance,
-                    state.sequence,
+                // update the code cid of the actor to new_code_cid
+                cm.set_actor(
+                    self.actor_id,
+                    ActorState::new(
+                        new_code_cid,
+                        state.state,
+                        state.balance,
+                        state.sequence,
+                        None,
+                    ),
+                )?;
+
+                // run the upgrade entrypoint
+                let result = cm.call_actor::<K>(
+                    self.caller,
+                    Address::new_id(self.actor_id),
+                    Entrypoint::Upgrade(UpgradeInfo { old_code_cid: code }),
+                    params,
+                    &TokenAmount::from_whole(0),
                     None,
-                ),
-            )?;
+                    false,
+                )?;
 
-            // run the upgrade entrypoint
-            let result = cm.call_actor::<K>(
-                self.caller,
-                Address::new_id(self.actor_id),
-                Entrypoint::Upgrade(UpgradeInfo { old_code_cid: code }),
-                params,
-                &TokenAmount::from_whole(0),
-                None,
-                false,
-            )?;
-
-            Ok(result)
-        });
+                Ok(result)
+            },
+            false,
+        );
 
         match result {
             Ok(InvocationResult { exit_code, value }) => {

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -51,8 +51,13 @@ where
     /// * `blockstore`: The underlying [blockstore][`Blockstore`] for reading/writing state.
     /// * `externs`: Client-provided ["external"][`Externs`] methods for accessing chain state.
     pub fn new(context: &MachineContext, blockstore: B, externs: E) -> anyhow::Result<Self> {
+        #[cfg(not(feature = "nv25-dev"))]
         const SUPPORTED_VERSIONS: RangeInclusive<NetworkVersion> =
             NetworkVersion::V21..=NetworkVersion::V24;
+
+        #[cfg(feature = "nv25-dev")]
+        const SUPPORTED_VERSIONS: RangeInclusive<NetworkVersion> =
+            NetworkVersion::V21..=NetworkVersion::V25;
 
         debug!(
             "initializing a new machine, epoch={}, base_fee={}, nv={:?}, root={}",

--- a/fvm/tests/dummy.rs
+++ b/fvm/tests/dummy.rs
@@ -291,6 +291,7 @@ impl CallManager for DummyCallManager {
     fn with_transaction(
         &mut self,
         _f: impl FnOnce(&mut Self) -> kernel::Result<InvocationResult>,
+        _always_revert: bool,
     ) -> kernel::Result<InvocationResult> {
         // Ok(InvocationResult::Return(None))
         todo!()

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 4.4.4 [2024-11-18]
+
+- feat: add `nv25-dev` feature flag [#2076](https://github.com/filecoin-project/ref-fvm/pull/2076)
+
 ## 4.4.3 [2024-10-21]
 
 - Update wasmtime to 25.0.2.

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 4.4.4 [2024-11-18]
+
+- feat: add `nv25-dev` feature flag [#2076](https://github.com/filecoin-project/ref-fvm/pull/2076)
+
 ## 4.4.3 [2024-10-21]
 
 - Update wasmtime to 25.0.2.

--- a/shared/src/version/mod.rs
+++ b/shared/src/version/mod.rs
@@ -61,8 +61,10 @@ impl NetworkVersion {
     pub const V22: Self = Self(22);
     /// Waffle (builtin-actors v14)
     pub const V23: Self = Self(23);
-    /// TBD (builtin-actors v15)
+    /// TukTuk (builtin-actors v15)
     pub const V24: Self = Self(24);
+    /// TBD (builtin-actors v16)
+    pub const V25: Self = Self(25);
 
     pub const MAX: Self = Self(u32::MAX);
 

--- a/testing/integration/tests/main.rs
+++ b/testing/integration/tests/main.rs
@@ -21,8 +21,8 @@ use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use fvm_test_actors::wasm_bin::{
     ADDRESS_ACTOR_BINARY, CREATE_ACTOR_BINARY, CUSTOM_SYSCALL_ACTOR_BINARY, EXIT_DATA_ACTOR_BINARY,
-    HELLO_WORLD_ACTOR_BINARY, IPLD_ACTOR_BINARY, OOM_ACTOR_BINARY, READONLY_ACTOR_BINARY,
-    SSELF_ACTOR_BINARY, STACK_OVERFLOW_ACTOR_BINARY, SYSCALL_ACTOR_BINARY,
+    HELLO_WORLD_ACTOR_BINARY, INTEGER_OVERFLOW_ACTOR_BINARY, IPLD_ACTOR_BINARY, OOM_ACTOR_BINARY,
+    READONLY_ACTOR_BINARY, SSELF_ACTOR_BINARY, STACK_OVERFLOW_ACTOR_BINARY, SYSCALL_ACTOR_BINARY,
     SYSCALL_ACTOR_BINARY_FIP0079, UPGRADE_ACTOR_BINARY, UPGRADE_RECEIVE_ACTOR_BINARY,
 };
 use num_traits::Zero;
@@ -30,7 +30,7 @@ use num_traits::Zero;
 mod bundles;
 use bundles::*;
 use fvm_shared::chainid::ChainID;
-use fvm_shared::ActorID;
+use fvm_shared::{ActorID, METHOD_SEND};
 
 /// The state object.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug, Default)]
@@ -1320,6 +1320,209 @@ fn upgrade_actor_test() {
                 .code;
             assert_eq!(code, expected_cid);
         }
+    }
+}
+
+/// Testing a read only transaction where fund send are not applied
+#[test]
+fn test_readonly_txn_send_ok() {
+    let mut tester = new_tester(
+        NetworkVersion::V21,
+        StateTreeVersion::V5,
+        MemoryBlockstore::default(),
+    )
+    .unwrap();
+
+    let (_, sender) = tester.create_account().unwrap();
+
+    // Send to an f4 to create a placeholder. Otherwise, we end up invoking a constructor.
+    let receiver = Address::new_delegated(10, b"foobar").expect("failed to construct f4 address");
+
+    tester.instantiate_machine(DummyExterns).unwrap();
+
+    let executor = tester.executor.as_mut().unwrap();
+
+    let message = Message {
+        from: sender,
+        to: receiver,
+        gas_limit: i64::MAX as u64,
+        method_num: METHOD_SEND,
+        sequence: 1,
+        value: TokenAmount::from_atto(1),
+        ..Message::default()
+    };
+
+    let sender_pre_balance = executor
+        .state_tree()
+        .get_actor_by_address(&sender)
+        .unwrap()
+        .unwrap()
+        .balance;
+    let receiver_pre_balance = executor
+        .state_tree()
+        .get_actor_by_address(&sender)
+        .unwrap()
+        .unwrap()
+        .balance;
+
+    // always revert the transaction
+    let always_revert = true;
+    let res = executor
+        .execute_message_with_revert(message, ApplyKind::Explicit, 100, always_revert)
+        .unwrap();
+
+    let sender_post_balance = executor
+        .state_tree()
+        .get_actor_by_address(&sender)
+        .unwrap()
+        .unwrap()
+        .balance;
+    let receiver_post_balance = executor
+        .state_tree()
+        .get_actor_by_address(&sender)
+        .unwrap()
+        .unwrap()
+        .balance;
+
+    assert!(res.msg_receipt.exit_code.is_success());
+    assert_eq!(sender_pre_balance, sender_post_balance);
+    assert_eq!(receiver_pre_balance, receiver_post_balance);
+}
+
+/// Testing a read only transaction where create actor will not take effect
+#[test]
+fn test_readonly_txn_set_integer() {
+    // Instantiate tester
+    let mut tester = new_tester(
+        NetworkVersion::V21,
+        StateTreeVersion::V5,
+        MemoryBlockstore::default(),
+    )
+    .unwrap();
+
+    let sender: [Account; 1] = tester.create_accounts().unwrap();
+    let sender = sender[0];
+
+    // Set actor state
+    let actor_state = State::default();
+    let state_cid = tester.set_state(&actor_state).unwrap();
+
+    let (actor_address, wasm_bin) = (Address::new_id(10000), INTEGER_OVERFLOW_ACTOR_BINARY);
+
+    tester
+        .set_actor_from_bin(wasm_bin, state_cid, actor_address, TokenAmount::zero())
+        .unwrap();
+
+    // Instantiate machine
+    tester.instantiate_machine(DummyExterns).unwrap();
+
+    // X is the target value.
+    let x: i64 = 10000000000;
+
+    {
+        // Params setup
+        let params = RawBytes::serialize(x).unwrap();
+
+        // Send message to set
+        let message = Message {
+            from: sender.1,
+            to: actor_address,
+            gas_limit: 1000000000,
+            method_num: 1,
+            params,
+            ..Message::default()
+        };
+
+        // Set inner state value
+        let res = tester
+            .executor
+            .as_mut()
+            .unwrap()
+            .execute_message(message, ApplyKind::Explicit, 100)
+            .unwrap();
+
+        assert_eq!(
+            ExitCode::OK,
+            res.msg_receipt.exit_code,
+            "{}",
+            res.failure_info.unwrap()
+        );
+
+        // Read inner state value
+        let message = Message {
+            from: sender.1,
+            to: actor_address,
+            gas_limit: 1000000000,
+            method_num: 3,
+            sequence: 1,
+            ..Message::default()
+        };
+
+        let res = tester
+            .executor
+            .as_mut()
+            .unwrap()
+            .execute_message(message, ApplyKind::Explicit, 100)
+            .unwrap();
+        assert!(res.msg_receipt.exit_code.is_success());
+
+        let current_state_value: i64 = res.msg_receipt.return_data.deserialize().unwrap();
+
+        assert_eq!(current_state_value, x);
+    }
+
+    // now we perform the revert test, to see the effects are not applied
+    let y: i64 = 10000000001;
+
+    {
+        // Params setup
+        let params = RawBytes::serialize(y).unwrap();
+
+        // Send message to set
+        let message = Message {
+            from: sender.1,
+            to: actor_address,
+            gas_limit: 1000000000,
+            method_num: 1,
+            params,
+            ..Message::default()
+        };
+
+        // Set inner state value
+        let res = tester
+            .executor
+            .as_mut()
+            .unwrap()
+            .execute_message_with_revert(message, ApplyKind::Explicit, 100, true)
+            .unwrap();
+
+        assert_eq!(
+            ExitCode::OK,
+            res.msg_receipt.exit_code,
+            "{}",
+            res.failure_info.unwrap()
+        );
+
+        // Read inner state value
+        let message = Message {
+            from: sender.1,
+            to: actor_address,
+            gas_limit: 1000000000,
+            method_num: 3,
+            sequence: 1,
+            ..Message::default()
+        };
+
+        let res = tester
+            .executor
+            .as_mut()
+            .unwrap()
+            .execute_message_with_revert(message, ApplyKind::Explicit, 100, true)
+            .unwrap();
+        assert!(res.msg_receipt.exit_code.is_success());
+
+        let current_state_value: i64 = res.msg_receipt.return_data.deserialize().unwrap();
+        assert_eq!(current_state_value, x);
     }
 }
 


### PR DESCRIPTION
This PR adds customisable gas distribution at the end of a transaction.

This is implemented by introducing a gas processing hook with a newly added method: `execute_with_options`. This method takes a closure as the gas processing hook. At the end of the execution, `finish_message` is replaced with `finish_message_with_hook` instead that calls the hook.