### PR TITLE
feat: downgrade serde_tuple and move it into the encoding crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,7 +1934,6 @@ dependencies = [
  "fvm_shared 4.6.0",
  "num-traits",
  "serde",
- "serde_tuple 1.1.0",
 ]
 
 [[package]]
@@ -1945,7 +1944,6 @@ dependencies = [
  "fvm_sdk 4.6.0",
  "fvm_shared 4.6.0",
  "serde",
- "serde_tuple 1.1.0",
 ]
 
 [[package]]
@@ -1982,7 +1980,6 @@ dependencies = [
  "fvm_shared 4.6.0",
  "log",
  "serde",
- "serde_tuple 1.1.0",
 ]
 
 [[package]]
@@ -2005,7 +2002,6 @@ dependencies = [
  "fvm_shared 4.6.0",
  "multihash-codetable",
  "serde",
- "serde_tuple 1.1.0",
 ]
 
 [[package]]
@@ -2082,7 +2078,6 @@ dependencies = [
  "fvm_sdk 4.6.0",
  "fvm_shared 4.6.0",
  "serde",
- "serde_tuple 1.1.0",
 ]
 
 [[package]]
@@ -2094,7 +2089,6 @@ dependencies = [
  "fvm_sdk 4.6.0",
  "fvm_shared 4.6.0",
  "serde",
- "serde_tuple 1.1.0",
 ]
 
 [[package]]
@@ -2299,7 +2293,7 @@ dependencies = [
  "multihash-codetable",
  "num-traits",
  "serde",
- "serde_tuple 0.5.0",
+ "serde_tuple",
  "thiserror 1.0.69",
 ]
 
