### PR TITLE
Revert "chore: add `fil_builtin_actors_bundle` to dependabot (#2213)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,3 @@ updates:
       - dependency-name: "serde_ipld_dagcbor"
       - dependency-name: "serde_repr"
       - dependency-name: "serde_tuple"
-
-      # Testing utilities
-      - dependency-name: "fil_builtin_actors_bundle"


### PR DESCRIPTION
This reverts commit d42b9d30af5dbc60f5aba91081afa2784feb0abc.

Unfortunately, [it doesn't seem Dependabot can deal with git dependencies](https://github.com/filecoin-project/ref-fvm/actions/runs/17293379473/job/49085726259):
```

updater | 2025/08/28 10:41:34 INFO <job_1085959453> Checking if fil_builtin_actors_bundle b7a35b4368377f090465553d0d6fe651fefb771b needs updating
updater | 2025/08/28 10:41:34 INFO <job_1085959453> Latest version is 
updater | 2025/08/28 10:41:34 INFO <job_1085959453> Requirements to unlock update_not_possible
2025/08/28 10:41:34 INFO <job_1085959453> Requirements update strategy bump_versions
updater | 2025/08/28 10:41:34 INFO <job_1085959453> No update possible for fil_builtin_actors_bundle b7a35b4368377f090465553d0d6fe651fefb771b
```