### PR TITLE
ci: port release workflows to release/v3

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,50 @@
+name: Release Checker
+
+on:
+  # Change to pull_request_target for the workflow to function correctly on PRs from forks
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-check:
+    uses: ipdxco/unified-github-workflows/.github/workflows/release-check.yml@v1.0
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.pull_request.head.repo.fork }}
+    with:
+      sources: |
+        [
+          "fvm/Cargo.toml",
+          "sdk/Cargo.toml",
+          "shared/Cargo.toml"
+        ]
+      separator: "@"
+  cargo-publish:
+    needs: [release-check]
+    if: needs.release-check.outputs.json != '{}'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install required packages
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          shell: bash
+          command: |
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends --yes libhwloc-dev ocl-icd-opencl-dev
+      - name: Dry-run publish
+        run: |
+          # Use cargo publish --workspace --dry-run to verify the entire workspace at once.
+          # This correctly handles interdependent crates which a matrix-based approach misses.
+          cargo publish --workspace --exclude fvm_conformance_tests --dry-run

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -28,6 +28,7 @@ jobs:
           "shared/Cargo.toml"
         ]
       separator: "@"
+      branches: '["release/v3"]'
   cargo-publish:
     needs: [release-check]
     if: needs.release-check.outputs.json != '{}'

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -48,4 +48,4 @@ jobs:
         run: |
           # Use cargo publish --workspace --dry-run to verify the entire workspace at once.
           # This correctly handles interdependent crates which a matrix-based approach misses.
-          cargo publish --workspace --exclude fvm_conformance_tests --dry-run
+          cargo publish --workspace --dry-run

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,0 +1,50 @@
+name: Releaser
+
+on:
+  push:
+    paths:
+      - "**/Cargo.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  releaser:
+    uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1.0
+    with:
+      sources: |
+        [
+          "fvm/Cargo.toml",
+          "sdk/Cargo.toml",
+          "shared/Cargo.toml"
+        ]
+      separator: "@"
+    secrets:
+      UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}
+
+  cargo-publish:
+    needs: [releaser]
+    if: needs.releaser.outputs.json != '{}'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install required packages
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          shell: bash
+          command: |
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends --yes libhwloc-dev ocl-icd-opencl-dev
+      - name: Publish to crates.io
+        run: |
+          # Use cargo publish --workspace to publish all changed crates in the workspace.
+          # This handles interdependent crates correctly and only publishes those with version bumps.
+          cargo publish --workspace --exclude fvm_conformance_tests

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -25,6 +25,7 @@ jobs:
           "shared/Cargo.toml"
         ]
       separator: "@"
+      branches: '["release/v3"]'
     secrets:
       UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}
 

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -48,4 +48,4 @@ jobs:
         run: |
           # Use cargo publish --workspace to publish all changed crates in the workspace.
           # This handles interdependent crates correctly and only publishes those with version bumps.
-          cargo publish --workspace --exclude fvm_conformance_tests
+          cargo publish --workspace


### PR DESCRIPTION
## Summary
- add releaser and release-check workflows to release/v3
- scope release sources to the publishable v3 workspace crates: fvm, sdk, and shared
- exclude fvm_conformance_tests from workspace publish commands because it has publish = false

## Validation
- ruby YAML parsing for both workflow files
- whitespace checks for both workflow files

Note: cargo metadata could not be run locally because rustup failed installing pinned toolchain components with download rename errors.