### PR TITLE
feat: backport StateTree::for_each_cacheless to fvm@v3

### DIFF
--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+- feat: add `StateTree::for_each_cacheless` for cacheless state tree iteration [#2307](https://github.com/filecoin-project/ref-fvm/pull/2307)
+
 ## 3.14.1 [2026-04-20]
 
 - Backport `multihash-codetable` bump to remove `core2` and update `wasmtime` to 36.0.7 [#2285](https://github.com/filecoin-project/ref-fvm/pull/2285)

--- a/fvm/src/state_tree.rs
+++ b/fvm/src/state_tree.rs
@@ -378,6 +378,18 @@ where
         })?;
         Ok(())
     }
+
+    /// Iterates over each KV in the Hamt and runs a function on the values without cache.
+    pub fn for_each_cacheless<F>(&self, mut f: F) -> anyhow::Result<()>
+    where
+        F: FnMut(Address, &ActorState) -> anyhow::Result<()>,
+    {
+        self.hamt.for_each_cacheless(|k, v| {
+            let addr = Address::from_bytes(&k.0)?;
+            f(addr, v)
+        })?;
+        Ok(())
+    }
 }
 
 /// State of all actor implementations.


### PR DESCRIPTION
https://github.com/filecoin-project/ref-fvm/blob/fvm%40v4.8.2/fvm/src/state_tree.rs#L380