### PR TITLE
chore: release v4.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
  "cid",
  "fvm_ipld_bitfield 0.7.2",
  "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.1",
+ "fvm_shared 4.7.2",
  "libfuzzer-sys",
  "rand",
  "serde",
@@ -1883,8 +1883,8 @@ name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
 ]
 
 [[package]]
@@ -1920,8 +1920,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
 ]
 
 [[package]]
@@ -1930,8 +1930,8 @@ version = "0.1.0"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
  "num-traits",
  "serde",
 ]
@@ -1941,8 +1941,8 @@ name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
  "serde",
 ]
 
@@ -1951,8 +1951,8 @@ name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
 ]
 
 [[package]]
@@ -1963,8 +1963,8 @@ dependencies = [
  "cid",
  "fvm_gas_calibration_shared",
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
  "ipld-core",
  "num-derive",
  "num-traits",
@@ -1976,8 +1976,8 @@ name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
  "log",
  "serde",
 ]
@@ -1986,8 +1986,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
 ]
 
 [[package]]
@@ -1998,8 +1998,8 @@ dependencies = [
  "cid",
  "fvm_ipld_blockstore 0.3.1",
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
  "multihash-codetable",
  "serde",
 ]
@@ -2009,24 +2009,24 @@ name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
 ]
 
 [[package]]
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
 ]
 
 [[package]]
@@ -2035,8 +2035,8 @@ version = "0.1.0"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
 ]
 
 [[package]]
@@ -2045,16 +2045,16 @@ version = "0.1.0"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
 ]
 
 [[package]]
@@ -2063,8 +2063,8 @@ version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
  "multihash-codetable",
  "multihash-derive",
 ]
@@ -2075,8 +2075,8 @@ version = "0.1.0"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
  "serde",
 ]
 
@@ -2086,8 +2086,8 @@ version = "0.1.0"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
  "serde",
 ]
 
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.7.1"
+version = "4.7.2"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2432,7 +2432,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.3.1",
  "fvm_ipld_encoding 0.5.3",
  "fvm_ipld_hamt 0.10.4",
- "fvm_shared 4.7.1",
+ "fvm_shared 4.7.2",
  "lazy_static",
  "log",
  "minstant",
@@ -2462,7 +2462,7 @@ dependencies = [
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.1",
+ "fvm_shared 4.7.2",
  "hex",
 ]
 
@@ -2516,7 +2516,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.3.1",
  "fvm_ipld_car 0.9.0",
  "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.1",
+ "fvm_shared 4.7.2",
  "ipld-core",
  "itertools 0.14.0",
  "ittapi-rs",
@@ -2536,7 +2536,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.7.1",
+ "fvm_shared 4.7.2",
  "num-derive",
  "num-traits",
  "serde",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.7.1"
+version = "4.7.2"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2559,8 +2559,8 @@ dependencies = [
  "fvm_ipld_blockstore 0.3.1",
  "fvm_ipld_car 0.9.0",
  "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.1",
- "fvm_shared 4.7.1",
+ "fvm_sdk 4.7.2",
+ "fvm_shared 4.7.2",
  "fvm_test_actors",
  "hex",
  "k256",
@@ -2823,11 +2823,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.7.1"
+version = "4.7.2"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.1",
+ "fvm_shared 4.7.2",
  "lazy_static",
  "log",
  "num-traits",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.7.1"
+version = "4.7.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2873,7 +2873,7 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.1",
+ "fvm_shared 4.7.2",
  "hex",
  "k256",
  "multihash-codetable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.7.1"
+version = "4.7.2"
 license = "MIT OR Apache-2.0"
 edition = "2024"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -72,10 +72,10 @@ minstant = "0.1.7"
 coverage-helper = "0.2.4"
 
 # workspace (FVM)
-fvm = { path = "fvm", version = "~4.7.0", default-features = false }
-fvm_shared = { path = "shared", version = "~4.7.0", default-features = false }
-fvm_sdk = { path = "sdk", version = "~4.7.0" }
-fvm_integration_tests = { path = "testing/integration", version = "~4.7.0" }
+fvm = { path = "fvm", version = "~4.7.2", default-features = false }
+fvm_shared = { path = "shared", version = "~4.7.2", default-features = false }
+fvm_sdk = { path = "sdk", version = "~4.7.2" }
+fvm_integration_tests = { path = "testing/integration", version = "~4.7.2" }
 
 # workspace (other)
 fvm_ipld_amt = { path = "ipld/amt", version = "0.7.4" }

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,14 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.7.2 [2025-05-01]
+
+- feat: add nv27-skeleton [#2175](https://github.com/filecoin-project/ref-fvm/pull/2175)
+- chore: use workspace fields for license & repository url [#2172](https://github.com/filecoin-project/ref-fvm/pull/2172)
+- Update to 2024 edition everywhere else [#2170](https://github.com/filecoin-project/ref-fvm/pull/2170)
+- fix: correctly deserialize test vectors [#2168](https://github.com/filecoin-project/ref-fvm/pull/2168)
+- Switch to rust 2024 edition [#2162](https://github.com/filecoin-project/ref-fvm/pull/2162)
+
 ## 4.7.1 [2025-04-15]
 
 - Upgrade to fvm_shared@v4.7.1 to fix: accept malleable secp256k1 signatures (per EVM, etc.) [#2156](https://github.com/filecoin-project/ref-fvm/pull/2156)

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## 4.7.2 [2025-05-01]
+
+- feat: add nv27-skeleton [#2175](https://github.com/filecoin-project/ref-fvm/pull/2175)
+- chore: use workspace fields for license & repository url [#2172](https://github.com/filecoin-project/ref-fvm/pull/2172)
+- Update to 2024 edition everywhere else [#2170](https://github.com/filecoin-project/ref-fvm/pull/2170)
+- fix: correctly deserialize test vectors [#2168](https://github.com/filecoin-project/ref-fvm/pull/2168)
+- Switch to rust 2024 edition [#2162](https://github.com/filecoin-project/ref-fvm/pull/2162)
+
 ## 4.7.1 [2025-04-15]
 
 - Upgrade to fvm_shared@v4.7.1 to fix: accept malleable secp256k1 signatures (per EVM, etc.) [#2156](https://github.com/filecoin-project/ref-fvm/pull/2156)

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## 4.7.2 [2025-05-01]
+
+- feat: add nv27-skeleton [#2175](https://github.com/filecoin-project/ref-fvm/pull/2175)
+- chore: use workspace fields for license & repository url [#2172](https://github.com/filecoin-project/ref-fvm/pull/2172)
+- Update to 2024 edition everywhere else [#2170](https://github.com/filecoin-project/ref-fvm/pull/2170)
+- fix: correctly deserialize test vectors [#2168](https://github.com/filecoin-project/ref-fvm/pull/2168)
+- Switch to rust 2024 edition [#2162](https://github.com/filecoin-project/ref-fvm/pull/2162)
+
 ## 4.7.1 [2025-04-15]
 
 This is an important bugfix release as v4.7.0 won't perform correct signature validation in some cases.


### PR DESCRIPTION
Cut a ref-fvm release so that we can continue on the network version 27 skeleton in: https://github.com/filecoin-project/filecoin-ffi/pull/531