### PR TITLE
Remove async from `fvm_ipld_car`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,7 +2554,6 @@ dependencies = [
  "cid",
  "criterion",
  "fil_builtin_actors_bundle",
- "futures",
  "fvm",
  "fvm_gas_calibration_shared",
  "fvm_ipld_blockstore 0.3.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,9 +2682,7 @@ dependencies = [
 name = "fvm_ipld_car"
 version = "0.8.2"
 dependencies = [
- "async-std",
  "cid",
- "futures",
  "fvm_ipld_blockstore 0.3.1",
  "fvm_ipld_encoding 0.5.3",
  "multihash-codetable",

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -13,10 +13,6 @@ multihash-codetable = { workspace = true }
 multihash-derive = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-unsigned-varint = { workspace = true, features = ["futures"] }
+unsigned-varint = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
-futures = { workspace = true }
-
-[dev-dependencies]
-async-std = { version = "1.13", features = ["attributes"] }

--- a/ipld/car/src/block.rs
+++ b/ipld/car/src/block.rs
@@ -1,0 +1,50 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use cid::Cid;
+use multihash_codetable::{Code, MultihashDigest};
+
+use super::Error;
+
+/// IPLD Block
+#[derive(Clone, Debug)]
+pub struct Block {
+    pub cid: Cid,
+    pub data: Vec<u8>,
+}
+
+impl From<Block> for (Cid, Vec<u8>) {
+    fn from(block: Block) -> Self {
+        (block.cid, block.data)
+    }
+}
+
+impl From<(Cid, Vec<u8>)> for Block {
+    fn from((cid, data): (Cid, Vec<u8>)) -> Self {
+        Block { cid, data }
+    }
+}
+
+impl Block {
+    pub(crate) fn validate(&self) -> Result<(), Error> {
+        match self.cid.hash().code() {
+            0x0 => {
+                if self.cid.hash().digest() != self.data {
+                    return Err(Error::InvalidFile(
+                        "CAR has an identity CID that doesn't match the corresponding data".into(),
+                    ));
+                }
+            }
+            code => {
+                let code = Code::try_from(code)?;
+                let actual = Cid::new_v1(self.cid.codec(), code.digest(&self.data));
+                if actual != self.cid {
+                    return Err(Error::InvalidFile(format!(
+                        "CAR has an incorrect CID: expected {}, found {}",
+                        self.cid, actual,
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/ipld/car/src/util.rs
+++ b/ipld/car/src/util.rs
@@ -2,18 +2,17 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::io::{self, Read};
+
 use cid::Cid;
-use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use unsigned_varint::io::ReadError;
 
-use super::error::Error;
+use super::Block;
+use super::Error;
 
-pub(crate) async fn ld_read<R>(mut reader: &mut R) -> Result<Option<Vec<u8>>, Error>
-where
-    R: AsyncRead + Send + Unpin,
-{
+pub(crate) fn ld_read(reader: &mut impl io::Read) -> Result<Option<Vec<u8>>, Error> {
     const MAX_ALLOC: usize = 1 << 20;
-    let l: usize = match unsigned_varint::aio::read_usize(&mut reader).await {
+    let l: usize = match unsigned_varint::io::read_usize(&mut *reader) {
         Ok(len) => len,
         Err(ReadError::Io(e)) => {
             return if e.kind() == std::io::ErrorKind::UnexpectedEof {
@@ -29,7 +28,6 @@ where
     let bytes_read = reader
         .take(l as u64)
         .read_to_end(&mut buf)
-        .await
         .map_err(|e| Error::Other(e.to_string()))?;
     if bytes_read != l {
         return Err(Error::Io(std::io::Error::new(
@@ -43,27 +41,23 @@ where
     Ok(Some(buf))
 }
 
-pub(crate) async fn ld_write<W>(writer: &mut W, bytes: &[u8]) -> Result<(), Error>
-where
-    W: AsyncWrite + Send + Unpin,
-{
+pub(crate) fn ld_write(writer: &mut impl io::Write, bytes: &[u8]) -> Result<(), Error> {
     let mut buff = unsigned_varint::encode::usize_buffer();
     let len = unsigned_varint::encode::usize(bytes.len(), &mut buff);
-    writer.write_all(len).await?;
-    writer.write_all(bytes).await?;
-    writer.flush().await?;
+    writer.write_all(len)?;
+    writer.write_all(bytes)?;
     Ok(())
 }
 
-pub(crate) async fn read_node<R>(buf_reader: &mut R) -> Result<Option<(Cid, Vec<u8>)>, Error>
-where
-    R: AsyncRead + Send + Unpin,
-{
-    match ld_read(buf_reader).await? {
+pub(crate) fn read_node(buf_reader: &mut impl io::Read) -> Result<Option<Block>, Error> {
+    match ld_read(buf_reader)? {
         Some(buf) => {
             let mut cursor = std::io::Cursor::new(&buf);
             let cid = Cid::read_bytes(&mut cursor)?;
-            Ok(Some((cid, buf[cursor.position() as usize..].to_vec())))
+            Ok(Some(Block {
+                cid,
+                data: buf[cursor.position() as usize..].to_vec(),
+            }))
         }
         None => Ok(None),
     }
@@ -71,16 +65,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use async_std::io::Cursor;
-
     use super::*;
 
-    #[async_std::test]
-    async fn ld_read_write() {
+    #[test]
+    fn ld_read_write() {
         let mut buffer = Vec::<u8>::new();
-        ld_write(&mut buffer, b"test bytes").await.unwrap();
-        let mut reader = Cursor::new(&buffer);
-        let read = ld_read(&mut reader).await.unwrap();
+        ld_write(&mut buffer, b"test bytes").unwrap();
+        let mut reader = std::io::Cursor::new(buffer);
+        let read = ld_read(&mut reader).unwrap();
         assert_eq!(read, Some(b"test bytes".to_vec()));
     }
 }

--- a/ipld/car/tests/car_file_test.rs
+++ b/ipld/car/tests/car_file_test.rs
@@ -2,31 +2,32 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use async_std::fs::File;
-use async_std::io::BufReader;
+use std::fs::File;
+use std::io::BufReader;
+
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_car::{load_car, CarReader};
 
-#[async_std::test]
-async fn load_into_blockstore() {
-    let file = File::open("tests/test.car").await.unwrap();
+#[test]
+fn load_into_blockstore() {
+    let file = File::open("tests/test.car").unwrap();
     let buf_reader = BufReader::new(file);
     let bs = MemoryBlockstore::default();
 
-    let _ = load_car(&bs, buf_reader).await.unwrap();
+    let _ = load_car(&bs, buf_reader).unwrap();
 }
 
-#[async_std::test]
-async fn load_car_reader_into_blockstore() {
-    let file = File::open("tests/test.car").await.unwrap();
-    let car_reader = CarReader::new(file).await.unwrap();
+#[test]
+fn load_car_reader_into_blockstore() {
+    let file = File::open("tests/test.car").unwrap();
+    let car_reader = CarReader::new(file).unwrap();
     let bs = MemoryBlockstore::default();
 
     // perform some action with the reader
     let roots = car_reader.header.roots.clone();
 
     // load it into the blockstore
-    let res = car_reader.read_into(&bs).await.unwrap();
+    let res = car_reader.read_into(&bs).unwrap();
 
     assert_eq!(res, roots);
 }

--- a/testing/conformance/src/actors.rs
+++ b/testing/conformance/src/actors.rs
@@ -3,7 +3,6 @@
 use std::io::Read;
 use std::sync::Mutex;
 
-use futures::executor::block_on;
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_car::load_car;
 use lazy_static::lazy_static;
@@ -24,7 +23,7 @@ fn load_bundles(bundles: &[&[u8]]) -> anyhow::Result<MemoryBlockstore> {
             // We need to read it to a vec first as we can't send it between threads (async issues).
             let mut car = Vec::new();
             entry?.read_to_end(&mut car)?;
-            block_on(load_car(&bs, &*car))?;
+            load_car(&bs, &*car)?;
         }
     }
     Ok(bs)

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -17,7 +17,6 @@ fvm_sdk = { workspace = true }
 
 anyhow = { workspace = true }
 cid = { workspace = true }
-futures = { workspace = true }
 multihash-codetable = { workspace = true, features = ["blake2b"] }
 num-traits = { workspace = true }
 lazy_static = { workspace = true }

--- a/testing/integration/src/bundle.rs
+++ b/testing/integration/src/bundle.rs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::anyhow;
 use cid::Cid;
-use futures::executor::block_on;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_car::load_car_unchecked;
 
 // Import built-in actors
 pub fn import_bundle(blockstore: &impl Blockstore, bundle: &[u8]) -> anyhow::Result<Cid> {
-    match &*block_on(async { load_car_unchecked(blockstore, bundle).await })? {
+    match &*load_car_unchecked(blockstore, bundle)? {
         [root] => Ok(*root),
         _ => Err(anyhow!("multiple root CIDs in bundle")),
     }


### PR DESCRIPTION
This isn't highly parallel networking code so making it async isn't worth the added complexity. The logic in this library isn't _that_ complex, but the async logic in the conformance test engine definitely is and I want to remove all async code from that library next.

TL;DR: slowly remove an unmaintained dependency (`async-std`) and make everything a little more maintainable at the same time.

Part one of #2144