### PR TITLE
chore: use default wasmtime memory_reservation

### DIFF
--- a/fvm/src/engine/mod.rs
+++ b/fvm/src/engine/mod.rs
@@ -168,11 +168,7 @@ fn wasmtime_config(ec: &EngineConfig) -> anyhow::Result<wasmtime::Config> {
     // compiled wasm modules.
     c.memory_init_cow(false);
 
-    // wasmtime default: 4GB
-    // TODO: we should likely revert this to 4GiB for performance reasons. This doesn't affect
-    // actual memory used, just virtual address-space.
-    // https://github.com/filecoin-project/ref-fvm/issues/2128
-    c.memory_reservation(instance_memory_maximum_size);
+    // wasmtime default: true
     c.memory_may_move(false);
 
     // Note: Threads are disabled by default.


### PR DESCRIPTION
Closes: https://github.com/filecoin-project/ref-fvm/issues/2128

Default is 4GiB, the initial size of the virtual address space. The full 32-bit address space means runtime memory bounds checking should be elided.

I think this is all that's needed, but it might be interesting to try and do some basic before & after benchmarking. I can't find an obvious way to do that though, @Stebalien suggestions?