### PR TITLE
chore(release): prepare release 2.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "2.12.0"
+version = "2.12.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_conformance_tests"
-version = "2.12.0"
+version = "2.12.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "2.12.0"
+version = "2.12.1"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "2.12.0"
+version = "2.12.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.12.0"
+version = "2.12.1"
 license = "MIT OR Apache-2.0"
 edition = "2024"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -26,9 +26,9 @@ fvm_ipld_blockstore = { version = "0.3.1" }
 fvm_ipld_encoding = { version = "0.5.3" }
 wasmtime = {version = "36", default-features = false, features = ["cranelift", "pooling-allocator", "parallel-compilation", "runtime"] }
 
-fvm = { path = "fvm", version = "~2.12.0", default-features = false }
-fvm_shared = { path = "shared", version = "~2.12.0", default-features = false }
-fvm_sdk = { path = "sdk", version = "~2.12.0" }
+fvm = { path = "fvm", version = "~2.12.1", default-features = false }
+fvm_shared = { path = "shared", version = "~2.12.1", default-features = false }
+fvm_sdk = { path = "sdk", version = "~2.12.1" }
 
 [profile.actor]
 inherits = "release"

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 2.12.1 (2026-04-20)
+
+- Backport `multihash-codetable` bump to remove `core2` and update `wasmtime` to 36.0.7 [#2286](https://github.com/filecoin-project/ref-fvm/pull/2286)
+
 ## 2.12.0 (2026-04-16)
 
 - chore: update proofs dependency and rust toolchain [#2272](https://github.com/filecoin-project/ref-fvm/pull/2272)

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 2.12.1 (2026-04-20)
+
+- Backport `multihash-codetable` bump to remove `core2` and update `wasmtime` to 36.0.7 [#2286](https://github.com/filecoin-project/ref-fvm/pull/2286)
+
 ## 2.12.0 (2026-04-16)
 
 - chore: update proofs dependency and rust toolchain [#2272](https://github.com/filecoin-project/ref-fvm/pull/2272)

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 2.12.1 (2026-04-20)
+
+- Backport `multihash-codetable` bump to remove `core2` and update `wasmtime` to 36.0.7 [#2286](https://github.com/filecoin-project/ref-fvm/pull/2286)
+
 ## 2.12.0 (2026-04-16)
 
 - chore: update proofs dependency and rust toolchain [#2272](https://github.com/filecoin-project/ref-fvm/pull/2272)


### PR DESCRIPTION
## What changed

This prepares the `release/v2` branch for patch release `2.12.1`.

It bumps the workspace version and the coupled `fvm`, `fvm_shared`, and `fvm_sdk` dependency versions to `2.12.1`, refreshes the lockfile, and adds release entries to the `fvm`, `sdk`, and `shared` changelogs.

## Why

`release/v2` has already merged the backport in [#2286](https://github.com/filecoin-project/ref-fvm/pull/2286), so the next step is to cut a patch release that packages those changes for downstream consumers.

## Included changes

- Backport `multihash-codetable` bump to remove `core2`
- Update `wasmtime` to `36.0.7`

## Validation

- `cargo check --all`