@@ -2451,7 +2445,6 @@ dependencies = [
  "rayon",
  "replace_with",
  "serde",
- "serde_tuple 1.1.0",
  "static_assertions",
  "thiserror 2.0.12",
  "wasmtime",
@@ -2501,7 +2494,7 @@ dependencies = [
  "multihash-codetable",
  "num-traits",
  "serde",
- "serde_tuple 0.5.0",
+ "serde_tuple",
  "thiserror 1.0.69",
 ]
 
@@ -2580,7 +2573,6 @@ dependencies = [
  "rand_chacha",
  "serde",
  "serde_json",
- "serde_tuple 1.1.0",
  "thiserror 2.0.12",
  "wasmtime",
  "wat",
@@ -2714,7 +2706,7 @@ dependencies = [
  "serde_ipld_dagcbor",
  "serde_json",
  "serde_repr",
- "serde_tuple 1.1.0",
+ "serde_tuple",
  "thiserror 2.0.12",
 ]
 
@@ -2731,7 +2723,7 @@ dependencies = [
  "serde",
  "serde_ipld_dagcbor",
  "serde_repr",
- "serde_tuple 0.5.0",
+ "serde_tuple",
  "thiserror 1.0.69",
 ]
 
@@ -2874,7 +2866,6 @@ dependencies = [
  "rusty-fork",
  "serde",
  "serde_json",
- "serde_tuple 1.1.0",
  "thiserror 2.0.12",
  "unsigned-varint",
 ]
@@ -2898,7 +2889,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "serde_tuple 0.5.0",
+ "serde_tuple",
  "thiserror 1.0.69",
  "unsigned-varint",
 ]
@@ -4555,17 +4546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f025b91216f15a2a32aa39669329a475733590a015835d1783549a56d09427"
 dependencies = [
  "serde",
- "serde_tuple_macros 0.5.0",
-]
-
-[[package]]
-name = "serde_tuple"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9b739e59a0e07b7a73bc11c3dcd6abf790d0f54042b67a422d4bd1f6cf6c0"
-dependencies = [
- "serde",
- "serde_tuple_macros 1.0.1",
+ "serde_tuple_macros",
 ]
 
 [[package]]
@@ -4573,17 +4554,6 @@ name = "serde_tuple_macros"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4076151d1a2b688e25aaf236997933c66e18b870d0369f8b248b8ab2be630d7e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "serde_tuple_macros"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e87546e85c5047d03b454d12ee25266fc269a461a4029956ca58d246b9aefae"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ anyhow = "1.0.97"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 serde_json = "1.0.140"
-serde_tuple = "1.1.0"
 byteorder = "1.5.0"
 hex = "0.4.3"
 num-traits = { version = "0.2.19", default-features = false }

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -26,7 +26,6 @@ fvm_ipld_encoding = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-environ = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 arbitrary = { workspace = true, optional = true, features = ["derive"] }

--- a/fvm/src/system_actor.rs
+++ b/fvm/src/system_actor.rs
@@ -3,7 +3,7 @@
 use anyhow::Context;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
+use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::CborStore;
 use fvm_shared::ActorID;
 

--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/filecoin-project/ref-fvm"
 
 [dependencies]
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 cid = { workspace = true, features = ["serde", "std"] }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
@@ -17,6 +16,7 @@ fvm_ipld_blockstore = { workspace = true }
 multihash-codetable = { workspace = true, features = ["blake2b"] }
 serde_ipld_dagcbor = "0.6.2"
 serde_repr = "0.1"
+serde_tuple = "0.5.0"
 
 [features]
 default = []

--- a/ipld/encoding/src/lib.rs
+++ b/ipld/encoding/src/lib.rs
@@ -30,14 +30,22 @@ pub const IPLD_RAW: u64 = 0x55;
 
 pub type Multihash = cid::multihash::Multihash<64>;
 
-// TODO: these really don't work all that well in a shared context like this as anyone importing
-// them also need to _explicitly_ import the serde_tuple & serde_repr crates. These are _macros_,
-// not normal items.
-
+/// Re-export of `serde_tuple`. If you import this, you must make sure to import
+/// `tuple::serde_tuple` or the derive macros won't work properly. You should generally import as:
+///
+/// ```rust
+/// use fvm_ipld_encoding::tuple::*
+/// ```
 pub mod tuple {
     pub use serde_tuple::{self, Deserialize_tuple, Serialize_tuple};
 }
 
+/// Re-export of `serde_repr`. If you import this, you must make sure to import `repr::serde_repr`
+/// or the derive macros won't work properly. You should generally import as:
+///
+/// ```rust
+/// use fvm_ipld_encoding::repr::*
+/// ```
 pub mod repr {
     pub use serde_repr::{Deserialize_repr, Serialize_repr};
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -17,7 +17,6 @@ unsigned-varint = { workspace = true }
 anyhow = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 serde = { workspace = true, default-features = false }
-serde_tuple = { workspace = true }
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
 quickcheck = { workspace = true, optional = true }
 

--- a/shared/src/event/mod.rs
+++ b/shared/src/event/mod.rs
@@ -1,9 +1,8 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use bitflags::bitflags;
-use fvm_ipld_encoding::strict_bytes;
+use fvm_ipld_encoding::{strict_bytes, tuple::*};
 use serde::{Deserialize, Serialize};
-use serde_tuple::*;
 
 use crate::ActorID;
 

--- a/shared/src/piece/mod.rs
+++ b/shared/src/piece/mod.rs
@@ -6,8 +6,8 @@
 pub mod zero;
 
 use cid::Cid;
+use fvm_ipld_encoding::tuple::*;
 use serde::{Deserialize, Serialize};
-use serde_tuple::*;
 #[cfg(feature = "proofs")]
 pub use zero::zero_piece_commitment;
 

--- a/shared/src/receipt.rs
+++ b/shared/src/receipt.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
+use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 
 use crate::error::ExitCode;

--- a/shared/src/sector/post.rs
+++ b/shared/src/sector/post.rs
@@ -4,7 +4,6 @@
 
 use cid::Cid;
 use fvm_ipld_encoding::strict_bytes;
-use serde_tuple::*;
 
 use super::*;
 use crate::randomness::Randomness;

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -25,7 +25,6 @@ k256 = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 thiserror = { workspace = true }
 ambassador = { workspace = true }
 wasmtime = { workspace = true, default-features = false, features = ["cranelift", "parallel-compilation"] }

--- a/testing/integration/tests/gaslimit_test.rs
+++ b/testing/integration/tests/gaslimit_test.rs
@@ -6,6 +6,7 @@ use fvm::machine::Machine;
 use fvm_integration_tests::dummy::DummyExterns;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::to_vec;
+use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -14,7 +15,6 @@ use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use fvm_test_actors::wasm_bin::GASLIMIT_ACTOR_BINARY;
 use num_traits::Zero;
-use serde_tuple::*;
 
 mod bundles;
 

--- a/testing/test_actors/actors/fil-custom-syscall/Cargo.toml
+++ b/testing/test_actors/actors/fil-custom-syscall/Cargo.toml
@@ -11,7 +11,6 @@ fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 cid = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 num-traits = { workspace = true }
 
 [lib]

--- a/testing/test_actors/actors/fil-events-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-events-actor/Cargo.toml
@@ -10,7 +10,6 @@ fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-gaslimit-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-gaslimit-actor/Cargo.toml
@@ -10,7 +10,6 @@ fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 log = { workspace = true }
 
 [lib]

--- a/testing/test_actors/actors/fil-gaslimit-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-gaslimit-actor/src/actor.rs
@@ -1,13 +1,12 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use fvm_ipld_encoding::IPLD_RAW;
+use fvm_ipld_encoding::{tuple::*, IPLD_RAW};
 use fvm_sdk as sdk;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::event::{Entry, Flags};
-use serde_tuple::*;
 
 #[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
 struct Params {

--- a/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-integer-overflow-actor/Cargo.toml
@@ -14,7 +14,6 @@ fvm_ipld_blockstore = { workspace = true }
 anyhow = { workspace = true }
 cid = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 multihash-codetable = { workspace = true }
 
 [lib]

--- a/testing/test_actors/actors/fil-upgrade-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-upgrade-actor/Cargo.toml
@@ -11,7 +11,6 @@ fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 cid = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-upgrade-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-upgrade-actor/src/actor.rs
@@ -1,13 +1,13 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::{to_vec, CBOR};
+use fvm_ipld_encoding::{to_vec, tuple::*, CBOR};
 use fvm_sdk as sdk;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ErrorNumber;
 use fvm_shared::upgrade::UpgradeInfo;
-use serde_tuple::*;
+
 #[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
 struct SomeStruct {
     value: u64,

--- a/testing/test_actors/actors/fil-upgrade-receive-actor/Cargo.toml
+++ b/testing/test_actors/actors/fil-upgrade-receive-actor/Cargo.toml
@@ -11,7 +11,6 @@ fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 cid = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/fil-upgrade-receive-actor/src/actor.rs
+++ b/testing/test_actors/actors/fil-upgrade-receive-actor/src/actor.rs
@@ -1,12 +1,11 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::{to_vec, CBOR};
+use fvm_ipld_encoding::{to_vec, tuple::*, CBOR};
 use fvm_sdk as sdk;
 use fvm_shared::address::Address;
 use fvm_shared::error::ExitCode;
 use fvm_shared::upgrade::UpgradeInfo;
-use serde_tuple::*;
 
 #[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
 struct SomeStruct {


### PR DESCRIPTION
We publically re-export this crate so upgrading it is a breaking change. Which is... annoying! But this latest version literally adds nothing so I've:

1. Moved the `serde_tuple` dependency into `fvm_ipld_encoding`.
2. Used the re-exports everywhere.

For context, releasing breaking changes for the `fvm_ipld_encoding` crate is not fun (it's used everywhere).