### PR TITLE
fix: propagate errors in `Amt::for_each_cacheless`

### DIFF
--- a/ipld/amt/CHANGELOG.md
+++ b/ipld/amt/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed a bug in `for_each_cacheless` where it would swallow errors and continue iterating.
+
 ## 0.7.5 [2025-08-05]
 
 - Added `for_each_cacheless` method to iterate over the AMT without caching the values. This is lowers memory requirements usage and is useful for single-pass, read-only operations over large AMTs.

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -593,7 +593,8 @@ where
 
     /// Iterates over each value in the Amt and runs a function on the values. This is a
     /// non-caching version of [`Self::for_each`]. It can potentially be more efficient, especially memory-wise,
-    /// for large AMTs or when the iteration occurs only once.
+    /// for large AMTs or when the iteration occurs only once. An error during iteration stops the
+    /// iteration and is returned.
     ///
     /// # Examples
     ///

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -437,7 +437,7 @@ where
             Node::Leaf { vals } => {
                 for (i, v) in (0..).zip(vals.iter()) {
                     if let Some(v) = v {
-                        let _ = f(offset + i, v);
+                        f(offset + i, v)?;
                     }
                 }
             }

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -459,6 +459,11 @@ fn for_each_cacheless() {
     // 2nd pass, no caching so block reads roughly doubled.
     #[rustfmt::skip]
     assert_eq!(*db.stats.borrow(), BSStats {r: 2861, w: 1431, br: 177158, bw: 88649});
+
+    // errorr during iteration is propagated
+    let res = new_amt.for_each_cacheless(|_, _: &BytesDe| anyhow::bail!("cthulhu fhtagn"));
+    let err = res.unwrap_err();
+    assert_eq!(err.to_string(), "cthulhu fhtagn");
 }
 
 #[test]


### PR DESCRIPTION
Fixed the lack of error propagation in the `Amt::for_each_cacheless`. Thanks @hanabi1224 for pointing this out.