### PR TITLE
feat: cacheless hamt iteration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,6 +2527,7 @@ dependencies = [
  "fvm_ipld_encoding 0.5.3",
  "hex",
  "ipld-core",
+ "itertools 0.14.0",
  "multihash-codetable",
  "once_cell",
  "quickcheck",

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -374,4 +374,15 @@ where
         })?;
         Ok(())
     }
+
+    pub fn for_each_cacheless<F>(&self, mut f: F) -> anyhow::Result<()>
+    where
+        F: FnMut(Address, &ActorState) -> anyhow::Result<()>,
+    {
+        self.hamt.for_each_cacheless(|k, v| {
+            let addr = Address::from_bytes(&k.0)?;
+            f(addr, v)
+        })?;
+        Ok(())
+    }
 }

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -32,6 +32,7 @@ unsigned-varint = { workspace = true }
 quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
 rand = { workspace = true }
+itertools = { workspace = true }
 
 [[bench]]
 name = "hamt_beckmark"

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -382,6 +382,38 @@ where
         Ok(())
     }
 
+    /// Iterates over each KV in the Hamt and runs a function on the values. This is a
+    /// non-caching version of [`Self::for_each`]. It can potentially be more efficient, especially memory-wise,
+    /// for large HAMTs or when the iteration occurs only once.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fvm_ipld_hamt::Hamt;
+    ///
+    /// let store = fvm_ipld_blockstore::MemoryBlockstore::default();
+    ///
+    /// let mut map: Hamt<_, _, usize> = Hamt::new(store);
+    /// map.set(1, 1).unwrap();
+    /// map.set(4, 2).unwrap();
+    ///
+    /// let mut total = 0;
+    /// map.for_each_cacheless(|_, v: &u64| {
+    ///    total += v;
+    ///    Ok(())
+    /// }).unwrap();
+    /// assert_eq!(total, 3);
+    /// ```
+    pub fn for_each_cacheless<F>(&self, mut f: F) -> Result<(), Error>
+    where
+        K: Clone,
+        V: DeserializeOwned + Clone,
+        F: FnMut(&K, &V) -> anyhow::Result<()>,
+    {
+        self.root
+            .for_each_cacheless(&self.store, &self.conf, &mut f)
+    }
+
     /// Iterates over each KV in the Hamt and runs a function on the values. If starting key is
     /// provided, iteration will start from that key. If max is provided, iteration will stop after
     /// max number of items have been traversed. The number of items that were traversed is

--- a/ipld/hamt/src/hash_algorithm.rs
+++ b/ipld/hamt/src/hash_algorithm.rs
@@ -72,9 +72,9 @@ pub enum Identity {}
 
 #[cfg(feature = "identity")]
 impl HashAlgorithm for Identity {
-    fn hash<X: ?Sized>(key: &X) -> HashedKey
+    fn hash<X>(key: &X) -> HashedKey
     where
-        X: Hash,
+        X: Hash + ?Sized,
     {
         let mut ident_hasher = IdentityHasher::default();
         key.hash(&mut ident_hasher);

--- a/ipld/hamt/src/lib.rs
+++ b/ipld/hamt/src/lib.rs
@@ -75,7 +75,7 @@ impl Default for Config {
 
 type HashedKey = [u8; 32];
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 struct KeyValuePair<K, V>(K, V);
 
 impl<K, V> KeyValuePair<K, V> {

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -46,6 +46,23 @@ pub(crate) enum Pointer<K, V, H, Ver = version::V3> {
     Dirty(Box<Node<K, V, H, Ver>>),
 }
 
+impl<K, V, H, Ver> Clone for Pointer<K, V, H, Ver>
+where
+    K: Clone,
+    V: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::Values(v) => Self::Values(v.clone()),
+            Self::Link { cid, cache: _ } => Self::Link {
+                cid: *cid,
+                cache: Default::default(),
+            },
+            Self::Dirty(n) => Self::Dirty(n.clone()),
+        }
+    }
+}
+
 impl<K: PartialEq, V: PartialEq, H, Ver> PartialEq for Pointer<K, V, H, Ver> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::collections::{HashMap, HashSet};
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 
 use cid::Cid;
 use fvm_ipld_blockstore::tracking::{BSStats, TrackingBlockstore};
@@ -14,6 +14,7 @@ use fvm_ipld_encoding::strict_bytes::ByteBuf;
 #[cfg(feature = "identity")]
 use fvm_ipld_hamt::Identity;
 use fvm_ipld_hamt::{BytesKey, Config, Error, Hamt, Hash};
+use itertools::Itertools as _;
 use multihash_codetable::Code;
 use quickcheck::Arbitrary;
 use rand::SeedableRng;
@@ -84,44 +85,61 @@ impl HamtFactory {
     }
 }
 
