### PR TITLE
chore: remove the nv29-dev feature flag

### DIFF
--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
-- `nv29-dev` is now part of the default build; the feature flag was removed.
+- Network version 29 support (previously gated behind `nv29-dev`) is now enabled by default; the feature flag was removed.
 
 ## 4.8.2 [2026-04-17]
 

--- a/fvm/CHANGELOG.md
+++ b/fvm/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to the reference FVM implementation.
 
 ## [Unreleased]
 
+- `nv29-dev` is now part of the default build; the feature flag was removed.
+
 ## 4.8.2 [2026-04-17]
 
 - Bump `multihash-codetable` to get rid of `core2`

--- a/fvm/Cargo.toml
+++ b/fvm/Cargo.toml
@@ -60,7 +60,6 @@ gas_calibration = []
 # The current implementation keeps it by default for backward compatibility reason.
 # See <https://github.com/filecoin-project/ref-fvm/issues/2001>
 verify-signature = []
-nv29-dev = []
 
 # Allow coverage attribute.
 [lints.rust]

--- a/fvm/src/gas/price_list.rs
+++ b/fvm/src/gas/price_list.rs
@@ -1085,11 +1085,11 @@ pub fn price_list_by_network_version(network_version: NetworkVersion) -> &'stati
         NetworkVersion::V21 | NetworkVersion::V22 | NetworkVersion::V23 | NetworkVersion::V24 => {
             &WATERMELON_PRICES
         }
-        NetworkVersion::V25 | NetworkVersion::V26 | NetworkVersion::V27 | NetworkVersion::V28 => {
-            &TEEP_PRICES
-        }
-        #[cfg(feature = "nv29-dev")]
-        NetworkVersion::V29 => &TEEP_PRICES,
+        NetworkVersion::V25
+        | NetworkVersion::V26
+        | NetworkVersion::V27
+        | NetworkVersion::V28
+        | NetworkVersion::V29 => &TEEP_PRICES,
         _ => panic!("network version {nv} not supported", nv = network_version),
     }
 }

--- a/fvm/src/machine/default.rs
+++ b/fvm/src/machine/default.rs
@@ -51,10 +51,6 @@ where
     /// * `blockstore`: The underlying [blockstore][`Blockstore`] for reading/writing state.
     /// * `externs`: Client-provided ["external"][`Externs`] methods for accessing chain state.
     pub fn new(context: &MachineContext, blockstore: B, externs: E) -> anyhow::Result<Self> {
-        #[cfg(not(feature = "nv29-dev"))]
-        const SUPPORTED_VERSIONS: RangeInclusive<NetworkVersion> =
-            NetworkVersion::V21..=NetworkVersion::V28;
-        #[cfg(feature = "nv29-dev")]
         const SUPPORTED_VERSIONS: RangeInclusive<NetworkVersion> =
             NetworkVersion::V21..=NetworkVersion::V29;
 

--- a/shared/src/version/mod.rs
+++ b/shared/src/version/mod.rs
@@ -71,7 +71,7 @@ impl NetworkVersion {
     pub const V27: Self = Self(27);
     /// FireHorse (builtin-actor v18)
     pub const V28: Self = Self(28);
-    /// TBD (TBD builtin-actor v19)
+    /// Solstice (builtin-actor v19)
     pub const V29: Self = Self(29);
 
     pub const MAX: Self = Self(u32::MAX);


### PR DESCRIPTION
In preparation for the release for FVM.