### PR TITLE
Refactor AMT to use iter_mut Instead of for_each_mut 

### DIFF
--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -111,7 +111,7 @@ use fvm_ipld_encoding::ser::Serialize;
 use fvm_ipld_encoding::serde::Deserialize;
 use itertools::sorted;
 use multihash_codetable::Code;
-use std::cell::{RefMut, RefCell};
+use std::cell::{Ref, RefCell, RefMut};
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 
@@ -143,8 +143,10 @@ impl<T> Amtptr<T> {
         self.changed = true;
         self.value.borrow_mut()
     }
-
-    pub fn delete(){}
+    
+    pub fn delete(&self) -> Ref<'_, T> {
+        self.value.borrow()
+    }
 }
 
 impl<T> Deref for Amtptr<T> {

--- a/ipld/amt/src/value_mut.rs
+++ b/ipld/amt/src/value_mut.rs
@@ -32,6 +32,7 @@ impl<V> Deref for ValueMut<'_, V> {
     }
 }
 
+
 impl<V> DerefMut for ValueMut<'_, V> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.value_mutated = true;

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -2,7 +2,7 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_amt::{Amt, Amtv0, Error, ValueMut, MAX_INDEX};
+use fvm_ipld_amt::{Amt, Amtv0, Error, MAX_INDEX, ValueMut};
 use fvm_ipld_blockstore::tracking::{BSStats, TrackingBlockstore};
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::BytesDe;
@@ -613,7 +613,7 @@ fn iter_mutable() {
 
         Ok(())
     };
-    for ptr in new_amt.iter_mut2() {
+    for ptr in new_amt.iter_mut() {
         let current_idx = ptr.0;
         let mut val = ptr.1;
         let mut val_ref = val.get_mut();

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -617,8 +617,7 @@ fn iter_mutable() {
         let current_idx = ptr.0;
         let mut val = ptr.1;
         let mut val_ref = val.get_mut();
-        let mut vale = ValueMut::new(&mut *val_ref);
-        f(current_idx, &mut vale).unwrap();
+        f(current_idx, &mut ValueMut::new(&mut *val_ref)).unwrap();
     }
 
     assert_eq!(


### PR DESCRIPTION
This PR refactors the AMT mplementation by replacing internal iteration via `for_each_mut` with external iteration using `iter_mut` and adds a test case showing the use case of the `iter_mut` function . 

**Motivation:**

Solves #1996 

**Progress:**

- [x] The iter_mut function yields a Smart pointer `Amtptr`.
- [x] `Amtptr` can be dereferenced immutably.
- [x] Can be dereferenced mutably.
- [ ] Can be deleted to yield the inner value. 



> [!NOTE]
>  Instead of using the `deref_mut` ,  the `get_mut` function can be used instead as written in the test case and as shown 
> below 


```rust

    for ptr in new_amt.iter_mut() {
        let current_idx = ptr.0;
        let mut val = ptr.1;
        let mut val_ref = val.get_mut();
        f(current_idx, &mut ValueMut::new(&mut *val_ref)).unwrap();
    }
``` 


