### PR TITLE
chore(dependabot): add wasmtime-environ to the allow list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "weekly"
     allow:
       - dependency-name: "wasmtime"
+      - dependency-name: "wasmtime-environ"


### PR DESCRIPTION
I think this might be why dependabot still isn't picking up the change of wasmtime even though dependabot now knows about workspaces in the way we use them