### PR TITLE
chore(release): prepare release 3.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.14.0"
+version = "3.14.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.14.0"
+version = "3.14.1"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.14.0"
+version = "3.14.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.14.0"
+version = "3.14.1"
 license = "MIT OR Apache-2.0"
 edition = "2024"
 repository = "https://github.com/filecoin-project/ref-fvm"
@@ -23,9 +23,9 @@ ipld-core = { version = "0.4.3", features = ["serde"] }
 wasmtime = {version = "36", default-features = false, features = ["cranelift", "pooling-allocator", "parallel-compilation", "runtime"] }
 wasmtime-environ = "36"
 
-fvm = { path = "fvm", version = "~3.14.0", default-features = false }
-fvm_shared = { path = "shared", version = "~3.14.0", default-features = false }
-fvm_sdk = { path = "sdk", version = "~3.14.0" }
+fvm = { path = "fvm", version = "~3.14.1", default-features = false }
+fvm_shared = { path = "shared", version = "~3.14.1", default-features = false }
+fvm_sdk = { path = "sdk", version = "~3.14.1" }
 
 fvm_ipld_hamt = { version = "0.10.4"}
 fvm_ipld_amt = { version = "0.7.4"}

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+## 3.14.1 [2026-04-20]
+
+- Backport `multihash-codetable` bump to remove `core2` and update `wasmtime` to 36.0.7 [#2285](https://github.com/filecoin-project/ref-fvm/pull/2285)
+
 ## 3.14.0 [2026-04-16]
 
 - chore: update proofs dependency and rust toolchain [#2273](https://github.com/filecoin-project/ref-fvm/pull/2273)

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 3.14.1 [2026-04-20]
+
+- Backport `multihash-codetable` bump to remove `core2` and update `wasmtime` to 36.0.7 [#2285](https://github.com/filecoin-project/ref-fvm/pull/2285)
+
 ## 3.14.0 [2026-04-16]
 
 - chore: update proofs dependency and rust toolchain [#2273](https://github.com/filecoin-project/ref-fvm/pull/2273)

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 3.14.1 [2026-04-20]
+
+- Backport `multihash-codetable` bump to remove `core2` and update `wasmtime` to 36.0.7 [#2285](https://github.com/filecoin-project/ref-fvm/pull/2285)
+
 ## 3.14.0 [2026-04-16]
 
 - chore: update proofs dependency and rust toolchain [#2273](https://github.com/filecoin-project/ref-fvm/pull/2273)


### PR DESCRIPTION
## What changed

This prepares the `release/v3` branch for patch release `3.14.1`.

It bumps the workspace version and the coupled `fvm`, `fvm_shared`, and `fvm_sdk` dependency versions to `3.14.1`, refreshes the lockfile, and adds release entries to the `fvm`, `sdk`, and `shared` changelogs.

## Why

`release/v3` has already merged the backport in [#2285](https://github.com/filecoin-project/ref-fvm/pull/2285), so the next step is to cut a patch release that packages those changes for downstream consumers.

## Included changes

- Backport `multihash-codetable` bump to remove `core2`
- Update `wasmtime` to `36.0.7`

## Validation

- `cargo check --all`
