### PR TITLE
chore: release fvm_ipld_car v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,7 +2514,7 @@ dependencies = [
  "futures",
  "fvm",
  "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_car 0.8.2",
+ "fvm_ipld_car 0.9.0",
  "fvm_ipld_encoding 0.5.3",
  "fvm_shared 4.7.0",
  "ipld-core",
@@ -2557,7 +2557,7 @@ dependencies = [
  "fvm",
  "fvm_gas_calibration_shared",
  "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_car 0.8.2",
+ "fvm_ipld_car 0.9.0",
  "fvm_ipld_encoding 0.5.3",
  "fvm_sdk 4.7.0",
  "fvm_shared 4.7.0",
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_car"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "cid",
  "fvm_ipld_blockstore 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ fvm_integration_tests = { path = "testing/integration", version = "~4.7.0" }
 fvm_ipld_amt = { path = "ipld/amt", version = "0.7.4" }
 fvm_ipld_hamt = { path = "ipld/hamt", version = "0.10.4" }
 fvm_ipld_kamt = { path = "ipld/kamt", version = "0.4.5" }
-fvm_ipld_car = { path = "ipld/car", version = "0.8.2" }
+fvm_ipld_car = { path = "ipld/car", version = "0.9.0" }
 fvm_ipld_blockstore = { path = "ipld/blockstore", version = "0.3.1" }
 fvm_ipld_bitfield = { path = "ipld/bitfield", version = "0.7.2" }
 fvm_ipld_encoding = { path = "ipld/encoding", version = "0.5.3" }

--- a/ipld/car/CHANGELOG.md
+++ b/ipld/car/CHANGELOG.md
@@ -4,6 +4,13 @@ Changes to the FVM's CAR implementation.
 
 ## [Unreleased]
 
+## 0.9.0 [2025-04-11]
+
+- Remove async support, it's overkill for our use-case and leaks complexity.
+- Improve the interfaces:
+  - There's now a separate `CarWriter` struct with methods for writing individual blocks. There's no longer a separate "write from stream" method as feeding an iterator into the writer should be simple enough (now that there's no longer any async stream complexity).
+  - `CarReader` now implements the iterator interface instead of an async `next_block` function.
+
 ## 0.8.2 [2025-04-09]
 
 - Updates multiple dependencies (semver breaking internally but not exported).

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_car"
 description = "IPLD CAR handling library"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Removes async support and simplifies interfaces.