-/// Check hard-coded CIDs during testing.
-struct CidChecker {
+type CidChecker = Checker<Cid>;
+
+type BSStatsChecker = Checker<BSStats>;
+
+/// Check hard-coded values during testing.
+struct Checker<T> {
     checked: usize,
-    cids: Option<Vec<&'static str>>,
+    expected_values: Option<Vec<T>>,
 }
 
-impl CidChecker {
-    pub fn new(cids: Vec<&'static str>) -> Self {
+impl<T> Checker<T>
+where
+    T: Debug + PartialEq,
+{
+    pub fn new<V>(expected_values: impl IntoIterator<Item = V>) -> Self
+    where
+        T: TryFrom<V>,
+        <T as TryFrom<V>>::Error: Debug,
+    {
         Self {
-            cids: Some(cids),
+            expected_values: Some(
+                expected_values
+                    .into_iter()
+                    .map(T::try_from)
+                    .try_collect()
+                    .unwrap(),
+            ),
             checked: 0,
         }
     }
 
     pub fn empty() -> Self {
         Self {
-            cids: None,
+            expected_values: None,
             checked: 0,
         }
     }
 
-    pub fn check_next(&mut self, cid: Cid) {
-        if let Some(cids) = &self.cids {
-            assert_ne!(self.checked, cids.len());
-            assert_eq!(cid.to_string().as_str(), cids[self.checked]);
+    pub fn check_next(&mut self, actual_value: &T) {
+        if let Some(expected_values) = &self.expected_values {
+            assert_ne!(self.checked, expected_values.len());
+            assert_eq!(actual_value, &expected_values[self.checked]);
             self.checked += 1;
         }
     }
 }
 
-impl Drop for CidChecker {
+impl<T> Drop for Checker<T> {
     fn drop(&mut self) {
         if std::thread::panicking() {
             // Already failed, don't double-panic.
             return;
         }
-        if let Some(cids) = &self.cids {
-            assert_eq!(self.checked, cids.len())
+        if let Some(expected_values) = &self.expected_values {
+            assert_eq!(self.checked, expected_values.len())
         }
     }
 }
@@ -302,7 +320,7 @@ fn test_set_if_absent(factory: HamtFactory, stats: Option<BSStats>, mut cids: Ci
             .unwrap()
     );
 
-    cids.check_next(c);
+    cids.check_next(&c);
 
     if let Some(stats) = stats {
         assert_eq!(*store.stats.borrow(), stats);
@@ -324,12 +342,12 @@ fn set_with_no_effect_does_not_put(
     }
 
     let c = begn.flush().unwrap();
-    cids.check_next(c);
+    cids.check_next(&c);
 
     begn.set(tstring("favorite-animal"), tstring("bright green bear"))
         .unwrap();
     let c2 = begn.flush().unwrap();
-    cids.check_next(c2);
+    cids.check_next(&c2);
     if let Some(stats) = stats {
         assert_eq!(*store.stats.borrow(), stats);
     }
@@ -337,7 +355,7 @@ fn set_with_no_effect_does_not_put(
     begn.set(tstring("favorite-animal"), tstring("bright green bear"))
         .unwrap();
     let c3 = begn.flush().unwrap();
-    cids.check_next(c3);
+    cids.check_next(&c3);
 
     if let Some(stats) = stats {
         assert_eq!(*store.stats.borrow(), stats);
@@ -356,7 +374,7 @@ fn delete(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidChecker) {
     assert!(hamt.contains_key(&tstring("foo")).unwrap());
 
     let c = hamt.flush().unwrap();
-    cids.check_next(c);
+    cids.check_next(&c);
 
     let mut h2: Hamt<_, BytesKey> = factory.load(&c, &store).unwrap();
     assert!(h2.get(&b"foo".to_vec()).unwrap().is_some());
@@ -368,7 +386,7 @@ fn delete(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidChecker) {
     assert!(h2.delete(&b"nonexistent".to_vec()).unwrap().is_none());
 
     let c2 = h2.flush().unwrap();
-    cids.check_next(c2);
+    cids.check_next(&c2);
     if let Some(stats) = stats {
         assert_eq!(*store.stats.borrow(), stats);
     }
@@ -384,14 +402,14 @@ fn delete_case(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidChecke
         .unwrap();
 
     let c = hamt.flush().unwrap();
-    cids.check_next(c);
+    cids.check_next(&c);
 
     let mut h2: Hamt<_, ByteBuf> = factory.load(&c, &store).unwrap();
     assert!(h2.delete(&[0].to_vec()).unwrap().is_some());
     assert_eq!(h2.get(&[0].to_vec()).unwrap(), None);
 
     let c2 = h2.flush().unwrap();
-    cids.check_next(c2);
+    cids.check_next(&c2);
     if let Some(stats) = stats {
         assert_eq!(*store.stats.borrow(), stats);
     }
@@ -407,7 +425,7 @@ fn reload_empty(factory: HamtFactory, stats: Option<BSStats>, mut cids: CidCheck
     let h2: Hamt<_, ()> = factory.load(&c, &store).unwrap();
     let c2 = store.put_cbor(&h2, Code::Blake2b256).unwrap();
     assert_eq!(c, c2);
-    cids.check_next(c);
+    cids.check_next(&c);
     if let Some(stats) = stats {
         assert_eq!(*store.stats.borrow(), stats);
     }
@@ -430,14 +448,14 @@ fn set_delete_many(
     }
 
     let c1 = hamt.flush().unwrap();
-    cids.check_next(c1);
+    cids.check_next(&c1);
 
     for i in size_factor..(size_factor * 2) {
         hamt.set(tstring(i), tstring(i)).unwrap();
     }
 
     let cid_all = hamt.flush().unwrap();
-    cids.check_next(cid_all);
+    cids.check_next(&cid_all);
 
     for i in size_factor..(size_factor * 2) {
         assert!(hamt.delete(&tstring(i)).unwrap().is_some());
@@ -449,7 +467,7 @@ fn set_delete_many(
     }
 
     let cid_d = hamt.flush().unwrap();
-    cids.check_next(cid_d);
+    cids.check_next(&cid_d);
 
     // Assert that we can empty it.
     for i in 0..size_factor {
@@ -460,7 +478,7 @@ fn set_delete_many(
     assert_eq!(hamt.iter().count(), 0);
 
     let cid_d = hamt.flush().unwrap();
-    cids.check_next(cid_d);
+    cids.check_next(&cid_d);
     if let Some(stats) = stats {
         assert_eq!(*store.stats.borrow(), stats);
     }
@@ -496,7 +514,7 @@ fn for_each(
     assert_eq!(count, size_factor);
 
     let c = hamt.flush().unwrap();
-    cids.check_next(c);
+    cids.check_next(&c);
 
     let mut hamt: Hamt<_, BytesKey> = factory.load_with_bit_width(&c, &store, 5).unwrap();
 
@@ -522,7 +540,7 @@ fn for_each(
 
     {
         let c = hamt.flush().unwrap();
-        cids.check_next(c);
+        cids.check_next(&c);
     }
 
     // Iterate with a few modified nodes.
@@ -573,10 +591,113 @@ fn for_each(
     assert_eq!(count, expected_count);
 
     let c = hamt.flush().unwrap();
-    cids.check_next(c);
+    cids.check_next(&c);
 
     if let Some(stats) = stats {
         assert_eq!(*store.stats.borrow(), stats);
+    }
+}
+
+fn for_each_cacheless(
+    size_factor: usize,
+    factory: HamtFactory,
+    mut stats: Option<BSStatsChecker>,
+    mut cids: CidChecker,
+) {
+    let mem = MemoryBlockstore::default();
+    let store = TrackingBlockstore::new(&mem);
+
+    let mut hamt: Hamt<_, BytesKey> = factory.new_with_bit_width(&store, 5);
+
+    for i in 0..size_factor {
+        hamt.set(tstring(i), tstring(i)).unwrap();
+    }
+
+    // Iterating through hamt with dirty caches.
+    let mut count = 0;
+    hamt.for_each_cacheless(|k, v| {
+        assert_eq!(k, v);
+        count += 1;
+        Ok(())
+    })
+    .unwrap();
+    assert_eq!(count, size_factor);
+
+    let c = hamt.flush().unwrap();
+    cids.check_next(&c);
+    if let Some(stats) = &mut stats {
+        stats.check_next(&*store.stats.borrow());
+    }
+
+    let mut hamt: Hamt<_, BytesKey> = factory.load_with_bit_width(&c, &store, 5).unwrap();
+
+    // Iterating through hamt with no cache.
+    let mut count = 0;
+    hamt.for_each_cacheless(|k, v| {
+        assert_eq!(k, v);
+        count += 1;
+        Ok(())
+    })
+    .unwrap();
+    assert_eq!(count, size_factor);
+
+    let c = hamt.flush().unwrap();
+    cids.check_next(&c);
+    if let Some(stats) = &mut stats {
+        stats.check_next(&*store.stats.borrow());
+    }
+
+    // Iterate with a few modified nodes.
+    if size_factor > 10 {
+        hamt.set(tstring(10), tstring("modified-10")).unwrap();
+    }
+    if size_factor > 80 {
+        hamt.set(tstring(80), tstring("modified-80")).unwrap();
+        hamt.set(tstring(81), tstring("modified-81")).unwrap();
+    }
+    if size_factor > 30 {
+        assert!(hamt.delete(&tstring(30)).unwrap().is_some());
+    }
+
+    // Delete a non-existent value
+    assert!(hamt.delete(&tstring(size_factor + 100)).unwrap().is_none());
+
+    // Iterate and verify modifications
+    let mut count = 0;
+    hamt.for_each_cacheless(|k, v| {
+        if size_factor > 30 {
+            // Should not see deleted key
+            assert_ne!(k, &tstring(30));
+        }
+
+        if size_factor > 10 && k == &tstring(10) {
+            assert_eq!(v, &tstring("modified-10"));
+        } else if size_factor > 80 && k == &tstring(80) {
+            assert_eq!(v, &tstring("modified-80"));
+        } else if size_factor > 80 && k == &tstring(81) {
+            assert_eq!(v, &tstring("modified-81"));
+        } else if k != &tstring(30) {
+            // Normal key-value equality except for modified keys
+            assert_eq!(k, v);
+        }
+
+        count += 1;
+        Ok(())
+    })
+    .unwrap();
+
+    // Verify count matches expectation: original size - deleted + new entries
+    let expected_count = if size_factor > 30 {
+        size_factor - 1
+    } else {
+        size_factor
+    };
+    assert_eq!(count, expected_count);
+
+    let c = hamt.flush().unwrap();
+    cids.check_next(&c);
+    if let Some(stats) = &mut stats {
+        stats.check_next(&*store.stats.borrow());
     }
 }
 
@@ -698,7 +819,7 @@ fn for_each_ranged(
     }
 
     let c = hamt.flush().unwrap();
-    cids.check_next(c);
+    cids.check_next(&c);
 
     // Chain paginated requests over a HAMT with committed nodes
     let mut hamt: Hamt<_, usize> = factory.load_with_bit_width(&c, &store, 5).unwrap();
@@ -749,7 +870,7 @@ fn for_each_ranged(
     }
 
     let c = hamt.flush().unwrap();
-    cids.check_next(c);
+    cids.check_next(&c);
 
     // Test modifications and deletions in ranged iteration
     if size_factor > 10 {
@@ -782,7 +903,7 @@ fn for_each_ranged(
     assert_eq!(kvs_after_mod.len(), expected_count);
 
     let c = hamt.flush().unwrap();
-    cids.check_next(c);
+    cids.check_next(&c);
 
     if let Some(stats) = stats {
         assert_eq!(*store.stats.borrow(), stats);
@@ -828,7 +949,7 @@ fn clear(factory: HamtFactory, mut cids: CidChecker) {
     assert_eq!(hamt.get(&3).unwrap(), Some(&"c".to_string()));
 
     let c = hamt.flush().unwrap();
-    cids.check_next(c);
+    cids.check_next(&c);
 }
 
 #[cfg(feature = "identity")]
@@ -973,7 +1094,7 @@ fn clean_child_ordering(factory: HamtFactory, stats: Option<BSStats>, mut cids: 
     }
 
     let root = h.flush().unwrap();
-    cids.check_next(root);
+    cids.check_next(&root);
     let mut h: Hamt<_, u8> = factory.load_with_bit_width(&root, &store, 5).unwrap();
 
     h.delete(&make_key(104)).unwrap();
@@ -981,7 +1102,7 @@ fn clean_child_ordering(factory: HamtFactory, stats: Option<BSStats>, mut cids: 
     let root = h.flush().unwrap();
     let _: Hamt<_, u8> = factory.load_with_bit_width(&root, &store, 5).unwrap();
 
-    cids.check_next(root);
+    cids.check_next(&root);
 
     if let Some(stats) = stats {
         assert_eq!(*store.stats.borrow(), stats);
@@ -1181,7 +1302,7 @@ mod test_default {
     use fvm_ipld_hamt::{Config, Hamtv0};
     use quickcheck_macros::quickcheck;
 
-    use crate::{CidChecker, HamtFactory, LimitedKeyOps, UniqueKeyValuePairs};
+    use crate::{BSStatsChecker, CidChecker, HamtFactory, LimitedKeyOps, UniqueKeyValuePairs};
 
     #[test]
     fn test_basics() {
@@ -1285,13 +1406,29 @@ mod test_default {
     #[test]
     fn for_each_ranged() {
         #[rustfmt::skip]
-            let stats = BSStats {r: 30, w: 33, br: 2895, bw: 4321};
+        let stats = BSStats {r: 30, w: 33, br: 2895, bw: 4321};
         let cids = CidChecker::new(vec![
             "bafy2bzacedy4ypl2vedhdqep3llnwko6vrtfiys5flciz2f3c55pl4whlhlqm",
             "bafy2bzacedy4ypl2vedhdqep3llnwko6vrtfiys5flciz2f3c55pl4whlhlqm",
             "bafy2bzacecrxqeuuk34jsrol3azfpgy35ldw4bpgsa6pdxvzj262jzpvoekye",
         ]);
         super::for_each_ranged(200, HamtFactory::default(), Some(stats), cids);
+    }
+
+    #[test]
+    fn for_each_cacheless() {
+        #[rustfmt::skip]
+        let stats = BSStatsChecker::new(vec![
+            BSStats {r: 0, w: 30, br: 0, bw: 3209},
+            BSStats {r: 30, w: 30, br: 3209, bw: 3209},
+            BSStats {r: 60, w: 33, br: 5158, bw: 4697},
+        ]);
+        let cids = CidChecker::new(vec![
+            "bafy2bzaceczhz54xmmz3xqnbmvxfbaty3qprr6dq7xh5vzwqbirlsnbd36z7a",
+            "bafy2bzaceczhz54xmmz3xqnbmvxfbaty3qprr6dq7xh5vzwqbirlsnbd36z7a",
+            "bafy2bzacebln5j7tdfavh2qqhio6mgaoq6mm2jbmcex2ngcmi3uqlx5k3mov4",
+        ]);
+        super::for_each_cacheless(200, HamtFactory::default(), Some(stats), cids);
     }
 
     #[test]


### PR DESCRIPTION
(Simliar to https://github.com/filecoin-project/ref-fvm/pull/2189)
This PR adds `HamtImpl::for_each_cacheless` and `StateTree::for_each_cacheless` to reduce memory usage for iterating over a large hamt