### PR TITLE
chore: bump multihash-codetable to get rid of `core2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ dependencies = [
  "blstrs",
  "byteorder",
  "crossbeam-channel",
- "digest",
+ "digest 0.10.7",
  "ec-gpu",
  "ec-gpu-gen 0.7.1",
  "ff",
@@ -240,12 +240,12 @@ dependencies = [
  "log",
  "memmap2",
  "pairing",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rayon",
  "rustversion",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "supraseal-c2",
  "thiserror 1.0.69",
 ]
@@ -329,6 +329,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,7 +357,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "thiserror 1.0.69",
 ]
@@ -377,7 +386,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "subtle",
 ]
@@ -467,7 +476,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -499,16 +508,16 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
+checksum = "cbb4913a732503de004e94ce7a4e7119ffc55d1727cc9979ac3b52f511e6578c"
 dependencies = [
  "arbitrary",
- "core2",
  "multibase",
  "multihash",
+ "no_std_io2",
  "quickcheck",
- "rand",
+ "rand 0.10.1",
  "serde",
  "serde_bytes",
  "unsigned-varint",
@@ -520,7 +529,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
@@ -605,10 +614,10 @@ dependencies = [
  "arbitrary",
  "cid",
  "fvm_ipld_bitfield 0.7.2",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_shared 4.8.2",
  "libfuzzer-sys",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -629,6 +638,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -677,6 +692,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -930,7 +954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -943,6 +967,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1023,7 +1056,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1072,10 +1105,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1113,7 +1157,7 @@ dependencies = [
  "once_cell",
  "rayon",
  "rust-gpu-tools",
- "sha2",
+ "sha2 0.10.8",
  "thiserror 1.0.69",
  "yastl",
 ]
@@ -1136,7 +1180,7 @@ dependencies = [
  "once_cell",
  "rayon",
  "rust-gpu-tools",
- "sha2",
+ "sha2 0.10.8",
  "thiserror 1.0.69",
  "yastl",
 ]
@@ -1148,7 +1192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1168,11 +1212,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array 0.14.7",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1321,7 +1365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1346,8 +1390,8 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_shared 4.7.3",
  "num-derive",
  "num-traits",
@@ -1363,10 +1407,10 @@ dependencies = [
  "anyhow",
  "cid",
  "clap",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_car 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash-codetable",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_car 0.9.0",
+ "fvm_ipld_encoding 0.5.3",
+ "multihash-codetable 0.1.4",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
@@ -1378,8 +1422,8 @@ version = "17.0.0"
 source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_shared 4.7.3",
  "log",
  "num-derive",
@@ -1397,8 +1441,8 @@ dependencies = [
  "frc42_dispatch",
  "frc46_token",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_ipld_hamt 0.10.4",
  "fvm_shared 4.7.3",
  "lazy_static",
@@ -1417,8 +1461,8 @@ dependencies = [
  "cid",
  "fil_actors_evm_shared",
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_shared 4.7.3",
  "hex-literal",
  "log",
@@ -1437,7 +1481,7 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_shared 4.7.3",
  "hex-literal",
  "num-derive",
@@ -1456,14 +1500,14 @@ dependencies = [
  "fil_actors_evm_shared",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_kamt 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
+ "fvm_ipld_kamt 0.4.5",
  "fvm_shared 4.7.3",
  "hex",
  "hex-literal",
  "log",
- "multihash-codetable",
+ "multihash-codetable 0.1.4",
  "num-derive",
  "num-traits",
  "serde",
@@ -1480,8 +1524,8 @@ dependencies = [
  "cid",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_ipld_hamt 0.10.4",
  "fvm_shared 4.7.3",
  "log",
@@ -1501,15 +1545,15 @@ dependencies = [
  "frc42_dispatch",
  "frc46_token",
  "fvm_ipld_bitfield 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_ipld_hamt 0.10.4",
  "fvm_shared 4.7.3",
  "integer-encoding",
  "ipld-core",
  "lazy_static",
  "log",
- "multihash-codetable",
+ "multihash-codetable 0.1.4",
  "num-derive",
  "num-traits",
  "serde",
@@ -1528,15 +1572,15 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_amt 0.7.5",
  "fvm_ipld_bitfield 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_ipld_hamt 0.10.4",
  "fvm_shared 4.7.3",
  "itertools 0.14.0",
  "lazy_static",
  "log",
  "multihash",
- "multihash-codetable",
+ "multihash-codetable 0.1.4",
  "num-derive",
  "num-traits",
  "serde",
@@ -1552,8 +1596,8 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_ipld_hamt 0.10.4",
  "fvm_shared 4.7.3",
  "indexmap 2.9.0",
@@ -1572,8 +1616,8 @@ dependencies = [
  "cid",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_shared 4.7.3",
  "num-derive",
  "num-traits",
@@ -1594,8 +1638,8 @@ dependencies = [
  "cid",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_ipld_hamt 0.10.4",
  "fvm_shared 4.7.3",
  "indexmap 2.9.0",
@@ -1613,8 +1657,8 @@ version = "17.0.0"
 source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_shared 4.7.3",
  "lazy_static",
  "log",
@@ -1631,10 +1675,10 @@ dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_shared 4.7.3",
- "multihash-codetable",
+ "multihash-codetable 0.1.4",
  "num-derive",
  "num-traits",
  "serde",
@@ -1651,8 +1695,8 @@ dependencies = [
  "frc42_dispatch",
  "frc46_token",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_ipld_hamt 0.10.4",
  "fvm_shared 4.7.3",
  "lazy_static",
@@ -1668,7 +1712,7 @@ version = "17.0.0"
 source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_shared 4.7.3",
  "hex",
  "serde",
@@ -1686,8 +1730,8 @@ dependencies = [
  "cid",
  "fvm_ipld_amt 0.7.5",
  "fvm_ipld_bitfield 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_ipld_hamt 0.10.4",
  "fvm_sdk 4.7.3",
  "fvm_shared 4.7.3",
@@ -1695,14 +1739,14 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "log",
- "multihash-codetable",
+ "multihash-codetable 0.1.4",
  "num",
  "num-derive",
  "num-traits",
  "regex",
  "serde",
  "serde_repr",
- "sha2",
+ "sha2 0.10.8",
  "thiserror 2.0.12",
  "unsigned-varint",
  "vm_api",
@@ -1712,9 +1756,9 @@ dependencies = [
 name = "fil_address_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
 ]
 
 [[package]]
@@ -1750,8 +1794,8 @@ name = "fil_create_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
 ]
 
 [[package]]
@@ -1759,9 +1803,9 @@ name = "fil_custom_syscall_actor"
 version = "0.1.0"
 dependencies = [
  "cid",
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
  "num-traits",
  "serde",
 ]
@@ -1770,9 +1814,9 @@ dependencies = [
 name = "fil_events_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
  "serde",
 ]
 
@@ -1780,9 +1824,9 @@ dependencies = [
 name = "fil_exit_data_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
 ]
 
 [[package]]
@@ -1792,9 +1836,9 @@ dependencies = [
  "anyhow",
  "cid",
  "fvm_gas_calibration_shared",
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
  "ipld-core",
  "num-derive",
  "num-traits",
@@ -1805,9 +1849,9 @@ dependencies = [
 name = "fil_gaslimit_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
  "log",
  "serde",
 ]
@@ -1816,8 +1860,8 @@ dependencies = [
 name = "fil_hello_world_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
 ]
 
 [[package]]
@@ -1826,11 +1870,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cid",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
- "multihash-codetable",
+ "fvm_ipld_blockstore 0.3.2",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
+ "multihash-codetable 0.2.1",
  "serde",
 ]
 
@@ -1838,25 +1882,25 @@ dependencies = [
 name = "fil_ipld_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
 ]
 
 [[package]]
 name = "fil_malformed_syscall_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
 ]
 
 [[package]]
 name = "fil_oom_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
 ]
 
 [[package]]
@@ -1864,9 +1908,9 @@ name = "fil_readonly_actor"
 version = "0.1.0"
 dependencies = [
  "cid",
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
 ]
 
 [[package]]
@@ -1874,17 +1918,17 @@ name = "fil_sself_actor"
 version = "0.1.0"
 dependencies = [
  "cid",
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
 ]
 
 [[package]]
 name = "fil_stack_overflow_actor"
 version = "0.1.0"
 dependencies = [
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
 ]
 
 [[package]]
@@ -1892,10 +1936,10 @@ name = "fil_syscall_actor"
 version = "0.1.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
- "multihash-codetable",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
+ "multihash-codetable 0.2.1",
  "multihash-derive",
 ]
 
@@ -1904,9 +1948,9 @@ name = "fil_upgrade_actor"
 version = "0.1.0"
 dependencies = [
  "cid",
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
  "serde",
 ]
 
@@ -1915,9 +1959,9 @@ name = "fil_upgrade_receive_actor"
 version = "0.1.0"
 dependencies = [
  "cid",
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
  "serde",
 ]
 
@@ -1936,9 +1980,9 @@ dependencies = [
  "lazy_static",
  "merkletree",
  "neptune",
- "rand",
+ "rand 0.8.5",
  "serde",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1963,11 +2007,11 @@ dependencies = [
  "memmap2",
  "merkletree",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "storage-proofs-core",
  "storage-proofs-porep",
  "storage-proofs-post",
@@ -2075,7 +2119,7 @@ checksum = "4701d2d5e6a8ed95ee124d607e8ef51bd8bda11f3bf3f472a5e14d552ed696e6"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_sdk 4.7.3",
  "fvm_shared 4.7.3",
  "thiserror 2.0.12",
@@ -2114,13 +2158,13 @@ dependencies = [
  "cid",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_ipld_hamt 0.10.4",
  "fvm_sdk 4.7.3",
  "fvm_shared 4.7.3",
  "integer-encoding",
- "multihash-codetable",
+ "multihash-codetable 0.1.4",
  "num-traits",
  "serde",
  "thiserror 2.0.12",
@@ -2233,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.8.1"
+version = "4.8.2"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2244,20 +2288,20 @@ dependencies = [
  "filecoin-proofs-api",
  "fvm",
  "fvm-wasm-instrument",
- "fvm_ipld_amt 0.7.6",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_ipld_hamt 0.10.5",
- "fvm_shared 4.8.1",
+ "fvm_ipld_amt 0.7.7",
+ "fvm_ipld_blockstore 0.3.2",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_ipld_hamt 0.10.6",
+ "fvm_shared 4.8.2",
  "lazy_static",
  "log",
  "minstant",
- "multihash-codetable",
+ "multihash-codetable 0.2.1",
  "multihash-derive",
  "num-traits",
  "pretty_assertions",
  "quickcheck",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "replace_with",
  "serde",
@@ -2277,8 +2321,8 @@ dependencies = [
  "env_logger 0.11.8",
  "fvm",
  "fvm_integration_tests",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_shared 4.8.2",
  "hex",
 ]
 
@@ -2303,11 +2347,11 @@ dependencies = [
  "anyhow",
  "cid",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_sdk 4.7.3",
  "fvm_shared 4.7.3",
- "multihash-codetable",
+ "multihash-codetable 0.1.4",
  "num-traits",
  "serde",
  "thiserror 2.0.12",
@@ -2327,10 +2371,10 @@ dependencies = [
  "flate2",
  "futures",
  "fvm",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_car 0.9.0",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.8.1",
+ "fvm_ipld_blockstore 0.3.2",
+ "fvm_ipld_car 0.9.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_shared 4.8.2",
  "ipld-core",
  "itertools 0.14.0",
  "ittapi-rs",
@@ -2352,7 +2396,7 @@ dependencies = [
 name = "fvm_gas_calibration_shared"
 version = "0.1.0"
 dependencies = [
- "fvm_shared 4.8.1",
+ "fvm_shared 4.8.2",
  "num-derive",
  "num-traits",
  "serde",
@@ -2361,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "4.8.1"
+version = "4.8.2"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -2372,19 +2416,19 @@ dependencies = [
  "fil_builtin_actors_bundle",
  "fvm",
  "fvm_gas_calibration_shared",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_car 0.9.0",
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.8.1",
- "fvm_shared 4.8.1",
+ "fvm_ipld_blockstore 0.3.2",
+ "fvm_ipld_car 0.9.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_sdk 4.8.2",
+ "fvm_shared 4.8.2",
  "fvm_test_actors",
  "hex",
  "k256",
  "lazy_static",
  "minstant",
- "multihash-codetable",
+ "multihash-codetable 0.2.1",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rand_chacha",
  "serde",
  "serde_json",
@@ -2401,10 +2445,10 @@ checksum = "437a2791237a87bbb91f3c827b5c2e05789b8ba22467a8bce1be831e74612d00"
 dependencies = [
  "anyhow",
  "cid",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "itertools 0.14.0",
- "multihash-codetable",
+ "multihash-codetable 0.1.4",
  "once_cell",
  "serde",
  "thiserror 2.0.12",
@@ -2412,15 +2456,15 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_amt"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "cid",
  "criterion",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
+ "fvm_ipld_blockstore 0.3.2",
+ "fvm_ipld_encoding 0.5.4",
  "itertools 0.14.0",
- "multihash-codetable",
+ "multihash-codetable 0.2.1",
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
@@ -2434,9 +2478,9 @@ version = "0.7.2"
 dependencies = [
  "arbitrary",
  "criterion",
- "fvm_ipld_encoding 0.5.3",
+ "fvm_ipld_encoding 0.5.4",
  "gperftools",
- "rand",
+ "rand 0.8.5",
  "rand_xorshift",
  "serde",
  "serde_json",
@@ -2450,19 +2494,10 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de140b940443d5d783824563f15b5fe6d1559e7b103a7b55082da93655585350"
 dependencies = [
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.3",
  "serde",
  "thiserror 2.0.12",
  "unsigned-varint",
-]
-
-[[package]]
-name = "fvm_ipld_blockstore"
-version = "0.3.1"
-dependencies = [
- "anyhow",
- "cid",
- "multihash-codetable",
 ]
 
 [[package]]
@@ -2473,21 +2508,16 @@ checksum = "97b8b31e022f71b73440054f7e5171231a1ebc745adf075014d5aa8ea78ea283"
 dependencies = [
  "anyhow",
  "cid",
- "multihash-codetable",
+ "multihash-codetable 0.1.4",
 ]
 
 [[package]]
-name = "fvm_ipld_car"
-version = "0.9.0"
+name = "fvm_ipld_blockstore"
+version = "0.3.2"
 dependencies = [
+ "anyhow",
  "cid",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "multihash-codetable",
- "multihash-derive",
- "serde",
- "thiserror 2.0.12",
- "unsigned-varint",
+ "multihash-codetable 0.2.1",
 ]
 
 [[package]]
@@ -2497,9 +2527,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3f49d53950e37e2b310a6527135f4b9b09c2fb8c25f1846622131f9db965be0"
 dependencies = [
  "cid",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash-codetable",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
+ "multihash-codetable 0.1.4",
  "multihash-derive",
  "serde",
  "thiserror 2.0.12",
@@ -2507,19 +2537,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "fvm_ipld_encoding"
-version = "0.5.3"
+name = "fvm_ipld_car"
+version = "0.9.1"
 dependencies = [
- "anyhow",
  "cid",
- "fvm_ipld_blockstore 0.3.1",
- "multihash-codetable",
+ "fvm_ipld_blockstore 0.3.2",
+ "fvm_ipld_encoding 0.5.4",
+ "multihash-codetable 0.2.1",
+ "multihash-derive",
  "serde",
- "serde_ipld_dagcbor",
- "serde_json",
- "serde_repr",
- "serde_tuple 1.1.3",
  "thiserror 2.0.12",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2530,12 +2558,28 @@ checksum = "c4fd0c7d16be0076920acd5bf13e705a80dfe6540d4722b19745daa9ea93722a"
 dependencies = [
  "anyhow",
  "cid",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash-codetable",
+ "fvm_ipld_blockstore 0.3.1",
+ "multihash-codetable 0.1.4",
  "serde",
  "serde_ipld_dagcbor",
  "serde_repr",
  "serde_tuple 0.5.0",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "fvm_ipld_encoding"
+version = "0.5.4"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fvm_ipld_blockstore 0.3.2",
+ "multihash-codetable 0.2.1",
+ "serde",
+ "serde_ipld_dagcbor",
+ "serde_json",
+ "serde_repr",
+ "serde_tuple 1.1.3",
  "thiserror 2.0.12",
 ]
 
@@ -2549,58 +2593,37 @@ dependencies = [
  "byteorder",
  "cid",
  "forest_hash_utils",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "ipld-core",
- "multihash-codetable",
+ "multihash-codetable 0.1.4",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "fvm_ipld_hamt"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "anyhow",
  "byteorder",
  "cid",
  "criterion",
  "forest_hash_utils",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
+ "fvm_ipld_blockstore 0.3.2",
+ "fvm_ipld_encoding 0.5.4",
  "hex",
  "ipld-core",
  "itertools 0.14.0",
- "multihash-codetable",
+ "multihash-codetable 0.2.1",
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
- "rand",
+ "rand 0.8.5",
  "serde",
- "sha2",
- "thiserror 2.0.12",
- "unsigned-varint",
-]
-
-[[package]]
-name = "fvm_ipld_kamt"
-version = "0.4.5"
-dependencies = [
- "anyhow",
- "byteorder",
- "cid",
- "criterion",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "hex",
- "multihash-codetable",
- "once_cell",
- "quickcheck",
- "quickcheck_macros",
- "rand",
- "serde",
+ "sha2 0.11.0",
  "thiserror 2.0.12",
  "unsigned-varint",
 ]
@@ -2614,12 +2637,33 @@ dependencies = [
  "anyhow",
  "byteorder",
  "cid",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash-codetable",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
+ "multihash-codetable 0.1.4",
  "once_cell",
  "serde",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "fvm_ipld_kamt"
+version = "0.4.6"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "cid",
+ "criterion",
+ "fvm_ipld_blockstore 0.3.2",
+ "fvm_ipld_encoding 0.5.4",
+ "hex",
+ "multihash-codetable 0.2.1",
+ "once_cell",
+ "quickcheck",
+ "quickcheck_macros",
+ "rand 0.8.5",
+ "serde",
+ "thiserror 2.0.12",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2629,7 +2673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d5ef8cdc442a175ec04696adb82953fa28b151a81bd7a67f55f1cfd5af1d8a"
 dependencies = [
  "cid",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_shared 4.7.3",
  "lazy_static",
  "log",
@@ -2639,11 +2683,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.8.1"
+version = "4.8.2"
 dependencies = [
  "cid",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_shared 4.8.2",
  "lazy_static",
  "log",
  "num-traits",
@@ -2662,7 +2706,7 @@ dependencies = [
  "cid",
  "data-encoding",
  "data-encoding-macro",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.3",
  "num-bigint",
  "num-derive",
  "num-integer",
@@ -2674,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.8.1"
+version = "4.8.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2686,18 +2730,18 @@ dependencies = [
  "data-encoding",
  "data-encoding-macro",
  "filecoin-proofs-api",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.8.1",
+ "fvm_ipld_encoding 0.5.4",
+ "fvm_shared 4.8.2",
  "hex",
  "k256",
- "multihash-codetable",
+ "multihash-codetable 0.2.1",
  "num-bigint",
  "num-derive",
  "num-integer",
  "num-traits",
  "quickcheck",
  "quickcheck_macros",
- "rand",
+ "rand 0.8.5",
  "rand_chacha",
  "rusty-fork",
  "serde",
@@ -2816,8 +2860,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rand_xorshift",
  "subtle",
 ]
@@ -2881,7 +2925,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2891,6 +2935,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -3095,8 +3148,8 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "cid",
- "fvm_ipld_amt 0.7.6",
- "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_amt 0.7.7",
+ "fvm_ipld_blockstore 0.3.2",
  "itertools 0.14.0",
  "libfuzzer-sys",
 ]
@@ -3106,8 +3159,8 @@ name = "ipld_hamt-fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_hamt 0.10.5",
+ "fvm_ipld_blockstore 0.3.2",
+ "fvm_ipld_hamt 0.10.6",
  "libfuzzer-sys",
 ]
 
@@ -3116,8 +3169,8 @@ name = "ipld_kamt-fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_kamt 0.4.5",
+ "fvm_ipld_blockstore 0.3.2",
+ "fvm_ipld_kamt 0.4.6",
  "libfuzzer-sys",
 ]
 
@@ -3248,16 +3301,17 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
- "cpufeatures",
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -3436,14 +3490,14 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
 dependencies = [
  "arbitrary",
- "core2",
+ "no_std_io2",
  "quickcheck",
- "rand",
+ "rand 0.10.1",
  "serde",
  "unsigned-varint",
 ]
@@ -3456,22 +3510,33 @@ checksum = "67996849749d25f1da9f238e8ace2ece8f9d6bdf3f9750aaf2ae7de3a5cad8ea"
 dependencies = [
  "blake2b_simd",
  "core2",
- "digest",
  "multihash-derive",
+]
+
+[[package]]
+name = "multihash-codetable"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "facfe64780489b29aae20d32d0245219f4a8167f91193f7061589f5dae9ba307"
+dependencies = [
+ "blake2b_simd",
+ "digest 0.11.2",
+ "multihash-derive",
+ "no_std_io2",
  "ripemd",
- "sha2",
+ "sha2 0.11.0",
  "sha3",
 ]
 
 [[package]]
 name = "multihash-derive"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1b7edab35d920890b88643a765fc9bd295cf0201f4154dda231bef9b8404eb"
+checksum = "0576e09c49157d1910e522e595d2b32749b029dd0bc10ff6967d588490c30348"
 dependencies = [
- "core2",
  "multihash",
  "multihash-derive-impl",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -3507,6 +3572,15 @@ dependencies = [
  "pasta_curves",
  "serde",
  "trait-set",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3719,7 +3793,7 @@ dependencies = [
  "group",
  "hex",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "serde",
  "static_assertions",
  "subtle",
@@ -3895,7 +3969,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger 0.8.4",
  "log",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3938,7 +4012,16 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3948,7 +4031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3961,12 +4044,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4059,11 +4148,11 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
 dependencies = [
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4088,7 +4177,7 @@ dependencies = [
  "log",
  "once_cell",
  "opencl3",
- "sha2",
+ "sha2 0.10.8",
  "temp-env",
  "thiserror 1.0.69",
 ]
@@ -4343,9 +4432,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
  "sha2-asm",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4364,8 +4464,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d413a25ea10bb37dd8d8a1a18a41ae466c4519c93d179443f09a590d756eb68"
 dependencies = [
  "byteorder",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
  "fake-simd",
  "lazy_static",
  "opaque-debug",
@@ -4373,11 +4473,11 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
- "digest",
+ "digest 0.11.2",
  "keccak",
 ]
 
@@ -4393,8 +4493,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
- "rand_core",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4468,13 +4568,13 @@ dependencies = [
  "memmap2",
  "merkletree",
  "num_cpus",
- "rand",
+ "rand 0.8.5",
  "rand_chacha",
  "rayon",
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "thiserror 2.0.12",
 ]
 
@@ -4514,7 +4614,7 @@ dependencies = [
  "rustversion",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "sha2raw",
  "storage-proofs-core",
  "yastl",
@@ -4536,7 +4636,7 @@ dependencies = [
  "log",
  "rayon",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "storage-proofs-core",
 ]
 
@@ -4573,7 +4673,7 @@ dependencies = [
  "byteorder",
  "crunchy",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
 ]
 
@@ -4912,14 +5012,14 @@ source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2
 dependencies = [
  "anyhow",
  "cid",
- "fvm_ipld_blockstore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_encoding 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_blockstore 0.3.1",
+ "fvm_ipld_encoding 0.5.3",
  "fvm_ipld_hamt 0.10.4",
  "fvm_shared 4.7.3",
- "multihash-codetable",
+ "multihash-codetable 0.1.4",
  "num-derive",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rand_chacha",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.8.1"
+version = "4.8.2"
 license = "MIT OR Apache-2.0"
 edition = "2024"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -44,7 +44,7 @@ futures = "0.3.31"
 # IPLD/Encoding
 cid = { version = "0.11.1", default-features = false }
 ipld-core = { version = "0.4.3", features = ["serde"] }
-multihash-codetable = { version = "0.1.4", default-features = false }
+multihash-codetable = { version = "0.2", default-features = false }
 multihash-derive = { version = "0.9.1", default-features = false }
 
 # crypto

--- a/deny.toml
+++ b/deny.toml
@@ -2,6 +2,7 @@
 ignore = [
   "RUSTSEC-2025-0057", # fxhash is no longer maintained, tracked in https://github.com/filecoin-project/ref-fvm/issues/2221
   "RUSTSEC-2025-0141", # bincode unmaintained, transitive dep via bellperson/filecoin-proofs
+  "RUSTSEC-2026-0097", # Rand is unsound with a custom logger using `rand::rng()`
 ]
 
 [bans]

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 4.8.2 [2026-04-17]
+
+- Bump `multihash-codetable` to get rid of `core2`
+
 ## 4.8.0 [2026-04-16]
 
 - feat(executor): expose return codec in ApplyRet [#2264](https://github.com/filecoin-project/ref-fvm/pull/2264)

--- a/ipld/amt/CHANGELOG.md
+++ b/ipld/amt/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 0.7.6 [2026-04-17]
+
+- Bump `multihash-codetable` to get rid of `core2`
+
 ## 0.7.6 [2026-04-16]
 
 - Fixed a bug in `for_each_cacheless` where it would swallow errors and continue iterating.

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_amt"
 description = "Sharded IPLD Array implementation."
-version = "0.7.6"
+version = "0.7.7"
 license.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition.workspace = true

--- a/ipld/blockstore/CHANGELOG.md
+++ b/ipld/blockstore/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the FVM's Blockstore abstraction
 
 ## [Unreleased]
 
+## 0.3.2 [2026-04-17]
+
+- Bump `multihash-codetable` to get rid of `core2`
+
 ## 0.3.1 [2024-11-08]
 
 Remove unnecessary features from `multihash-codetable`.

--- a/ipld/blockstore/Cargo.toml
+++ b/ipld/blockstore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_blockstore"
 description = "Sharded IPLD Blockstore."
-version = "0.3.1"
+version = "0.3.2"
 license.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition.workspace = true

--- a/ipld/car/CHANGELOG.md
+++ b/ipld/car/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the FVM's CAR implementation.
 
 ## [Unreleased]
 
+## 0.9.1 [2026-04-17]
+
+- Bump `multihash-codetable` to get rid of `core2`
+
 ## 0.9.0 [2025-04-11]
 
 - Remove async support, it's overkill for our use-case and leaks complexity.

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_car"
 description = "IPLD CAR handling library"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition.workspace = true
 license.workspace = true

--- a/ipld/encoding/CHANGELOG.md
+++ b/ipld/encoding/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the FVM's shared encoding utilities.
 
 ## [Unreleased]
 
+## 0.5.4 [2026-04-17]
+
+- Bump `multihash-codetable` to get rid of `core2`
+
 ## 0.5.2 [2025-03-14]
 
 Update `ipld-core` and `serde_ipld_dagcbor` to support optional fields in tuple-encoded structs.

--- a/ipld/encoding/Cargo.toml
+++ b/ipld/encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_encoding"
 description = "Sharded IPLD encoding."
-version = "0.5.3"
+version = "0.5.4"
 license.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition.workspace = true

--- a/ipld/hamt/CHANGELOG.md
+++ b/ipld/hamt/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM's HAMT implementation.
 
 ## [Unreleased]
 
+## 0.10.6 [2026-04-17]
+
+- Bump `multihash-codetable` to get rid of `core2`
+
 ## 0.10.5 [2026-04-15]
 
 - Added `for_each_cacheless` method to iterate over the HAMT without caching the values. This is lowers memory requirements usage and is useful for single-pass, read-only operations over large HAMTs.

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_hamt"
 description = "Sharded IPLD HashMap implementation."
-version = "0.10.5"
+version = "0.10.6"
 license.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition.workspace = true
@@ -17,7 +17,7 @@ once_cell = { workspace = true }
 anyhow = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
-sha2 = "0.10"
+sha2 = "0.11"
 forest_hash_utils = "0.1"
 ipld-core = { workspace = true }
 

--- a/ipld/kamt/CHANGELOG.md
+++ b/ipld/kamt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.6 [2026-04-17]
+
+- Bump `multihash-codetable` to get rid of `core2`
+
 ## 0.4.5 [2025-04-09]
 
 - Updates multiple dependencies (semver breaking internally but not exported).

--- a/ipld/kamt/Cargo.toml
+++ b/ipld/kamt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_ipld_kamt"
 description = "Sharded IPLD Map implementation with level skipping."
-version = "0.4.5"
+version = "0.4.6"
 license.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition.workspace = true


### PR DESCRIPTION
To unblock https://github.com/filecoin-project/actors-utils/pull/259