### PR TITLE
chore: remove minicov

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,6 @@ dependencies = [
  "fvm_ipld_encoding 0.5.2",
  "fvm_sdk 4.6.0",
  "fvm_shared 4.6.0",
- "minicov",
 ]
 
 [[package]]
@@ -2036,7 +2035,6 @@ dependencies = [
  "fvm_ipld_encoding 0.5.2",
  "fvm_sdk 4.6.0",
  "fvm_shared 4.6.0",
- "minicov",
  "multihash-codetable",
  "multihash-derive",
 ]
@@ -3628,16 +3626,6 @@ dependencies = [
  "serde",
  "tempfile",
  "typenum",
-]
-
-[[package]]
-name = "minicov"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
-dependencies = [
- "cc",
- "walkdir",
 ]
 
 [[package]]

--- a/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
@@ -15,3 +15,6 @@ minicov = "0.3"
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-ipld-actor/Cargo.toml
@@ -10,11 +10,5 @@ fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 
-[target.'cfg(coverage)'.dependencies]
-minicov = "0.3"
-
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/testing/test_actors/actors/fil-ipld-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-ipld-actor/src/actor.rs
@@ -22,8 +22,6 @@ pub fn invoke(_: u32) -> u32 {
     test_stat_block();
     test_link_block();
 
-    #[cfg(coverage)]
-    sdk::debug::store_artifact("ipld_actor.profraw", minicov::capture_coverage());
     0
 }
 

--- a/testing/test_actors/actors/fil-sself-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-sself-actor/Cargo.toml
@@ -13,6 +13,3 @@ cid = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/testing/test_actors/actors/fil-sself-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-sself-actor/Cargo.toml
@@ -13,3 +13,6 @@ cid = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/testing/test_actors/actors/fil-sself-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-sself-actor/src/actor.rs
@@ -56,8 +56,5 @@ pub fn invoke(_: u32) -> u32 {
     // calling destroy on an already destroyed actor should succeed (no-op)
     sdk::sself::self_destruct(false).expect("deleting an already deleted actor should succeed");
 
-    #[cfg(coverage)]
-    sdk::debug::store_artifact("sself_actor.profraw", minicov::capture_coverage());
-
     0
 }

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -11,15 +11,10 @@ fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 multihash-derive = { workspace = true }
 multihash-codetable = { workspace = true, features = ["sha3", "sha2", "ripemd"] }
-minicov = {version = "0.3", optional = true}
 actors_v12_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build
 
 [features]
-coverage = ["minicov"]
 verify-signature = ["fvm_sdk/verify-signature"]
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-syscall-actor/Cargo.toml
@@ -20,3 +20,6 @@ crate-type = ["cdylib"] ## cdylib is necessary for Wasm build
 [features]
 coverage = ["minicov"]
 verify-signature = ["fvm_sdk/verify-signature"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-syscall-actor/src/actor.rs
@@ -43,8 +43,6 @@ pub fn invoke(_: u32) -> u32 {
     test_balance();
     test_unaligned();
 
-    #[cfg(coverage)]
-    sdk::debug::store_artifact("syscall_actor.profraw", minicov::capture_coverage());
     0
 }
 


### PR DESCRIPTION
Follow-up from https://github.com/filecoin-project/ref-fvm/pull/2114, I don't think any of this is used anywhere so we may as well just remove it?