### PR TITLE
chore: add `fil_builtin_actors_bundle` to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,6 @@ updates:
       - dependency-name: "serde_ipld_dagcbor"
       - dependency-name: "serde_repr"
       - dependency-name: "serde_tuple"
+
+      # Testing utilities
+      - dependency-name: "fil_builtin_actors_bundle"


### PR DESCRIPTION
See https://github.com/filecoin-project/ref-fvm/pull/2212#issuecomment-3230997499

This might work or not, given it's a git dependency. Let's try!

