### PR TITLE
fix: correctly deserialize test vectors

### DIFF
--- a/testing/conformance/src/vector.rs
+++ b/testing/conformance/src/vector.rs
@@ -42,6 +42,7 @@ pub struct MetaData {
     pub description: String,
     #[serde(default)]
     pub comment: String,
+    #[serde(rename = "gen")]
     pub generation: Vec<GenerationData>,
 }
 


### PR DESCRIPTION
I renamed the field when switching to rust 2024 but this broke deserializing test vectors (which we only use in v3/v2).