### PR TITLE
chore: suppress RUSTSEC-2025-0046

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,7 @@
 [advisories]
 ignore = [
   "RUSTSEC-2024-0436", # Paste is unmaintained, whatever.
-  "RUSTSEC-2025-0046", # wasmtime, tracked in https://github.com/filecoin-project/ref-fvm/issues/2186
+  "RUSTSEC-2025-0046", # wasmtime, only impacting WASI, tracked in https://github.com/filecoin-project/ref-fvm/issues/2186
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,7 @@
 [advisories]
 ignore = [
   "RUSTSEC-2024-0436", # Paste is unmaintained, whatever.
+  "RUSTSEC-2025-0046", # wasmtime, tracked in https://github.com/filecoin-project/ref-fvm/issues/2186
 ]
 
 [bans]


### PR DESCRIPTION
This suppresses https://rustsec.org/advisories/RUSTSEC-2025-0046.html. See https://github.com/filecoin-project/ref-fvm/issues/2186 for full context. Without this, unrelated PRs will fail.