### PR TITLE
feat(ci): deny cargo doc warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        name: [build, check-m2-native, check-clippy, check-clippy-verify-signature, test-fvm, test, integration, conformance, calibration, doctest]
+        name: [build, check-m2-native, check-clippy, check-clippy-verify-signature, test-fvm, test, integration, conformance, calibration, doctest, doc]
         include:
           - name: build
             key: v3
@@ -84,6 +84,10 @@ jobs:
             # we disable default features because Rust will otherwise unify them and turn on opencl in CI.
             # we also disable test packages, given they are unlikely to contain any doctests and would double the compilation duration
             args: --all --no-default-features --exclude fvm_conformance_tests --exclude fvm_integration_tests --exclude "*actor" --doc
+          - name: doc
+            key: v3
+            command: doc
+            args: --all --no-default-features --exclude fvm_conformance_tests --exclude fvm_integration_tests --exclude "*actor"
         exclude:
           - os: macos-latest
             name: check-m2-native
@@ -99,9 +103,12 @@ jobs:
             name: calibration
           - os: macos-latest
             name: doctest
+          - os: macos-latest
+            name: doc
     env:
       CARGO_INCREMENTAL: 0
       CARGO_TERM_COLOR: always
+      RUSTDOCFLAGS: "-Dwarnings"
     name: ${{matrix.os}} - ${{ matrix.name }}
     steps:
     - name: Checking out fvm

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 all: build
-.PHONY: all
 
 build:
 	cargo build
-.PHONY: build
 
 clean:
 	cargo clean
@@ -18,3 +16,8 @@ license:
 doctest:
         # We disable test packages, given they are unlikely to contain any doctests and would double the compilation duration.
 	cargo test --all --exclude fvm_conformance_tests --exclude fvm_integration_tests --exclude "*actor" --doc
+
+doc:
+	RUSTDOCFLAGS="-D warnings" cargo doc --all --no-default-features --exclude fvm_conformance_tests --exclude fvm_integration_tests --exclude "*actor"
+
+.PHONY: all build clean lint license doctest doc

--- a/fvm/src/account_actor.rs
+++ b/fvm/src/account_actor.rs
@@ -6,7 +6,7 @@
 //! ## Future direction
 //!
 //! This coupling between the FVM and a concrete actor must eventually be
-//! eliminated. Refer to https://github.com/filecoin-project/fvm/issues/229 for
+//! eliminated. Refer to <https://github.com/filecoin-project/fvm/issues/229> for
 //! details.
 
 use fvm_ipld_encoding::tuple::*;

--- a/fvm/src/gas/timer.rs
+++ b/fvm/src/gas/timer.rs
@@ -65,7 +65,7 @@ struct GasTimerInner {
 impl GasTimer {
     /// Convenience method to start measuring time before the charge is made.
     ///
-    /// Use the return value with [GasTimer::finish_with] to override the internal
+    /// Use the return value with [GasTimer::stop_with] to override the internal
     /// instant that the timer was started with.
     pub fn start() -> GasInstant {
         GasInstant::now()

--- a/fvm/src/syscalls/error.rs
+++ b/fvm/src/syscalls/error.rs
@@ -22,7 +22,7 @@ pub enum Abort {
     OutOfGas,
     /// The system failed with a fatal error indicating a bug in the FVM. This will abort the entire
     /// top-level message and record a
-    /// [`SYS_ASSERTION_FAILED`][fvm_shared::ExitCode::SYS_ASSERTION_FAILED] exit code on-chain.
+    /// [`SYS_ASSERTION_FAILED`][fvm_shared::error::ExitCode::SYS_ASSERTION_FAILED] exit code on-chain.
     #[error("fatal error: {0}")]
     Fatal(anyhow::Error),
 }

--- a/ipld/amt/src/lib.rs
+++ b/ipld/amt/src/lib.rs
@@ -5,7 +5,7 @@
 //! AMT crate for use as rust IPLD data structure
 //!
 //! Data structure reference:
-//! https://github.com/ipld/specs/blob/51fab05b4fe4930d3d851d50cc1e5f1a02092deb/data-structures/vector.md
+//! <https://github.com/ipld/specs/blob/51fab05b4fe4930d3d851d50cc1e5f1a02092deb/data-structures/vector.md>
 
 mod amt;
 mod diff;

--- a/ipld/bitfield/src/rleplus/mod.rs
+++ b/ipld/bitfield/src/rleplus/mod.rs
@@ -4,7 +4,7 @@
 
 //! # RLE+ Bitset Encoding
 //!
-//! (from https://github.com/filecoin-project/specs/blob/master/src/listings/data_structures.md)
+//! (from <https://github.com/filecoin-project/specs/blob/master/src/listings/data_structures.md>)
 //!
 //! RLE+ is a lossless compression format based on [RLE](https://en.wikipedia.org/wiki/Run-length_encoding).
 //! Its primary goal is to reduce the size in the case of many individual bits, where RLE breaks down quickly,

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -57,7 +57,7 @@ pub fn gas_premium() -> TokenAmount {
     MESSAGE_CONTEXT.gas_premium.into()
 }
 
-/// Returns the message parameters as an Option<IpldBlock>.
+/// Returns the message parameters as an [`Option<IpldBlock>`].
 pub fn params_raw(id: BlockId) -> SyscallResult<Option<IpldBlock>> {
     if id == NO_DATA_BLOCK_ID {
         return Ok(None);

--- a/sdk/src/sys/actor.rs
+++ b/sdk/src/sys/actor.rs
@@ -98,7 +98,7 @@ super::fvm_syscalls! {
     ///
     /// # Arguments
     ///
-    /// - `typ` specifies the builtin-actor [`Type`] to lookup.
+    /// - `typ` specifies the builtin-actor to lookup.
     /// - `obuf_off` and `obuf_len` specify the location and length of a byte buffer into which the
     ///   FVM will write the s code CID.
     ///

--- a/sdk/src/sys/mod.rs
+++ b/sdk/src/sys/mod.rs
@@ -20,7 +20,7 @@
 //!
 //! ## Kind 1: Divergent
 //!
-//! Syscalls that return `!` (e.g. [`vm::abort`]) have the signature:
+//! Syscalls that return `!` (e.g. [`crate::vm::abort`]) have the signature:
 //!
 //! ```wat
 //! (func $name (param ...) ... (result i32))

--- a/shared/src/sys/out.rs
+++ b/shared/src/sys/out.rs
@@ -7,7 +7,7 @@
 //! plagued with issues and catch-22 problems, making it unfeasible to use
 //! actual bare multi-value returns in FFI extern definitions.
 //!
-//! Read more at https://github.com/rust-lang/rust/issues/73755.
+//! Read more at <https://github.com/rust-lang/rust/issues/73755>.
 
 // NOTE: When possible, pack fields such that loads will be power-of-two aligned. Un-aligned loads
 // _can_ be done (LLVM will generate the appropriate code) but are slower.


### PR DESCRIPTION
- added `cargo doc` checks to the CI with fail on warnings,
- fixed warnings.

Closes https://github.com/filecoin-project/ref-fvm/issues/2191