### PR TITLE
chore: fix deny advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy-core"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e8604b0c092fabc80d075ede181c9b9e596249c70b99253082d7e689836529"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "itoa",
+ "paste",
+ "ruint",
+ "rustc-hash",
+ "sha3 0.10.9",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+dependencies = [
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck",
+ "indexmap 2.14.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "sha3 0.10.9",
+ "syn 2.0.100",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-macro",
+]
+
+[[package]]
 name = "ambassador"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,12 +207,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
-dependencies = [
- "backtrace",
-]
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -364,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
 dependencies = [
  "cc",
  "glob",
@@ -426,9 +508,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
@@ -633,6 +715,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,15 +766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "coverage-helper"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,36 +791,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8056d63fef9a6f88a1e7aae52bb08fcf48de8866d514c0dc52feb15975f5db5"
+checksum = "cb1ffe339f197d6645b4d3037edf67c13cd3aa8871f29c2c9c046c729c1b9a17"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d063b40884a0d733223a45c5de1155395af4393cf7f900d5be8e2cbc094015"
+checksum = "1e81a21df73d1b12ed19eba481c08de8891e179e1870ed28d6e397f7746108f5"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3add2881bae2d55cd7162906988dd70053cb7ece865ad793a6754b04d47df6"
+checksum = "3cf917d0180c15c945c13c8dde615d32a015769513b29158f728311d85a8f80d"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd73e32bc1ea4bddc4c770760c66fa24b2890991b0561af554219e603fcd7c34"
+checksum = "a6f4e1af2df00798c2895d228bb53d65c5aa09acace8525096f0b53830ffe42c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -743,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1da85f2636fe28244848861d1ed0f8dccdc6e98fc5db31aa5eb8878e7ff617"
+checksum = "4e3a5d7300e4b44933dcf2947399945abe3f30f92c789b496ad72949e3ee15a6"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -770,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3c8aba9d89832df27364b2e79dc2fe288daf4bd6c7347829e7f3f258ea5650"
+checksum = "becdb5c3111800d7f8e666fe5f35693bfc77de4401bfcaea19815caf7c482fb9"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -783,24 +868,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9a9b09fe107fef6377caed20614586124184cffccb73611312ceb922a917e6"
+checksum = "d8fa77efffa12934971f757e154b16dd5e369a7f388a0f3adff74aadfd4c5a1d"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50aef001c7ad250d5fdda2c7481cbfcabe6435c66106adf5760dcb9fb9a8ede4"
+checksum = "62441d3aae3372381e03a121880482158ce90ca3bc2a56607cc122ee07536fe4"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3c84656a010df2b5afaedcbbbd94f1efe175b55e29864df7b99e64bfa40d56"
+checksum = "7bdc9832a010e0d411439aa016e1664dd23ca5c8953bf26b90fe34ad4b76822d"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -809,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa1d2006915cddb63705db46dcfb8637fe08f91d26fbe59680d7257ec39d609"
+checksum = "9530b689b7c3accdbb32263ca318e19ab3bcf616d3a160c8456537c99b4c565b"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -821,15 +906,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4fecbcbb81273f9aff4559e26fc341f42663da420cca5ac84b34e74e9267e0"
+checksum = "3fcd3258a4d87376f2681c72269a42009286a3d3707b2af4024ba5b3750ad477"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976a3d85f197a56ae34ee4d5a5e469855ac52804a09a513d0562d425da0ff56e"
+checksum = "642c5703a22b58abccbf46f46c0dae65f0535bbe725beec70527a1ffcbbc1d34"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -838,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.7"
+version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fbd4aefce642145491ff862d2054a71b63d2d97b8dd1e280c9fdaf399598b7"
+checksum = "d200dcd5a37de108ec1329e0ba924e2badd2c0ef2343c338310135159ae454e2"
 
 [[package]]
 name = "crc32fast"
@@ -1133,6 +1218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ec-gpu"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,16 +1473,16 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "anyhow",
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive",
  "num-traits",
  "serde",
@@ -1399,17 +1490,17 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_bundler"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45a69ccfe5935bb364169a6ff14a6d25d40a6d64b4c250693bf6cee699e0d79"
+checksum = "5ee74a23eeee16b761e3afd12f31f57fc04853efd3190bfc3b09121902620eff"
 dependencies = [
  "anyhow",
  "cid",
  "clap",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_car 0.9.0",
- "fvm_ipld_encoding 0.5.3",
- "multihash-codetable 0.1.4",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_car 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multihash-codetable",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
@@ -1417,13 +1508,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "num-derive",
  "num-traits",
@@ -1432,18 +1523,18 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_datacap"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "cid",
  "fil_actors_runtime",
  "frc42_dispatch",
  "frc46_token",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_ipld_hamt 0.10.4",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "num-derive",
@@ -1453,16 +1544,16 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_eam"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "anyhow",
  "cid",
  "fil_actors_evm_shared",
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",
  "log",
  "multihash",
@@ -1474,14 +1565,14 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_ethaccount"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.3",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",
  "num-derive",
  "num-traits",
@@ -1490,43 +1581,45 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_evm"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
+ "alloy-core",
  "anyhow",
  "blst",
  "cid",
  "fil_actors_evm_shared",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_ipld_kamt 0.4.5",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_kamt 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "hex-literal",
  "log",
- "multihash-codetable 0.1.4",
+ "multihash-codetable",
  "num-derive",
  "num-traits",
+ "p256",
  "serde",
  "substrate-bn",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "fil_actor_init"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_ipld_hamt 0.10.4",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "num-derive",
  "num-traits",
@@ -1535,8 +1628,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "anyhow",
  "cid",
@@ -1544,15 +1637,15 @@ dependencies = [
  "frc42_dispatch",
  "frc46_token",
  "fvm_ipld_bitfield 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_ipld_hamt 0.10.4",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding",
  "ipld-core",
  "lazy_static",
  "log",
- "multihash-codetable 0.1.4",
+ "multihash-codetable",
  "num-derive",
  "num-traits",
  "serde",
@@ -1560,8 +1653,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "anyhow",
  "bitflags 2.9.0",
@@ -1569,37 +1662,38 @@ dependencies = [
  "cid",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_amt 0.7.5",
+ "fvm_ipld_amt 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_bitfield 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_ipld_hamt 0.10.4",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.14.0",
  "lazy_static",
  "log",
  "multihash",
- "multihash-codetable 0.1.4",
+ "multihash-codetable",
  "num-derive",
  "num-traits",
  "serde",
+ "serde_repr",
 ]
 
 [[package]]
 name = "fil_actor_multisig"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_ipld_hamt 0.10.4",
- "fvm_shared 4.7.3",
- "indexmap 2.9.0",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 2.14.0",
  "integer-encoding",
  "num-derive",
  "num-traits",
@@ -1608,16 +1702,16 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive",
  "num-traits",
  "serde",
@@ -1625,23 +1719,23 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_placeholder"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 
 [[package]]
 name = "fil_actor_power"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_ipld_hamt 0.10.4",
- "fvm_shared 4.7.3",
- "indexmap 2.9.0",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 2.14.0",
  "integer-encoding",
  "lazy_static",
  "log",
@@ -1652,13 +1746,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "num-derive",
@@ -1668,16 +1762,16 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.3",
- "multihash-codetable 0.1.4",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multihash-codetable",
  "num-derive",
  "num-traits",
  "serde",
@@ -1685,8 +1779,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "anyhow",
  "cid",
@@ -1694,10 +1788,10 @@ dependencies = [
  "frc42_dispatch",
  "frc46_token",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_ipld_hamt 0.10.4",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "num-derive",
@@ -1707,12 +1801,12 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_evm_shared"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.3",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "serde",
  "uint",
@@ -1720,33 +1814,33 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "anyhow",
  "byteorder",
  "castaway",
  "cid",
- "fvm_ipld_amt 0.7.5",
+ "fvm_ipld_amt 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_bitfield 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_ipld_hamt 0.10.4",
- "fvm_sdk 4.7.3",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding",
  "itertools 0.14.0",
  "lazy_static",
  "log",
- "multihash-codetable 0.1.4",
+ "multihash-codetable",
  "num",
  "num-derive",
  "num-traits",
  "regex",
  "serde",
  "serde_repr",
- "sha2 0.10.8",
- "thiserror 2.0.12",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
  "unsigned-varint",
  "vm_api",
 ]
@@ -1762,8 +1856,8 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "17.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+version = "18.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "cid",
  "clap",
@@ -1873,7 +1967,7 @@ dependencies = [
  "fvm_ipld_encoding 0.5.4",
  "fvm_sdk 4.8.2",
  "fvm_shared 4.8.2",
- "multihash-codetable 0.2.2",
+ "multihash-codetable",
  "serde",
 ]
 
@@ -1938,7 +2032,7 @@ dependencies = [
  "fvm_ipld_encoding 0.5.4",
  "fvm_sdk 4.8.2",
  "fvm_shared 4.8.2",
- "multihash-codetable 0.2.2",
+ "multihash-codetable",
  "multihash-derive",
 ]
 
@@ -2107,39 +2201,39 @@ dependencies = [
  "byte-slice-cast",
  "byteorder",
  "ff",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "frc42_dispatch"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4701d2d5e6a8ed95ee124d607e8ef51bd8bda11f3bf3f472a5e14d552ed696e6"
+checksum = "5adda887b823f91643af62fbe2b44e8e08aecdc55167463996f30ccf4891d9c4"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.3",
- "fvm_shared 4.7.3",
- "thiserror 2.0.12",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "frc42_hasher"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af72029ed0fafb01fda2d7f631b55f6916ad06e310a7b4241b933796b34d510c"
+checksum = "c23f342605b9ee11ae783e259b553e305807787be5ec7ead9ef086f6a17b4bfc"
 dependencies = [
- "fvm_sdk 4.7.3",
- "fvm_shared 4.7.3",
- "thiserror 2.0.12",
+ "fvm_sdk 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "frc42_macros"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0211504c112b71bcc2f1e9f25b8bc84b3bff043ff5a0ac3b960d273cb22c7bf"
+checksum = "f4a55499fbd3b12d5bbbecd18fbc59bc8774734c59e508776d0506a94c0e8178"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
@@ -2150,23 +2244,23 @@ dependencies = [
 
 [[package]]
 name = "frc46_token"
-version = "14.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891f9917156c52c5c1c3f95e083e3e21370b8044164ebf7894f74c02fa5c4a18"
+checksum = "6d916a9e49951ff90d124cbb4e61306bb4012ef6dbda39628684e1cfecd2ed5b"
 dependencies = [
  "cid",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_ipld_hamt 0.10.4",
- "fvm_sdk 4.7.3",
- "fvm_shared 4.7.3",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding",
- "multihash-codetable 0.1.4",
+ "multihash-codetable",
  "num-traits",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2295,7 +2389,7 @@ dependencies = [
  "lazy_static",
  "log",
  "minstant",
- "multihash-codetable 0.2.2",
+ "multihash-codetable",
  "multihash-derive",
  "num-traits",
  "pretty_assertions",
@@ -2305,7 +2399,7 @@ dependencies = [
  "replace_with",
  "serde",
  "static_assertions",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "wasmtime",
  "wasmtime-environ",
  "yastl",
@@ -2339,21 +2433,21 @@ dependencies = [
 
 [[package]]
 name = "fvm_actor_utils"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a9591b569cbafcc4685381067e702dedf56824db4f8b64d697a1bb9205530c"
+checksum = "e02939b3f50b030941710c3609fa8296d88cfde3793a973184fdafacc0262f0b"
 dependencies = [
  "anyhow",
  "cid",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_sdk 4.7.3",
- "fvm_shared 4.7.3",
- "multihash-codetable 0.1.4",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_sdk 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multihash-codetable",
  "num-traits",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2425,32 +2519,15 @@ dependencies = [
  "k256",
  "lazy_static",
  "minstant",
- "multihash-codetable 0.2.2",
+ "multihash-codetable",
  "num-traits",
  "rand 0.8.5",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "wasmtime",
  "wat",
-]
-
-[[package]]
-name = "fvm_ipld_amt"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437a2791237a87bbb91f3c827b5c2e05789b8ba22467a8bce1be831e74612d00"
-dependencies = [
- "anyhow",
- "cid",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "itertools 0.14.0",
- "multihash-codetable 0.1.4",
- "once_cell",
- "serde",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2463,12 +2540,29 @@ dependencies = [
  "fvm_ipld_blockstore 0.3.2",
  "fvm_ipld_encoding 0.5.4",
  "itertools 0.14.0",
- "multihash-codetable 0.2.2",
+ "multihash-codetable",
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "fvm_ipld_amt"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe03301f8a37c660dc94ba6c912e885664eec151bfb6bbe9dd3f09c18fdf6e5b"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.14.0",
+ "multihash-codetable",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2480,10 +2574,10 @@ dependencies = [
  "fvm_ipld_encoding 0.5.4",
  "gperftools",
  "rand 0.8.5",
- "rand_xorshift",
+ "rand_xorshift 0.3.0",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "unsigned-varint",
 ]
 
@@ -2493,21 +2587,10 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de140b940443d5d783824563f15b5fe6d1559e7b103a7b55082da93655585350"
 dependencies = [
- "fvm_ipld_encoding 0.5.3",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "unsigned-varint",
-]
-
-[[package]]
-name = "fvm_ipld_blockstore"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b8b31e022f71b73440054f7e5171231a1ebc745adf075014d5aa8ea78ea283"
-dependencies = [
- "anyhow",
- "cid",
- "multihash-codetable 0.1.4",
 ]
 
 [[package]]
@@ -2516,23 +2599,18 @@ version = "0.3.2"
 dependencies = [
  "anyhow",
  "cid",
- "multihash-codetable 0.2.2",
+ "multihash-codetable",
 ]
 
 [[package]]
-name = "fvm_ipld_car"
-version = "0.9.0"
+name = "fvm_ipld_blockstore"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f49d53950e37e2b310a6527135f4b9b09c2fb8c25f1846622131f9db965be0"
+checksum = "abf4ac541f791ccb38b3d7926045a16636dafda045e768fed58c96f35bead1ae"
 dependencies = [
+ "anyhow",
  "cid",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "multihash-codetable 0.1.4",
- "multihash-derive",
- "serde",
- "thiserror 2.0.12",
- "unsigned-varint",
+ "multihash-codetable",
 ]
 
 [[package]]
@@ -2542,28 +2620,27 @@ dependencies = [
  "cid",
  "fvm_ipld_blockstore 0.3.2",
  "fvm_ipld_encoding 0.5.4",
- "multihash-codetable 0.2.2",
+ "multihash-codetable",
  "multihash-derive",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "unsigned-varint",
 ]
 
 [[package]]
-name = "fvm_ipld_encoding"
-version = "0.5.3"
+name = "fvm_ipld_car"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fd0c7d16be0076920acd5bf13e705a80dfe6540d4722b19745daa9ea93722a"
+checksum = "36ca69774997f300516f7795e092464c56765c7f5ab63d51061682cbef64772b"
 dependencies = [
- "anyhow",
  "cid",
- "fvm_ipld_blockstore 0.3.1",
- "multihash-codetable 0.1.4",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multihash-codetable",
+ "multihash-derive",
  "serde",
- "serde_ipld_dagcbor",
- "serde_repr",
- "serde_tuple 0.5.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2573,33 +2650,30 @@ dependencies = [
  "anyhow",
  "cid",
  "fvm_ipld_blockstore 0.3.2",
- "multihash-codetable 0.2.2",
+ "multihash-codetable",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
  "serde_repr",
- "serde_tuple 1.1.3",
- "thiserror 2.0.12",
+ "serde_tuple",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "fvm_ipld_hamt"
-version = "0.10.4"
+name = "fvm_ipld_encoding"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92fa6ad9ebdb821f7d3183666a94b6fabd6640d5c83ce1cd850865746d2e4db"
+checksum = "60b78ddd909cfbcb210242e9b19804fbe17aae3866b6be3adcc1ed123484f928"
 dependencies = [
  "anyhow",
- "byteorder",
  "cid",
- "forest_hash_utils",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "ipld-core",
- "multihash-codetable 0.1.4",
- "once_cell",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multihash-codetable",
  "serde",
- "sha2 0.10.8",
- "thiserror 2.0.12",
+ "serde_ipld_dagcbor",
+ "serde_repr",
+ "serde_tuple",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2616,32 +2690,35 @@ dependencies = [
  "hex",
  "ipld-core",
  "itertools 0.14.0",
- "multihash-codetable 0.2.2",
+ "multihash-codetable",
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
  "rand 0.8.5",
  "serde",
  "sha2 0.11.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "unsigned-varint",
 ]
 
 [[package]]
-name = "fvm_ipld_kamt"
-version = "0.4.5"
+name = "fvm_ipld_hamt"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a7ef4cf7dab3bf09a2c988f7fc88fa0a532be2ca96136470942426ec5f99f0"
+checksum = "e9f488edd2c502303fd956f2830abc24444a28567f8e212237851e35e13d3779"
 dependencies = [
  "anyhow",
  "byteorder",
  "cid",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "multihash-codetable 0.1.4",
+ "forest_hash_utils",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld-core",
+ "multihash-codetable",
  "once_cell",
  "serde",
- "thiserror 2.0.12",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2655,29 +2732,31 @@ dependencies = [
  "fvm_ipld_blockstore 0.3.2",
  "fvm_ipld_encoding 0.5.4",
  "hex",
- "multihash-codetable 0.2.2",
+ "multihash-codetable",
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
  "rand 0.8.5",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "unsigned-varint",
 ]
 
 [[package]]
-name = "fvm_sdk"
-version = "4.7.3"
+name = "fvm_ipld_kamt"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d5ef8cdc442a175ec04696adb82953fa28b151a81bd7a67f55f1cfd5af1d8a"
+checksum = "808c3f259184b5e0c5eca5d081dac06c65ac28f7a50b2b93b81ac28dd693978c"
 dependencies = [
+ "anyhow",
+ "byteorder",
  "cid",
- "fvm_ipld_encoding 0.5.3",
- "fvm_shared 4.7.3",
- "lazy_static",
- "log",
- "num-traits",
- "thiserror 2.0.12",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multihash-codetable",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2690,29 +2769,22 @@ dependencies = [
  "lazy_static",
  "log",
  "num-traits",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "fvm_shared"
-version = "4.7.3"
+name = "fvm_sdk"
+version = "4.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2bef630181cdc25f2522c3fc83a968b42e6b7d3dfa00ed294f6bdb096ad1fa"
+checksum = "29dc0e6fe5cfac6cb6166b02b1a92eb8107afde1acd0bf2663c630da2434892a"
 dependencies = [
- "anyhow",
- "bitflags 2.9.0",
- "blake2b_simd",
  "cid",
- "data-encoding",
- "data-encoding-macro",
- "fvm_ipld_encoding 0.5.3",
- "num-bigint",
- "num-derive",
- "num-integer",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "log",
  "num-traits",
- "serde",
- "thiserror 2.0.12",
- "unsigned-varint",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2733,7 +2805,7 @@ dependencies = [
  "fvm_shared 4.8.2",
  "hex",
  "k256",
- "multihash-codetable 0.2.2",
+ "multihash-codetable",
  "num-bigint",
  "num-derive",
  "num-integer",
@@ -2741,11 +2813,33 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "rand 0.8.5",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rusty-fork",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "fvm_shared"
+version = "4.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1616995131e985185980751c8852d9ad4877a42cf1d4b9b203406f98cba6b47b"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.0",
+ "blake2b_simd",
+ "cid",
+ "data-encoding",
+ "data-encoding-macro",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "thiserror 2.0.18",
  "unsigned-varint",
 ]
 
@@ -2831,7 +2925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -2861,7 +2955,7 @@ dependencies = [
  "ff",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "rand_xorshift",
+ "rand_xorshift 0.3.0",
  "subtle",
 ]
 
@@ -2892,6 +2986,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2914,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "hex-literal"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hmac"
@@ -3096,13 +3196,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.17.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3117,9 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "integer-encoding"
-version = "4.0.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d762194228a2f1c11063e46e32e5acb96e66e906382b9eb5441f2e0504bbd5a"
+checksum = "14c00403deb17c3221a1fe4fb571b9ed0370b3dcd116553c77fa294a3d918699"
 
 [[package]]
 name = "iowrap"
@@ -3305,6 +3406,15 @@ dependencies = [
 
 [[package]]
 name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
@@ -3397,9 +3507,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mach2"
@@ -3408,6 +3518,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3502,17 +3623,6 @@ dependencies = [
 
 [[package]]
 name = "multihash-codetable"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67996849749d25f1da9f238e8ace2ece8f9d6bdf3f9750aaf2ae7de3a5cad8ea"
-dependencies = [
- "blake2b_simd",
- "core2",
- "multihash-derive",
-]
-
-[[package]]
-name = "multihash-codetable"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60384411b100398c5b2fdca476eed82e9898d09f2c60d1b1b66c5080ebe06118"
@@ -3522,7 +3632,7 @@ dependencies = [
  "multihash-derive",
  "ripemd",
  "sha2 0.11.0",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -3666,6 +3776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3695,7 +3806,7 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.2",
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -3734,6 +3845,18 @@ checksum = "26ab4a90cb496f787d3934deb0c54fa9d65e7bed710c10071234aab0196fba04"
 dependencies = [
  "cl3",
  "libc",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3785,6 +3908,12 @@ dependencies = [
  "static_assertions",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -3902,12 +4031,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3920,10 +4080,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulley-interpreter"
-version = "36.0.7"
+name = "proptest"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a078b4bdfd275fadeefc4f9ae3675ee5af302e69497da439956dd05257858970"
+checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+dependencies = [
+ "bitflags 2.9.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift 0.4.0",
+ "unarray",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "36.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35eaba3163b9faf1d707f0704a7370bfdbe73622c766acdaf1fa4addb87510de"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -3933,9 +4107,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.7"
+version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dac91999883fd00b900eb5377be403c5cb8b93e10efcb571bf66454c2d9f231"
+checksum = "ac294897a29ce07919714f9f25c11a819d75759d47eb9f3273845ffea5a5760d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3998,8 +4172,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4022,12 +4205,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -4043,6 +4245,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4151,6 +4362,27 @@ dependencies = [
  "bytes",
  "rustc-hex",
 ]
+
+[[package]]
+name = "ruint"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+dependencies = [
+ "proptest",
+ "rand 0.8.5",
+ "rand 0.9.4",
+ "ruint-macro",
+ "serde_core",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust-gpu-tools"
@@ -4372,33 +4604,12 @@ dependencies = [
 
 [[package]]
 name = "serde_tuple"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f025b91216f15a2a32aa39669329a475733590a015835d1783549a56d09427"
-dependencies = [
- "serde",
- "serde_tuple_macros 0.5.0",
-]
-
-[[package]]
-name = "serde_tuple"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af196b9c06f0aa5555ab980c01a2527b0f67517da8d68b1731b9d4764846a6f"
 dependencies = [
  "serde",
- "serde_tuple_macros 1.1.3",
-]
-
-[[package]]
-name = "serde_tuple_macros"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4076151d1a2b688e25aaf236997933c66e18b870d0369f8b248b8ab2be630d7e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "serde_tuple_macros",
 ]
 
 [[package]]
@@ -4460,12 +4671,22 @@ dependencies = [
 
 [[package]]
 name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.2",
- "keccak",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -4556,13 +4777,13 @@ dependencies = [
  "merkletree",
  "num_cpus",
  "rand 0.8.5",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rayon",
  "semver",
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4704,6 +4925,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-solidity"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4778,11 +5011,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4798,9 +5031,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4885,7 +5118,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4920,6 +5153,12 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -4987,6 +5226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4995,19 +5240,19 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vm_api"
 version = "1.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#2f040c122bf672314450fee16aa45e8420f40dde"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=master#13b4372503968a86fd3d43082c3ebd5763c8ced4"
 dependencies = [
  "anyhow",
  "cid",
- "fvm_ipld_blockstore 0.3.1",
- "fvm_ipld_encoding 0.5.3",
- "fvm_ipld_hamt 0.10.4",
- "fvm_shared 4.7.3",
- "multihash-codetable 0.1.4",
+ "fvm_ipld_blockstore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_hamt 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_shared 4.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multihash-codetable",
  "num-derive",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "serde",
 ]
 
@@ -5140,7 +5385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
  "bitflags 2.9.0",
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -5151,7 +5396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
 dependencies = [
  "bitflags 2.9.0",
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -5163,7 +5408,7 @@ checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
 dependencies = [
  "bitflags 2.9.0",
  "hashbrown 0.15.2",
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
@@ -5191,9 +5436,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.7"
+version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b80d5ba38b9b00f60a0665e07dde38e91d884d4a78cd61d777c8cf081a1267c1"
+checksum = "2060d93be880840d764ab537464b916e22c07758ac5d43e5f07cc86fec6d1bec"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -5203,7 +5448,7 @@ dependencies = [
  "cfg-if",
  "fxprof-processed-profile",
  "hashbrown 0.15.2",
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
  "ittapi",
  "libc",
  "log",
@@ -5236,15 +5481,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.7"
+version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a45d60dea98308decb71a9f7bb35a629696d1fbf7127dbfde42cbc64b8fa33"
+checksum = "902f991ca8c2e5abc03119eb5d7f7f57da1b7c2123addb8214b49c188737711e"
 dependencies = [
  "anyhow",
  "cranelift-bitset",
  "cranelift-entity",
  "gimli 0.32.3",
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
  "log",
  "object 0.37.3",
  "postcard",
@@ -5259,18 +5504,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.7"
+version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd014b4001b6da03d79062d9ad5ec98fa62e34d50e30e46298545282cc2957e4"
+checksum = "b02cec619b54ce7652d1d7676718a42ccf5f16b2fb23c27cd6e3c307bc93907a"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.7"
+version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4047020866a80aa943e41133e607020e17562126cf81533362275272098a22b1"
+checksum = "54eb7fc20c8692dc96148365d7a00a1b79fee810833c75bdf8ec073a46e4721a"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5286,7 +5531,7 @@ dependencies = [
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-math",
@@ -5295,9 +5540,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.7"
+version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd172b622993bb8f834f6ca3b7683dfdba72b12db0527824850fdec17c89e5a"
+checksum = "30708e122dcc1e175c66345c209c01752ca0cd20c9021721b6f56968342e9dbe"
 dependencies = [
  "anyhow",
  "cc",
@@ -5311,9 +5556,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.7"
+version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1287e310fef4c8759a6b5caa0d44eff9a03ebcd6c273729cc39ce3e321a9e26a"
+checksum = "1eeaab071a646d9ae205266adf186c63fa6d077d36b0b33628dd6c3d321d3195"
 dependencies = [
  "cc",
  "object 0.37.3",
@@ -5323,9 +5568,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.7"
+version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02bca30ef670a31496d742d9facdbd0228debe766b1e9541655c0530ff5c953"
+checksum = "09979561e6e4a17bf55722463b066ccb968f010ac6ec5d647e4dff19eddbb19e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5335,24 +5580,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.7"
+version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3a1f51a037ae2c048f0d76d36e27f0d22276295496c44f16a251f24690e003"
+checksum = "9193eb852e5c68aeb95a5ea7538c2bec503023169a0b24430224b4f1ded24988"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.7"
+version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6171aac3d66e4d69e50080bb6bc5205de2283513984a4118a93cb66dc02994"
+checksum = "289bfa4fbb43f406f36166737f1f25522c215ef2ef11f98423089a6a7590a3d1"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.7"
+version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd1bc1783391a02176fb687159b1779fc10b71d5350adf09c1f3aa8442a02cc"
+checksum = "4e748c970993865d9bf474465c3f10f96e541c472bc8f7ec0b031779f4ac29c6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5363,9 +5608,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.7"
+version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8097e2c8ca02ed65d31dda111faa0888ffbf28dc3ee74355e283118a8d293eb0"
+checksum = "e97e07438cb8b50df3bc9659c56757830a15235c94268dbbd54186524fd4ed84"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,7 @@ ignore = [
   "RUSTSEC-2025-0057", # fxhash is no longer maintained, tracked in https://github.com/filecoin-project/ref-fvm/issues/2221
   "RUSTSEC-2025-0141", # bincode unmaintained, transitive dep via bellperson/filecoin-proofs
   "RUSTSEC-2026-0097", # Rand is unsound with a custom logger using `rand::rng()`
+  "RUSTSEC-2024-0436", # paste unmaintained (indirect dep via alloy) - the upstream ignores the advisory, nothing to be done
 ]
 
 [bans]


### PR DESCRIPTION
Fixed a couple of `cargo deny` complaints:
- bumped `wasmtime` patch `36.0.7` -> `36.0.8` https://rustsec.org/advisories/RUSTSEC-2026-0114 (wasmtime)
- suppress `paste` warnings; it's a transitive dependency and `alloy` decided not to fix it so we can't do anything https://github.com/alloy-rs/core/pull/1086
- some plumbing to get rid of the yanked `core2` version 