### PR TITLE
chore: update fvm_ipld_car in v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,12 +1806,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_car"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4c2b7846233244459bb0370a6b5b58848c18e29505d262575ffa15324f176e"
+checksum = "e3f49d53950e37e2b310a6527135f4b9b09c2fb8c25f1846622131f9db965be0"
 dependencies = [
  "cid",
- "futures",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "multihash-codetable",
@@ -3899,10 +3898,6 @@ name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
-dependencies = [
- "futures-io",
- "futures-util",
-]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ fvm_sdk = { path = "sdk", version = "~3.13.0" }
 
 fvm_ipld_hamt = { version = "0.10.4"}
 fvm_ipld_amt = { version = "0.7.4"}
-fvm_ipld_car = { version = "0.8.2" }
+fvm_ipld_car = { version = "0.9.0" }
 fvm_ipld_blockstore = { version = "0.3.1" }
 fvm_ipld_encoding = { version = "0.5.3" }
 

--- a/testing/conformance/src/actors.rs
+++ b/testing/conformance/src/actors.rs
@@ -3,7 +3,6 @@
 use std::io::Read;
 use std::sync::Mutex;
 
-use futures::executor::block_on;
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_car::load_car;
 use lazy_static::lazy_static;
@@ -24,7 +23,7 @@ fn load_bundles(bundles: &[&[u8]]) -> anyhow::Result<MemoryBlockstore> {
             // We need to read it to a vec first as we can't send it between threads (async issues).
             let mut car = Vec::new();
             entry?.read_to_end(&mut car)?;
-            block_on(load_car(&bs, &*car))?;
+            load_car(&bs, &*car)?;
         }
     }
     Ok(bs)

--- a/testing/conformance/src/vector.rs
+++ b/testing/conformance/src/vector.rs
@@ -2,23 +2,19 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::BufReader;
-use std::path::Path;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-
 use anyhow::{anyhow, Context as _};
 use cid::Cid;
 use flate2::bufread::GzDecoder;
-use futures::AsyncRead;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_car::load_car;
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::receipt::Receipt;
 use serde::{Deserialize, Deserializer};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
 
 use crate::actors::load_actors;
 
@@ -189,21 +185,9 @@ impl MessageVector {
         load_actors(&blockstore)?;
 
         let bytes = self.car.as_slice();
-        let decoder = GzipDecoder(GzDecoder::new(bytes));
-        let cid = load_car(&blockstore, decoder).await?;
+        let decoder = GzDecoder::new(bytes);
+        let cid = load_car(&blockstore, decoder)?;
         Ok((blockstore, cid))
-    }
-}
-
-struct GzipDecoder<R>(GzDecoder<R>);
-
-impl<R: std::io::Read + Unpin + std::io::BufRead> AsyncRead for GzipDecoder<R> {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<Result<usize, std::io::Error>> {
-        Poll::Ready(std::io::Read::read(&mut self.0, buf))
     }
 }
 


### PR DESCRIPTION
This removes the async dependency (from the car logic). I'll update the
conformance tests in the next patch.