### PR TITLE
chore(deps): bump criterion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,25 +803,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -829,12 +826,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -2829,12 +2826,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,17 +3084,6 @@ dependencies = [
  "fvm_ipld_blockstore 0.3.1",
  "fvm_ipld_kamt 0.4.5",
  "libfuzzer-sys",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi 0.5.0",
- "libc",
- "windows-sys",
 ]
 
 [[package]]
@@ -3607,7 +3587,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ unsigned-varint = "0.8.0"
 ambassador = "0.4.1"
 
 # dev/tools/tests
-criterion = "0.5.1"
+criterion = "0.7"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
 minstant = "0.1.7"

--- a/ipld/amt/benches/amt_benchmark.rs
+++ b/ipld/amt/benches/amt_benchmark.rs
@@ -2,7 +2,9 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use fvm_ipld_amt::Amt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/ipld/bitfield/benches/benchmarks/main.rs
+++ b/ipld/bitfield/benches/benchmarks/main.rs
@@ -5,9 +5,10 @@
 mod examples;
 
 use std::fs;
+use std::hint::black_box;
 use std::path::Path;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use examples::{example1, example2};
 use fvm_ipld_bitfield::BitField;
 use gperftools::profiler::PROFILER;

--- a/ipld/hamt/benches/hamt_benchmark.rs
+++ b/ipld/hamt/benches/hamt_benchmark.rs
@@ -2,9 +2,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-extern crate serde;
+use std::hint::black_box;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_hamt::Hamt;
 

--- a/ipld/kamt/benches/kamt_benchmark.rs
+++ b/ipld/kamt/benches/kamt_benchmark.rs
@@ -2,11 +2,10 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-extern crate serde;
-
 use std::borrow::Cow;
+use std::hint::black_box;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_kamt::{AsHashedKey, Config, HashedKey, Kamt};

--- a/testing/conformance/benches/bench_conformance.rs
+++ b/testing/conformance/benches/bench_conformance.rs
@@ -1,7 +1,5 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-//#[macro_use]
-extern crate criterion;
 
 use std::env::var;
 use std::iter;

--- a/testing/conformance/benches/bench_conformance_overhead.rs
+++ b/testing/conformance/benches/bench_conformance_overhead.rs
@@ -1,6 +1,6 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-extern crate criterion;
+
 use std::env::var;
 use std::path::Path;
 use std::time::Duration;

--- a/testing/conformance/benches/bench_drivers.rs
+++ b/testing/conformance/benches/bench_drivers.rs
@@ -1,6 +1,7 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-extern crate criterion;
+
+use std::hint::black_box;
 
 use criterion::*;
 use fvm::engine::MultiEngine;
@@ -65,7 +66,7 @@ pub fn bench_vector_variant(
                     DefaultExecutor::new(engine, machine).unwrap();
                 (messages_with_lengths.clone(), exec)
             },
-            |(messages, exec)| apply_messages(criterion::black_box(messages), exec),
+            |(messages, exec)| apply_messages(black_box(messages), exec),
             BatchSize::LargeInput,
         )
     });


### PR DESCRIPTION
This PR upgrades `criterion` to the latest version and fixes clippy warnings